### PR TITLE
feat(claude): add /do:test-package command

### DIFF
--- a/.claude/commands/do/README.md
+++ b/.claude/commands/do/README.md
@@ -46,6 +46,7 @@ Each `do:` command is **MINIMAL** - it only points to where to read the full ins
 | `/do:npm-publish` | Publish packages to npm | `how-to/releases/npm-publish` |
 | `/do:npm-version` | Increment package versions | `how-to/releases/npm-version` |
 | `/do:release-version` | Create a core version release | `how-to/releases/release-version` |
+| `/do:test-package` | Test npm package from scratch | `npm-development-workflow` |
 
 ### Git & GitHub
 
@@ -66,6 +67,9 @@ Each `do:` command is **MINIMAL** - it only points to where to read the full ins
 /do:create-entity products
 /do:create-migration add-status-to-orders
 /do:npm-publish
+
+# Test package before publishing
+/do:test-package
 
 # For general tasks (skill enforcement)
 /do:use-skills create a webhook integration

--- a/.claude/commands/do/sync-code-review.md
+++ b/.claude/commands/do/sync-code-review.md
@@ -27,6 +27,7 @@ See `.claude/skills/github/SKILL.md` for general GitHub workflow patterns (branc
 7. **Verify** → `pnpm build`
 8. **Commit & push** → With structured message
 9. **Comment on PR** → With response table
+10. **Request re-review** → Comment `@claude` again to validate fixes
 
 ### Evaluation Criteria
 
@@ -101,6 +102,9 @@ Co-Authored-By: Claude Code <noreply@anthropic.com>"
 
 # Comment response
 gh pr comment <number> --body "<response>"
+
+# Request re-review after fixes
+gh pr comment <number> --body "@claude"
 ```
 
 ---

--- a/.claude/commands/do/test-package.md
+++ b/.claude/commands/do/test-package.md
@@ -1,0 +1,168 @@
+---
+description: "Test npm package from scratch - creates fresh Next.js project and validates full flow"
+---
+
+# do:test-package
+
+**Context:** {{{ input }}}
+
+---
+
+## Purpose
+
+Test the npm package distribution by creating a fresh Next.js project and validating the complete installation and runtime flow. This simulates exactly what a new user would experience when installing NextSpark from npm.
+
+---
+
+## MANDATORY: Read Skill First
+
+Read `.claude/skills/npm-development-workflow/SKILL.md` for context on dual-mode testing.
+
+---
+
+## Execution Steps
+
+Execute these steps in order. Stop and report if any step fails.
+
+### Step 1: Clean Previous Test Project
+
+```bash
+# Remove existing test project
+cd G:/GitHub/nextspark/projects
+rm -rf test-package
+```
+
+### Step 2: Build Core Package
+
+```bash
+cd G:/GitHub/nextspark/repo/packages/core
+pnpm build:js
+```
+
+**Validation:** Build completes without errors.
+
+### Step 3: Pack Core Package
+
+```bash
+cd G:/GitHub/nextspark/repo/packages/core
+pnpm pack
+```
+
+**Output:** Creates `nextsparkjs-core-X.Y.Z.tgz` file.
+
+### Step 4: Create Fresh Next.js Project
+
+```bash
+cd G:/GitHub/nextspark/projects
+npx create-next-app@latest test-package --typescript --tailwind --eslint --app --src-dir --import-alias "@/*" --use-pnpm
+```
+
+**Note:** Use `--yes` or provide answers non-interactively if needed.
+
+### Step 5: Install Core Tarball
+
+```bash
+cd G:/GitHub/nextspark/projects/test-package
+
+# Find the tarball version dynamically
+TARBALL=$(ls ../../repo/packages/core/nextsparkjs-core-*.tgz | head -1)
+pnpm add "$TARBALL"
+```
+
+### Step 6: Run CLI Init
+
+```bash
+cd G:/GitHub/nextspark/projects/test-package
+npx nextspark init
+```
+
+**Expected:** CLI copies structure, theme, configs to the project.
+
+### Step 7: Copy Environment File
+
+```bash
+cd G:/GitHub/nextspark/projects/test-package
+cp ../../repo/apps/dev/.env .env
+```
+
+**Important:** Verify DATABASE_URL points to valid database.
+
+### Step 8: Run Database Migrations
+
+```bash
+cd G:/GitHub/nextspark/projects/test-package
+pnpm db:migrate
+```
+
+**Validation:** All migrations run successfully, tables created.
+
+### Step 9: Start Development Server
+
+```bash
+cd G:/GitHub/nextspark/projects/test-package
+pnpm dev
+```
+
+**Expected:** Server starts on port 3000 (or as configured in .env).
+
+### Step 10: Manual Verification Checklist
+
+Open browser at http://localhost:3000 and verify:
+
+- [ ] Homepage loads without errors
+- [ ] No console errors in browser DevTools
+- [ ] No server errors in terminal
+- [ ] Login page accessible at /login
+- [ ] Can login with test user: `superadmin@tmt.dev` / `Test1234`
+- [ ] Dashboard loads after login
+- [ ] Sidebar shows entities
+- [ ] Can create/edit/delete records
+
+---
+
+## Quick One-Liner (For Experienced Users)
+
+```bash
+cd G:/GitHub/nextspark/projects && rm -rf test-package && \
+cd ../repo/packages/core && pnpm build:js && pnpm pack && \
+cd ../../projects && npx create-next-app@latest test-package --typescript --tailwind --eslint --app --src-dir --import-alias "@/*" --use-pnpm --yes && \
+cd test-package && pnpm add ../../repo/packages/core/nextsparkjs-core-*.tgz && \
+npx nextspark init && cp ../../repo/apps/dev/.env .env && \
+pnpm db:migrate && pnpm dev
+```
+
+---
+
+## Troubleshooting
+
+| Issue | Solution |
+|-------|----------|
+| `nextspark: command not found` | Ensure core package installed: `pnpm list @nextsparkjs/core` |
+| Migration fails | Check DATABASE_URL in .env, ensure DB server running |
+| `Module not found` | Run `pnpm install` again, check tarball version matches |
+| Port already in use | Change PORT in .env or kill existing process |
+| Login fails | Run migrations again, check test users exist in DB |
+
+---
+
+## Success Criteria
+
+The test passes if:
+1. All 10 steps complete without errors
+2. Dev server starts and serves pages
+3. Authentication flow works (login/logout)
+4. CRUD operations function correctly
+5. No hydration mismatches or console errors
+
+---
+
+## After Testing
+
+If test passes, the package is ready for publishing:
+```bash
+cd G:/GitHub/nextspark/repo
+pnpm pkg:version -- patch  # or minor/major
+pnpm pkg:publish
+```
+
+If test fails, fix issues and re-run `/do:test-package`.

--- a/.claude/commands/do/test-package.md
+++ b/.claude/commands/do/test-package.md
@@ -17,6 +17,8 @@ Test the npm package distribution by creating a **fresh Next.js project** and va
 - **Clean install testing** - After major changes to CLI or init process
 - **New user experience validation** - Ensuring the onboarding flow works
 
+See also: `.claude/skills/npm-development-workflow/SKILL.md` section "When to Reset my-app from Scratch" for the decision framework.
+
 **This is different from daily development testing:**
 - Daily dev testing uses `pnpm setup:update-local` with `projects/my-app`
 - This command creates a **completely fresh project** to simulate npm install
@@ -109,7 +111,12 @@ cp "$REPO_ROOT/apps/dev/.env" .env
 
 # Ensure PORT is set to 3000 for clean test project
 # (avoids conflict with monorepo dev server on 5173)
-sed -i 's/^PORT=.*/PORT=3000/' .env 2>/dev/null || echo "PORT=3000" >> .env
+# Portable sed: works on both Linux and macOS
+if grep -q '^PORT=' .env 2>/dev/null; then
+  sed -i.bak 's/^PORT=.*/PORT=3000/' .env && rm -f .env.bak
+else
+  echo "PORT=3000" >> .env
+fi
 ```
 
 **Important:** Verify DATABASE_URL points to valid database.
@@ -200,14 +207,28 @@ The test passes if:
 
 ## After Testing
 
-If test passes, the package is ready for publishing:
+If test passes, the package is ready for publishing. Follow the npm-development-workflow:
+
 ```bash
 cd "$REPO_ROOT"
-pnpm pkg:version -- patch  # or minor/major
-pnpm pkg:publish
+# See /do:npm-version and /do:npm-publish for complete details
+pnpm pkg:version -- patch  # or minor/major based on changes
+pnpm pkg:pack              # Create .tgz files
+pnpm pkg:publish           # Publish to npm registry
 ```
 
 If test fails, fix issues in the repo and re-run `/do:test-package`.
+
+---
+
+## Cleanup
+
+To remove the test project after validation:
+
+```bash
+cd "$PROJECTS_DIR"
+rm -rf test-package
+```
 
 ---
 


### PR DESCRIPTION
## Summary

- Adds `/do:test-package` command to automate npm package testing from scratch
- Creates a fresh Next.js project, installs the tarball, and validates the full flow
- Updates `/do:` commands README with the new command

## What it does

1. Cleans previous test project (`projects/test-package`)
2. Builds and packs core package
3. Creates fresh Next.js project with `create-next-app`
4. Installs the `.tgz` tarball
5. Runs `nextspark init` CLI
6. Copies `.env` from dev app
7. Runs database migrations
8. Starts dev server
9. Provides manual verification checklist

## Test plan

- [ ] Run `/do:test-package` command
- [ ] Verify all 10 steps execute successfully
- [ ] Verify dev server starts and serves pages
- [ ] Verify login works with test user

🤖 Generated with [Claude Code](https://claude.com/claude-code)