### PR TITLE
fix(core): use relative imports in pattern-resolver files

### DIFF
--- a/packages/core/src/lib/blocks/pattern-resolver.ts
+++ b/packages/core/src/lib/blocks/pattern-resolver.ts
@@ -10,9 +10,9 @@
  * @module core/lib/blocks/pattern-resolver
  */
 
-import type { BlockInstance } from '@/core/types/blocks'
-import type { Pattern, PatternReference } from '@/core/types/pattern-reference'
-import { isPatternReference } from '@/core/types/pattern-reference'
+import type { BlockInstance } from '../../types/blocks'
+import type { Pattern, PatternReference } from '../../types/pattern-reference'
+import { isPatternReference } from '../../types/pattern-reference'
 
 /**
  * Resolve pattern references in a blocks array

--- a/packages/core/src/lib/blocks/patterns-resolver.service.ts
+++ b/packages/core/src/lib/blocks/patterns-resolver.service.ts
@@ -12,9 +12,9 @@
  * @module core/lib/blocks/patterns-resolver.service
  */
 
-import { query } from '@/core/lib/db'
-import type { Pattern } from '@/core/types/pattern-reference'
-import type { BlockInstance } from '@/core/types/blocks'
+import { query } from '../db'
+import type { Pattern } from '../../types/pattern-reference'
+import type { BlockInstance } from '../../types/blocks'
 
 // Database row type for pattern
 interface DbPattern {


### PR DESCRIPTION
## Summary
- Replace `@/core/` alias imports with relative paths in pattern-resolver files

## Problem
The `@/core/` alias only works in the monorepo but fails when the package is installed via npm:
```
Module not found: Can't resolve '@/core/types/pattern-reference'
```

## Solution
Use relative paths that work in both environments:
- `@/core/types/blocks` → `../../types/blocks`
- `@/core/types/pattern-reference` → `../../types/pattern-reference`
- `@/core/lib/db` → `../db`

## Files Changed
- `packages/core/src/lib/blocks/pattern-resolver.ts`
- `packages/core/src/lib/blocks/patterns-resolver.service.ts`

## Test plan
- [x] Build succeeds
- [x] Verified compiled output has correct relative imports
- [ ] Publish new version and test in npm-installed project

🤖 Generated with [Claude Code](https://claude.com/claude-code)