### PR TITLE
feat(cache): CACHE-001 - Implement distributed two-tier cache (L1 + L2 Redis)

### DIFF
--- a/packages/core/src/lib/api/distributed-cache.ts
+++ b/packages/core/src/lib/api/distributed-cache.ts
@@ -1,0 +1,444 @@
+/**
+ * Distributed Cache System (Two-Tier: L1 Memory + L2 Redis)
+ *
+ * Provides distributed caching for multi-instance deployments using:
+ * - L1: In-memory cache for fastest access (per-instance)
+ * - L2: Redis (Upstash) for shared cache across instances
+ *
+ * Falls back gracefully when Redis is not configured.
+ *
+ * @example
+ * ```typescript
+ * // Basic usage
+ * await cacheSet('user:123', userData, 300)
+ * const user = await cacheGet<UserData>('user:123')
+ *
+ * // With tags for invalidation
+ * await cacheSet('user:123', userData, 300, ['users', 'user:123'])
+ * await cacheInvalidateByTag('users') // Invalidates all user caches
+ * ```
+ */
+
+// L1 Memory Cache (local to each instance)
+interface L1CacheEntry<T> {
+  value: T
+  expiresAt: number
+  tags: string[]
+}
+
+class L1MemoryCache {
+  private cache = new Map<string, L1CacheEntry<unknown>>()
+  private tagIndex = new Map<string, Set<string>>() // tag -> keys
+  private maxSize: number
+  private cleanupInterval: NodeJS.Timeout | null = null
+
+  constructor(maxSize: number = 10000) {
+    this.maxSize = maxSize
+
+    // Cleanup expired entries every 5 minutes (not in test)
+    if (process.env.NODE_ENV !== 'test') {
+      this.cleanupInterval = setInterval(() => this.cleanup(), 300000)
+    }
+  }
+
+  set<T>(key: string, value: T, ttlMs: number, tags: string[] = []): void {
+    // Evict LRU if full
+    if (this.cache.size >= this.maxSize && !this.cache.has(key)) {
+      this.evictOldest()
+    }
+
+    // Remove old tag associations
+    const existing = this.cache.get(key)
+    if (existing) {
+      for (const tag of existing.tags) {
+        this.tagIndex.get(tag)?.delete(key)
+      }
+    }
+
+    // Store entry
+    this.cache.set(key, {
+      value,
+      expiresAt: Date.now() + ttlMs,
+      tags,
+    })
+
+    // Update tag index
+    for (const tag of tags) {
+      if (!this.tagIndex.has(tag)) {
+        this.tagIndex.set(tag, new Set())
+      }
+      this.tagIndex.get(tag)!.add(key)
+    }
+  }
+
+  get<T>(key: string): T | null {
+    const entry = this.cache.get(key)
+
+    if (!entry) {
+      return null
+    }
+
+    if (entry.expiresAt < Date.now()) {
+      this.delete(key)
+      return null
+    }
+
+    return entry.value as T
+  }
+
+  delete(key: string): boolean {
+    const entry = this.cache.get(key)
+    if (entry) {
+      // Clean up tag index
+      for (const tag of entry.tags) {
+        this.tagIndex.get(tag)?.delete(key)
+      }
+    }
+    return this.cache.delete(key)
+  }
+
+  invalidateByTag(tag: string): number {
+    const keys = this.tagIndex.get(tag)
+    if (!keys) return 0
+
+    let count = 0
+    for (const key of keys) {
+      if (this.delete(key)) count++
+    }
+    this.tagIndex.delete(tag)
+    return count
+  }
+
+  clear(): void {
+    this.cache.clear()
+    this.tagIndex.clear()
+  }
+
+  private evictOldest(): void {
+    const firstKey = this.cache.keys().next().value
+    if (firstKey) {
+      this.delete(firstKey)
+    }
+  }
+
+  private cleanup(): void {
+    const now = Date.now()
+    const toDelete: string[] = []
+
+    for (const [key, entry] of this.cache.entries()) {
+      if (entry.expiresAt < now) {
+        toDelete.push(key)
+      }
+    }
+
+    for (const key of toDelete) {
+      this.delete(key)
+    }
+  }
+
+  destroy(): void {
+    if (this.cleanupInterval) {
+      clearInterval(this.cleanupInterval)
+      this.cleanupInterval = null
+    }
+    this.clear()
+  }
+
+  getStats() {
+    return {
+      size: this.cache.size,
+      maxSize: this.maxSize,
+      tagCount: this.tagIndex.size,
+    }
+  }
+}
+
+// L1 instance
+const l1Cache = new L1MemoryCache()
+
+// L2 Redis types and lazy loading
+type RedisClient = {
+  get: (key: string) => Promise<string | null>
+  set: (key: string, value: string, options?: { ex?: number }) => Promise<unknown>
+  del: (...keys: string[]) => Promise<number>
+  sadd: (key: string, ...members: string[]) => Promise<number>
+  smembers: (key: string) => Promise<string[]>
+  srem: (key: string, ...members: string[]) => Promise<number>
+  keys: (pattern: string) => Promise<string[]>
+  pipeline: () => {
+    del: (...keys: string[]) => unknown
+    srem: (key: string, ...members: string[]) => unknown
+    exec: () => Promise<unknown>
+  }
+}
+
+let redisClient: RedisClient | null = null
+let redisInitialized = false
+let redisError: Error | null = null
+
+const CACHE_PREFIX = 'cache:'
+const TAG_PREFIX = 'cache:tag:'
+
+/**
+ * Initialize Redis client lazily
+ */
+async function getRedisClient(): Promise<RedisClient | null> {
+  if (redisInitialized) {
+    return redisError ? null : redisClient
+  }
+
+  // Check if credentials are configured
+  if (!process.env.UPSTASH_REDIS_REST_URL || !process.env.UPSTASH_REDIS_REST_TOKEN) {
+    redisInitialized = true
+    return null
+  }
+
+  try {
+    const { Redis } = await import('@upstash/redis')
+    redisClient = new Redis({
+      url: process.env.UPSTASH_REDIS_REST_URL,
+      token: process.env.UPSTASH_REDIS_REST_TOKEN,
+    }) as unknown as RedisClient
+
+    redisInitialized = true
+    return redisClient
+  } catch (error) {
+    redisError = error as Error
+    redisInitialized = true
+
+    if (process.env.NODE_ENV === 'development') {
+      console.warn('[DistributedCache] Redis not available, using L1 only:', (error as Error).message)
+    }
+    return null
+  }
+}
+
+/**
+ * Serialize value for Redis storage
+ */
+function serialize<T>(value: T): string {
+  return JSON.stringify(value)
+}
+
+/**
+ * Deserialize value from Redis storage
+ */
+function deserialize<T>(value: string): T {
+  try {
+    return JSON.parse(value) as T
+  } catch {
+    return value as unknown as T
+  }
+}
+
+/**
+ * Get a value from the distributed cache
+ *
+ * Checks L1 (memory) first, then L2 (Redis) if not found.
+ * When found in L2, populates L1 for subsequent accesses.
+ *
+ * @param key - Cache key
+ * @returns Cached value or null if not found/expired
+ */
+export async function cacheGet<T>(key: string): Promise<T | null> {
+  // L1: Check memory first (fastest)
+  const l1Value = l1Cache.get<T>(key)
+  if (l1Value !== null) {
+    return l1Value
+  }
+
+  // L2: Check Redis
+  const redis = await getRedisClient()
+  if (redis) {
+    try {
+      const redisKey = `${CACHE_PREFIX}${key}`
+      const redisValue = await redis.get(redisKey)
+
+      if (redisValue) {
+        const parsed = deserialize<{ value: T; tags: string[]; ttl: number }>(redisValue)
+
+        // Populate L1 with remaining TTL
+        const remainingTtl = Math.max(parsed.ttl - Date.now(), 1000)
+        l1Cache.set(key, parsed.value, remainingTtl, parsed.tags)
+
+        return parsed.value
+      }
+    } catch (error) {
+      console.error('[DistributedCache] Redis get error:', error)
+      // Fall through to return null
+    }
+  }
+
+  return null
+}
+
+/**
+ * Set a value in the distributed cache
+ *
+ * Stores in both L1 (memory) and L2 (Redis).
+ * Uses tags for efficient bulk invalidation.
+ *
+ * @param key - Cache key
+ * @param value - Value to cache
+ * @param ttlSeconds - Time to live in seconds (default: 300 = 5 minutes)
+ * @param tags - Optional tags for bulk invalidation
+ */
+export async function cacheSet<T>(
+  key: string,
+  value: T,
+  ttlSeconds: number = 300,
+  tags: string[] = []
+): Promise<void> {
+  const ttlMs = ttlSeconds * 1000
+  const expiresAt = Date.now() + ttlMs
+
+  // L1: Store in memory
+  l1Cache.set(key, value, ttlMs, tags)
+
+  // L2: Store in Redis
+  const redis = await getRedisClient()
+  if (redis) {
+    try {
+      const redisKey = `${CACHE_PREFIX}${key}`
+      const redisValue = serialize({ value, tags, ttl: expiresAt })
+
+      await redis.set(redisKey, redisValue, { ex: ttlSeconds })
+
+      // Update tag index in Redis
+      if (tags.length > 0) {
+        await Promise.all(tags.map((tag) => redis.sadd(`${TAG_PREFIX}${tag}`, key)))
+      }
+    } catch (error) {
+      console.error('[DistributedCache] Redis set error:', error)
+      // L1 already set, so cache still works locally
+    }
+  }
+}
+
+/**
+ * Delete a specific key from the cache
+ *
+ * Removes from both L1 and L2.
+ *
+ * @param key - Cache key to delete
+ */
+export async function cacheDelete(key: string): Promise<boolean> {
+  // L1: Delete from memory
+  const l1Deleted = l1Cache.delete(key)
+
+  // L2: Delete from Redis
+  const redis = await getRedisClient()
+  if (redis) {
+    try {
+      const redisKey = `${CACHE_PREFIX}${key}`
+      await redis.del(redisKey)
+    } catch (error) {
+      console.error('[DistributedCache] Redis delete error:', error)
+    }
+  }
+
+  return l1Deleted
+}
+
+/**
+ * Invalidate all cache entries with a specific tag
+ *
+ * Useful for invalidating related caches, e.g., all user-related caches
+ * when user data changes.
+ *
+ * @param tag - Tag to invalidate
+ * @returns Number of entries invalidated (from L1)
+ */
+export async function cacheInvalidateByTag(tag: string): Promise<number> {
+  // L1: Invalidate locally
+  const l1Count = l1Cache.invalidateByTag(tag)
+
+  // L2: Invalidate in Redis
+  const redis = await getRedisClient()
+  if (redis) {
+    try {
+      const tagKey = `${TAG_PREFIX}${tag}`
+      const keys = await redis.smembers(tagKey)
+
+      if (keys.length > 0) {
+        const redisKeys = keys.map((k) => `${CACHE_PREFIX}${k}`)
+        const pipeline = redis.pipeline()
+        pipeline.del(...redisKeys)
+        pipeline.srem(tagKey, ...keys)
+        await pipeline.exec()
+      }
+    } catch (error) {
+      console.error('[DistributedCache] Redis invalidate error:', error)
+    }
+  }
+
+  return l1Count
+}
+
+/**
+ * Clear all cache entries
+ *
+ * Use with caution - clears entire cache.
+ */
+export async function cacheClear(): Promise<void> {
+  // L1: Clear memory
+  l1Cache.clear()
+
+  // L2: Clear Redis cache keys (not tag keys)
+  const redis = await getRedisClient()
+  if (redis) {
+    try {
+      const keys = await redis.keys(`${CACHE_PREFIX}*`)
+      if (keys.length > 0) {
+        await redis.del(...keys)
+      }
+
+      const tagKeys = await redis.keys(`${TAG_PREFIX}*`)
+      if (tagKeys.length > 0) {
+        await redis.del(...tagKeys)
+      }
+    } catch (error) {
+      console.error('[DistributedCache] Redis clear error:', error)
+    }
+  }
+}
+
+/**
+ * Check if Redis is available for distributed caching
+ */
+export async function isDistributedCacheAvailable(): Promise<boolean> {
+  const redis = await getRedisClient()
+  return redis !== null
+}
+
+/**
+ * Get cache statistics
+ */
+export async function getCacheStats(): Promise<{
+  l1: { size: number; maxSize: number; tagCount: number }
+  l2Available: boolean
+}> {
+  const redis = await getRedisClient()
+  return {
+    l1: l1Cache.getStats(),
+    l2Available: redis !== null,
+  }
+}
+
+/**
+ * Helper to create cache keys with consistent naming
+ */
+export function createCacheKey(namespace: string, ...parts: string[]): string {
+  return `${namespace}:${parts.join(':')}`
+}
+
+// Export L1 cache for testing purposes
+export const _l1Cache = l1Cache
+
+// Reset function for testing
+export function _resetForTesting(): void {
+  l1Cache.clear()
+  redisClient = null
+  redisInitialized = false
+  redisError = null
+}

