### PR TITLE
fix(cli): add pnpm-workspace.yaml for plugins and themes support

### DIFF
--- a/packages/cli/src/wizard/generators/index.ts
+++ b/packages/cli/src/wizard/generators/index.ts
@@ -113,6 +113,7 @@ async function copyProjectFiles(): Promise<void> {
     { src: 'tsconfig.json', dest: 'tsconfig.json', force: true },
     { src: 'postcss.config.mjs', dest: 'postcss.config.mjs', force: true },
     { src: 'i18n.ts', dest: 'i18n.ts', force: true },
+    { src: 'pnpm-workspace.yaml', dest: 'pnpm-workspace.yaml', force: false }, // Enable workspace for themes/plugins
     { src: 'npmrc', dest: '.npmrc', force: false },
     { src: 'tsconfig.cypress.json', dest: 'tsconfig.cypress.json', force: false },
     { src: 'cypress.d.ts', dest: 'cypress.d.ts', force: false },

--- a/packages/core/templates/pnpm-workspace.yaml
+++ b/packages/core/templates/pnpm-workspace.yaml
@@ -1,0 +1,3 @@
+packages:
+  - 'contents/themes/*'
+  - 'contents/plugins/*'

--- a/packages/core/templates/pnpm-workspace.yaml
+++ b/packages/core/templates/pnpm-workspace.yaml
@@ -1,3 +1,5 @@
+# pnpm workspace configuration
+# Enables plugins and themes to have their own package.json with dependencies
 packages:
   - 'contents/themes/*'
   - 'contents/plugins/*'


### PR DESCRIPTION
## Summary
- Add `pnpm-workspace.yaml` template to enable plugins/themes as workspaces
- Projects created with wizard now include workspace config by default
- Plugins and themes can now have their own `package.json` files

## Problem
When installing plugins via the CLI/wizard, the project didn't include a `pnpm-workspace.yaml` file. This meant plugins couldn't have their own `package.json` and be recognized as proper pnpm workspaces.

## Solution
- Created `packages/core/templates/pnpm-workspace.yaml` with:
  ```yaml
  packages:
    - 'contents/themes/*'
    - 'contents/plugins/*'
  ```
- Updated wizard generator to copy this file during project creation

## Test plan
- [ ] Create a new project with `create-nextspark-app`
- [ ] Verify `pnpm-workspace.yaml` exists in the new project
- [ ] Install a plugin (e.g., AI plugin)
- [ ] Verify the plugin can have its own `package.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)