### PR TITLE
fix(core): export core entities for NPM mode discovery

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nextsparkjs/cli",
-  "version": "0.1.0-beta.65",
+  "version": "0.1.0-beta.66",
   "description": "NextSpark CLI - Complete development toolkit",
   "type": "module",
   "bin": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nextsparkjs/core",
-  "version": "0.1.0-beta.65",
+  "version": "0.1.0-beta.66",
   "description": "NextSpark - The complete SaaS framework for Next.js",
   "license": "MIT",
   "author": "NextSpark <hello@nextspark.dev>",
@@ -271,6 +271,21 @@
     "./lib/actions": {
       "types": "./dist/lib/actions/index.d.ts",
       "import": "./dist/lib/actions/index.js"
+    },
+    "./entities/patterns/patterns.config": {
+      "types": "./dist/entities/patterns/patterns.config.d.ts",
+      "import": "./dist/entities/patterns/patterns.config.js"
+    },
+    "./entities/patterns/patterns.fields": {
+      "types": "./dist/entities/patterns/patterns.fields.d.ts",
+      "import": "./dist/entities/patterns/patterns.fields.js"
+    },
+    "./entities/patterns/patterns.service": {
+      "types": "./dist/entities/patterns/patterns.service.d.ts",
+      "import": "./dist/entities/patterns/patterns.service.js"
+    },
+    "./entities/patterns/messages/*": {
+      "import": "./src/entities/patterns/messages/*"
     }
   },
   "files": [
@@ -278,6 +293,7 @@
     "styles",
     "templates",
     "migrations",
+    "src/entities",
     "tests/cypress/support",
     "tests/jest/setup.ts",
     "tests/jest/__mocks__",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -272,12 +272,12 @@
       "types": "./dist/lib/actions/index.d.ts",
       "import": "./dist/lib/actions/index.js"
     },