--- a/packages/core/src/lib/api/index.ts
+++ b/packages/core/src/lib/api/index.ts
@@ -11,6 +11,7 @@ export * from './keys';
 export * from './helpers';
 export * from './rate-limit';
 export * from './cache';
+export * from './distributed-cache';
 
 // Re-export commonly used types and utilities
 export type { ApiKeyAuth, ApiKeyValidationResult } from './auth';

--- a/packages/core/tests/jest/lib/api/distributed-cache.test.ts
+++ b/packages/core/tests/jest/lib/api/distributed-cache.test.ts
@@ -1,0 +1,350 @@
+/**
+ * Tests for Distributed Cache System (Two-Tier: L1 Memory + L2 Redis)
+ *
+ * Tests the caching functionality including:
+ * - L1 memory cache operations
+ * - L2 Redis integration (mocked)
+ * - Tag-based invalidation
+ * - Fallback behavior when Redis is unavailable
+ */
+
+import { describe, it, expect, jest, beforeEach, afterEach } from '@jest/globals'
+import {
+  cacheGet,
+  cacheSet,
+  cacheDelete,
+  cacheInvalidateByTag,
+  cacheClear,
+  getCacheStats,
+  createCacheKey,
+  isDistributedCacheAvailable,
+  _l1Cache,
+  _resetForTesting,
+} from '@/core/lib/api/distributed-cache'
+
+// Mock Redis module
+const mockRedisGet = jest.fn()
+const mockRedisSet = jest.fn()
+const mockRedisDel = jest.fn()
+const mockRedisSadd = jest.fn()
+const mockRedisSmembers = jest.fn()
+const mockRedisSrem = jest.fn()
+const mockRedisKeys = jest.fn()
+const mockPipelineExec = jest.fn()
+
+const mockPipeline = jest.fn(() => ({
+  del: jest.fn().mockReturnThis(),
+  srem: jest.fn().mockReturnThis(),
+  exec: mockPipelineExec,
+}))
+
+jest.mock('@upstash/redis', () => ({
+  Redis: jest.fn().mockImplementation(() => ({
+    get: mockRedisGet,
+    set: mockRedisSet,
+    del: mockRedisDel,
+    sadd: mockRedisSadd,
+    smembers: mockRedisSmembers,
+    srem: mockRedisSrem,
+    keys: mockRedisKeys,
+    pipeline: mockPipeline,
+  })),
+}))
+
+describe('Distributed Cache System', () => {
+  const originalEnv = process.env
+
+  beforeEach(() => {
+    // Reset all mocks
+    jest.clearAllMocks()
+
+    // Reset cache state
+    _resetForTesting()
+
+    // Set up Redis env vars
+    process.env = {
+      ...originalEnv,
+      UPSTASH_REDIS_REST_URL: 'https://test.upstash.io',
+      UPSTASH_REDIS_REST_TOKEN: 'test-token',
+    }
+  })
+
+  afterEach(() => {
+    process.env = originalEnv
+  })
+
+  describe('cacheGet', () => {
+    it('should return null for non-existent key', async () => {
+      mockRedisGet.mockResolvedValue(null)
+
+      const result = await cacheGet('non-existent')
+
+      expect(result).toBeNull()
+    })
+
+    it('should return value from L1 cache if present', async () => {
+      // Pre-populate L1 cache
+      _l1Cache.set('test-key', 'test-value', 60000, [])
+
+      const result = await cacheGet('test-key')
+
+      expect(result).toBe('test-value')
+      // Redis should not be called if L1 has the value
+      expect(mockRedisGet).not.toHaveBeenCalled()
+    })
+
+    it('should populate L1 from L2 on cache miss', async () => {
+      const cachedData = {
+        value: { name: 'Test User' },
+        tags: ['users'],
+        ttl: Date.now() + 60000,
+      }
+      mockRedisGet.mockResolvedValue(JSON.stringify(cachedData))
+
+      const result = await cacheGet<{ name: string }>('user:123')
+
+      expect(result).toEqual({ name: 'Test User' })
+
+      // Verify L1 was populated
+      const l1Value = _l1Cache.get('user:123')
+      expect(l1Value).toEqual({ name: 'Test User' })
+    })
+
+    it('should handle Redis errors gracefully', async () => {
+      mockRedisGet.mockRejectedValue(new Error('Redis connection error'))
+
+      const result = await cacheGet('test-key')
+
+      expect(result).toBeNull()
+    })
+  })
+
+  describe('cacheSet', () => {
+    it('should store value in L1 cache', async () => {
+      mockRedisSet.mockResolvedValue('OK')
+      mockRedisSadd.mockResolvedValue(1)
+
+      await cacheSet('test-key', 'test-value', 300)
+
+      const l1Value = _l1Cache.get('test-key')
+      expect(l1Value).toBe('test-value')
+    })
+
+    it('should store value in Redis (L2)', async () => {
+      mockRedisSet.mockResolvedValue('OK')
+      mockRedisSadd.mockResolvedValue(1)
+
+      await cacheSet('test-key', { id: 123 }, 300, ['entity:123'])
+
+      expect(mockRedisSet).toHaveBeenCalledWith(
+        'cache:test-key',
+        expect.any(String),
+        { ex: 300 }
+      )
+    })
+
+    it('should update tag index in Redis', async () => {
+      mockRedisSet.mockResolvedValue('OK')
+      mockRedisSadd.mockResolvedValue(1)
+
+      await cacheSet('user:123', { name: 'Test' }, 300, ['users', 'user:123'])
+
+      expect(mockRedisSadd).toHaveBeenCalledWith('cache:tag:users', 'user:123')
+      expect(mockRedisSadd).toHaveBeenCalledWith('cache:tag:user:123', 'user:123')
+    })
+
+    it('should use default TTL of 300 seconds', async () => {
+      mockRedisSet.mockResolvedValue('OK')
+
+      await cacheSet('test-key', 'value')
+
+      expect(mockRedisSet).toHaveBeenCalledWith(
+        'cache:test-key',
+        expect.any(String),
+        { ex: 300 }
+      )
+    })
+
+    it('should handle Redis errors gracefully (L1 still works)', async () => {
+      mockRedisSet.mockRejectedValue(new Error('Redis error'))
+
+      await cacheSet('test-key', 'test-value', 300)
+
+      // L1 should still have the value
+      const l1Value = _l1Cache.get('test-key')
+      expect(l1Value).toBe('test-value')
+    })
+  })
+
+  describe('cacheDelete', () => {
+    it('should delete from L1 cache', async () => {
+      mockRedisDel.mockResolvedValue(1)
+
+      // Pre-populate
+      _l1Cache.set('test-key', 'value', 60000, [])
+
+      const result = await cacheDelete('test-key')
+
+      expect(result).toBe(true)
+      expect(_l1Cache.get('test-key')).toBeNull()
+    })
+
+    it('should delete from Redis (L2)', async () => {
+      mockRedisDel.mockResolvedValue(1)
+
+      await cacheDelete('test-key')
+
+      expect(mockRedisDel).toHaveBeenCalledWith('cache:test-key')
+    })
+
+    it('should return false for non-existent key', async () => {
+      mockRedisDel.mockResolvedValue(0)
+
+      const result = await cacheDelete('non-existent')
+
+      expect(result).toBe(false)
+    })
+  })
+
+  describe('cacheInvalidateByTag', () => {
+    it('should invalidate all keys with given tag in L1', async () => {
+      mockRedisSmembers.mockResolvedValue(['user:1', 'user:2'])
+      mockPipelineExec.mockResolvedValue([])
+
+      // Pre-populate L1 with tagged entries
+      _l1Cache.set('user:1', { id: 1 }, 60000, ['users'])
+      _l1Cache.set('user:2', { id: 2 }, 60000, ['users'])
+      _l1Cache.set('product:1', { id: 1 }, 60000, ['products'])
+
+      const count = await cacheInvalidateByTag('users')
+
+      expect(count).toBe(2)
+      expect(_l1Cache.get('user:1')).toBeNull()
+      expect(_l1Cache.get('user:2')).toBeNull()
+      expect(_l1Cache.get('product:1')).not.toBeNull()
+    })
+
+    it('should invalidate in Redis using pipeline', async () => {
+      mockRedisSmembers.mockResolvedValue(['key1', 'key2'])
+      mockPipelineExec.mockResolvedValue([])
+
+      await cacheInvalidateByTag('test-tag')
+
+      expect(mockRedisSmembers).toHaveBeenCalledWith('cache:tag:test-tag')
+      expect(mockPipeline).toHaveBeenCalled()
+    })
+
+    it('should return 0 for non-existent tag', async () => {
+      mockRedisSmembers.mockResolvedValue([])
+
+      const count = await cacheInvalidateByTag('non-existent')
+
+      expect(count).toBe(0)
+    })
+  })
+
+  describe('cacheClear', () => {
+    it('should clear L1 cache', async () => {
+      mockRedisKeys.mockResolvedValue([])
+
+      // Pre-populate
+      _l1Cache.set('key1', 'value1', 60000, [])
+      _l1Cache.set('key2', 'value2', 60000, [])
+
+      await cacheClear()
+
+      expect(_l1Cache.get('key1')).toBeNull()
+      expect(_l1Cache.get('key2')).toBeNull()
+    })
+
+    it('should clear Redis cache keys', async () => {
+      mockRedisKeys
+        .mockResolvedValueOnce(['cache:key1', 'cache:key2'])
+        .mockResolvedValueOnce(['cache:tag:users'])
+      mockRedisDel.mockResolvedValue(2)
+
+      await cacheClear()
+
+      expect(mockRedisKeys).toHaveBeenCalledWith('cache:*')
+      expect(mockRedisKeys).toHaveBeenCalledWith('cache:tag:*')
+    })
+  })
+
+  describe('getCacheStats', () => {
+    it('should return L1 stats and L2 availability', async () => {
+      _l1Cache.set('key1', 'value', 60000, ['tag1'])
+      _l1Cache.set('key2', 'value', 60000, ['tag1', 'tag2'])
+
+      const stats = await getCacheStats()
+
+      expect(stats.l1.size).toBe(2)
+      expect(stats.l1.maxSize).toBe(10000)
+      expect(stats.l2Available).toBe(true)
+    })
+  })
+
+  describe('createCacheKey', () => {
+    it('should create namespaced cache key', () => {
+      const key = createCacheKey('users', '123', 'profile')
+
+      expect(key).toBe('users:123:profile')
+    })
+
+    it('should handle single part', () => {
+      const key = createCacheKey('config', 'app')
+
+      expect(key).toBe('config:app')
+    })
+  })
+
+  describe('Fallback behavior (no Redis)', () => {
+    beforeEach(() => {
+      // Remove Redis env vars
+      delete process.env.UPSTASH_REDIS_REST_URL
+      delete process.env.UPSTASH_REDIS_REST_TOKEN
+      _resetForTesting()
+    })
+
+    it('should work with L1 only when Redis is not configured', async () => {
+      await cacheSet('test-key', 'test-value', 300)
+
+      const result = await cacheGet('test-key')
+
+      expect(result).toBe('test-value')
+    })
+
+    it('should report L2 as unavailable', async () => {
+      const available = await isDistributedCacheAvailable()
+
+      expect(available).toBe(false)
+    })
+
+    it('should still support tag invalidation in L1', async () => {
+      await cacheSet('user:1', { id: 1 }, 300, ['users'])
+      await cacheSet('user:2', { id: 2 }, 300, ['users'])
+
+      const count = await cacheInvalidateByTag('users')
+
+      expect(count).toBe(2)
+      expect(await cacheGet('user:1')).toBeNull()
+      expect(await cacheGet('user:2')).toBeNull()
+    })
+  })
+
+  describe('L1 Cache TTL and Expiration', () => {
+    it('should expire entries after TTL', async () => {
+      jest.useFakeTimers()
+
+      _l1Cache.set('expiring-key', 'value', 1000, []) // 1 second TTL
+
+      expect(_l1Cache.get('expiring-key')).toBe('value')
+
+      // Advance time past TTL
+      jest.advanceTimersByTime(1500)
+
+      expect(_l1Cache.get('expiring-key')).toBeNull()
+
+      jest.useRealTimers()
+    })
+  })
+})


