### PR TITLE
fix(security): SEC-003 - Validate UUID format in SET LOCAL commands

### DIFF
--- a/packages/core/src/lib/db.ts
+++ b/packages/core/src/lib/db.ts
@@ -1,4 +1,5 @@
 import { Pool, type PoolClient } from 'pg';
+import { isValidUUID } from './api/helpers';
 
 // Track active connections for graceful shutdown
 let activeConnections = 0;
@@ -79,17 +80,13 @@ const pool = new Pool({
 
 /**
  * Validate userId format to prevent SQL injection in SET LOCAL commands
+ * Requires userId to be a valid UUID format
  * @internal
  */
 function validateUserId(userId: string): void {
-  // FIX: Add explicit validation even though auth system should validate
-  // Reject backslashes (escape sequences) and excessively long values
-  if (userId.includes('\\') || userId.length > 255) {
-    throw new Error('Invalid userId format: contains invalid characters or is too long');
-  }
-  // Also reject null bytes and other control characters
-  if (/[\x00-\x1f]/.test(userId)) {
-    throw new Error('Invalid userId format: contains control characters');
+  // SEC-003: Validate UUID format before using in SET LOCAL
+  if (!isValidUUID(userId)) {
+    throw new Error('Invalid userId format - must be valid UUID');
   }
 }
 


### PR DESCRIPTION
## Summary
- Replace loose character-based validation with strict UUID format validation using `isValidUUID` helper
- Ensures only valid UUIDs (RFC 4122 compliant) are used in RLS context setting
- Prevents potential SQL injection attacks via malformed userId values

## Changes
- Import `isValidUUID` from `./api/helpers` in `db.ts`
- Simplify `validateUserId` function to use UUID regex validation
- Improve error message for invalid UUID format

## Test plan
- [x] Build passes (`pnpm build:core`)
- [x] Full app build passes
- [x] Server health check confirms DB connected
- [ ] Manual verification that valid UUIDs work correctly
- [ ] Manual verification that invalid UUIDs are rejected

## Related
- Closes SEC-003 from security audit
- Part of P0 critical security tasks
- Depends on: SEC-001, SEC-002 (already merged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)