-    "./entities/patterns/*": {
-      "types": "./dist/entities/patterns/*.d.ts",
-      "import": "./dist/entities/patterns/*.js"
+    "./entities/*/*": {
+      "types": "./dist/entities/*/*.d.ts",
+      "import": "./dist/entities/*/*.js"
     },
-    "./entities/patterns/messages/*": {
-      "import": "./dist/entities/patterns/messages/*"
+    "./entities/*/messages/*": {
+      "import": "./dist/entities/*/messages/*"
     }
   },
   "files": [

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -272,20 +272,12 @@
       "types": "./dist/lib/actions/index.d.ts",
       "import": "./dist/lib/actions/index.js"
     },
-    "./entities/patterns/patterns.config": {
-      "types": "./dist/entities/patterns/patterns.config.d.ts",
-      "import": "./dist/entities/patterns/patterns.config.js"
-    },
-    "./entities/patterns/patterns.fields": {
-      "types": "./dist/entities/patterns/patterns.fields.d.ts",
-      "import": "./dist/entities/patterns/patterns.fields.js"
-    },
-    "./entities/patterns/patterns.service": {
-      "types": "./dist/entities/patterns/patterns.service.d.ts",
-      "import": "./dist/entities/patterns/patterns.service.js"
+    "./entities/patterns/*": {
+      "types": "./dist/entities/patterns/*.d.ts",
+      "import": "./dist/entities/patterns/*.js"
     },
     "./entities/patterns/messages/*": {
-      "import": "./src/entities/patterns/messages/*"
+      "import": "./dist/entities/patterns/messages/*"
     }
   },
   "files": [

--- a/packages/core/tsup.config.ts
+++ b/packages/core/tsup.config.ts
@@ -139,12 +139,26 @@ export default defineConfig({
       { recursive: true }
     ).catch(() => console.log('No messages directory to copy'))
 
-    // Copy entity messages directories (for core entities like patterns)
-    await cp(
-      join(process.cwd(), 'src/entities/patterns/messages'),
-      join(distDir, 'entities/patterns/messages'),
-      { recursive: true }
-    ).catch(() => console.log('No patterns messages directory to copy'))
+    // Copy entity messages directories dynamically (for all core entities)
+    // This auto-discovers all entities with messages folders, eliminating manual updates
+    const entitiesDir = join(process.cwd(), 'src/entities')
+    if (existsSync(entitiesDir)) {
+      const entityDirs = await readdir(entitiesDir, { withFileTypes: true })
+        .then(entries => entries.filter(e => e.isDirectory()).map(e => e.name))
+        .catch(() => [])
+
+      for (const entityName of entityDirs) {
+        const entityMessagesPath = join(entitiesDir, entityName, 'messages')
+        if (existsSync(entityMessagesPath)) {
+          await cp(
+            entityMessagesPath,
+            join(distDir, 'entities', entityName, 'messages'),
+            { recursive: true }
+          ).catch(() => console.log(`No ${entityName} messages directory to copy`))
+        }
+      }
+      console.log(`✅ Copied messages for ${entityDirs.length} core entities`)
+    }
 
     // Copy presets/ directory
     await cp(

--- a/packages/core/tsup.config.ts
+++ b/packages/core/tsup.config.ts
@@ -139,6 +139,13 @@ export default defineConfig({
       { recursive: true }
     ).catch(() => console.log('No messages directory to copy'))
 
+    // Copy entity messages directories (for core entities like patterns)
+    await cp(
+      join(process.cwd(), 'src/entities/patterns/messages'),
+      join(distDir, 'entities/patterns/messages'),
+      { recursive: true }
+    ).catch(() => console.log('No patterns messages directory to copy'))
+
     // Copy presets/ directory
     await cp(
       join(process.cwd(), 'presets'),

--- a/packages/create-nextspark-app/package.json
+++ b/packages/create-nextspark-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-nextspark-app",
-  "version": "0.1.0-beta.65",
+  "version": "0.1.0-beta.66",
   "description": "Create a new NextSpark SaaS project",
   "type": "module",
   "bin": {

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nextsparkjs/testing",
-  "version": "0.1.0-beta.65",
+  "version": "0.1.0-beta.66",
   "description": "Testing utilities for NextSpark applications - Selectors, POMs, and Cypress helpers",
   "license": "MIT",
   "author": "NextSpark <hello@nextspark.dev>",

--- a/plugins/ai/package.json
+++ b/plugins/ai/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nextsparkjs/plugin-ai",
-  "version": "0.1.0-beta.65",
+  "version": "0.1.0-beta.66",
   "private": false,
   "main": "./plugin.config.ts",
   "requiredPlugins": [],

--- a/plugins/amplitude/package.json
+++ b/plugins/amplitude/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nextsparkjs/plugin-amplitude",
-  "version": "0.1.0-beta.65",
+  "version": "0.1.0-beta.66",
   "private": false,
   "main": "./plugin.config.ts",
   "requiredPlugins": [],

--- a/plugins/langchain/package.json
+++ b/plugins/langchain/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nextsparkjs/plugin-langchain",
-  "version": "0.1.0-beta.65",
+  "version": "0.1.0-beta.66",
   "private": false,
   "main": "./plugin.config.ts",
   "requiredPlugins": [],

--- a/plugins/social-media-publisher/package.json
+++ b/plugins/social-media-publisher/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nextsparkjs/plugin-social-media-publisher",
-  "version": "0.1.0-beta.65",
+  "version": "0.1.0-beta.66",
   "private": false,
   "main": "./plugin.config.ts",
   "requiredPlugins": [],

--- a/themes/blog/package.json
+++ b/themes/blog/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nextsparkjs/theme-blog",
-  "version": "0.1.0-beta.65",
+  "version": "0.1.0-beta.66",
   "private": false,
   "type": "module",
   "main": "./config/theme.config.ts",

--- a/themes/crm/package.json
+++ b/themes/crm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nextsparkjs/theme-crm",
-  "version": "0.1.0-beta.65",
+  "version": "0.1.0-beta.66",
   "private": false,
   "type": "module",
   "main": "./config/theme.config.ts",

--- a/themes/default/package.json
+++ b/themes/default/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nextsparkjs/theme-default",
-  "version": "0.1.0-beta.65",
+  "version": "0.1.0-beta.66",
   "private": false,
   "type": "module",
   "main": "./config/theme.config.ts",

--- a/themes/productivity/package.json
+++ b/themes/productivity/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nextsparkjs/theme-productivity",
-  "version": "0.1.0-beta.65",
+  "version": "0.1.0-beta.66",
   "private": false,
   "type": "module",
   "main": "./config/theme.config.ts",


### PR DESCRIPTION
## Summary

Fixes core entity discovery in NPM mode. Previously, entities like `patterns` weren't being discovered because:

1. `src/entities` wasn't published in the npm package
2. No exports existed for `./entities/*` paths  
3. Entity message JSON files weren't copied to `dist/`

## Changes

- **package.json**: Add `src/entities` to files array + add exports for `./entities/patterns/*`
- **tsup.config.ts**: Copy entity messages to `dist/` during build

## Test Results

| Mode | build:registries | build | patterns discovery |
|------|-----------------|-------|-------------------|
| Monorepo | ✅ | ✅ | ✅ |
| NPM local | ✅ | ✅ | ✅ |

## Test plan

- [x] Verify `pnpm build:registries` works in monorepo mode
- [x] Verify `pnpm setup:local` creates working NPM mode project
- [x] Verify patterns entity is discovered and permissions validated
- [x] Verify build completes without "Can't resolve './messages/*.json'" errors

---

@claude please review this PR for code quality, security, and any edge cases I might have missed.

🤖 Generated with [Claude Code](https://claude.ai/code)