### PR DESCRIPTION
## Summary

- Implements distributed caching system with L1 (memory) and L2 (Redis/Upstash) layers
- Enables cache sharing across multiple server instances in multi-instance deployments
- Provides tag-based bulk invalidation for efficient cache management
- Gracefully falls back to L1-only mode when Redis is unavailable

## Changes

### New Files
- `packages/core/src/lib/api/distributed-cache.ts` - Two-tier cache implementation
- `packages/core/tests/jest/lib/api/distributed-cache.test.ts` - Unit tests with mocked Redis

### Modified Files
- `packages/core/src/lib/api/index.ts` - Export new cache module
- `packages/core/docs/13-performance/05-caching-strategies.md` - Documentation update

## API

```typescript
import {
  cacheGet,
  cacheSet,
  cacheDelete,
  cacheInvalidateByTag,
  createCacheKey,
} from '@nextsparkjs/core/lib/api'

// Basic usage
await cacheSet('user:123', userData, 300)
const user = await cacheGet<UserData>('user:123')

// Tag-based invalidation
await cacheSet('user:1', user1, 300, ['users', 'team:alpha'])
await cacheInvalidateByTag('users')
```

## Test plan

- [x] Unit tests for L1 cache operations
- [x] Unit tests for L2 Redis operations (mocked)
- [x] Tests for tag-based invalidation
- [x] Tests for fallback behavior without Redis
- [x] Build passes successfully

## Dependencies

- **Requires:** RL-001 (uses same Redis/Upstash configuration)
- **Blocks:** Nothing

🤖 Generated with [Claude Code](https://claude.com/claude-code)