### PR TITLE
fix(security): SEC-005 - Add try-catch to JSON.parse of headers

### DIFF
--- a/packages/core/src/lib/api/helpers.ts
+++ b/packages/core/src/lib/api/helpers.ts
@@ -193,10 +193,20 @@ export function getApiAuth(request: NextRequest): ApiKeyAuth {
     throw new Error('Missing API authentication headers');
   }
   
+  let scopes: string[] = [];
+  try {
+    const parsed = JSON.parse(scopesHeader);
+    if (Array.isArray(parsed)) {
+      scopes = parsed.filter((s): s is string => typeof s === 'string');
+    }
+  } catch {
+    console.warn('[API] Invalid scopes header format');
+  }
+
   return {
     userId,
     keyId,
-    scopes: JSON.parse(scopesHeader)
+    scopes
   };
 }
 

--- a/packages/core/src/lib/api/rate-limit.ts
+++ b/packages/core/src/lib/api/rate-limit.ts
@@ -237,7 +237,15 @@ export function withRateLimit<T extends unknown[]>(
         return handler(request, ...args);
       }
       
-      const scopes = JSON.parse(scopesHeader);
+      let scopes: string[] = [];
+      try {
+        const parsed = JSON.parse(scopesHeader);
+        if (Array.isArray(parsed)) {
+          scopes = parsed.filter((s): s is string => typeof s === 'string');
+        }
+      } catch {
+        console.warn('[RateLimit] Invalid scopes header format');
+      }
       
       // Verificar rate limit
       const rateLimitResponse = applyRateLimit(request, keyId, scopes);


### PR DESCRIPTION
## Summary

- Add try-catch blocks to `JSON.parse` calls for header parsing to prevent server crashes
- Validate parsed result is an array and filter to ensure only strings are included
- Default to empty array on parse failure, logging a warning

## Files Changed

| File | Change |
|------|--------|
| `packages/core/src/lib/api/rate-limit.ts:240` | Wrapped `JSON.parse(scopesHeader)` in try-catch |
| `packages/core/src/lib/api/helpers.ts:199` | Wrapped `JSON.parse(scopesHeader)` in try-catch |

## Test plan

- [ ] Send request with valid `x-api-scopes` header - should work normally
- [ ] Send request with malformed `x-api-scopes` header (e.g., `{invalid}`) - should not crash
- [ ] Send request with non-array JSON (e.g., `"string"`) - should default to empty array
- [ ] Verify build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)