### PR TITLE
fix(core): use tableName property for PostgreSQL table derivation

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nextsparkjs/cli",
-  "version": "0.1.0-beta.72",
+  "version": "0.1.0-beta.73",
   "description": "NextSpark CLI - Complete development toolkit",
   "type": "module",
   "bin": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nextsparkjs/core",
-  "version": "0.1.0-beta.72",
+  "version": "0.1.0-beta.73",
   "description": "NextSpark - The complete SaaS framework for Next.js",
   "license": "MIT",
   "author": "NextSpark <hello@nextspark.dev>",

--- a/packages/core/src/lib/entities/meta-adapter.ts
+++ b/packages/core/src/lib/entities/meta-adapter.ts
@@ -39,8 +39,8 @@ export class MetaSystemAdapter {
 
     if (config && config.access?.metadata) {
       return {
-        tableName: config.slug,
-        metaTableName: `${config.slug}_metas`,
+        tableName: config.tableName || config.slug,
+        metaTableName: `${config.tableName || config.slug}_metas`,
         idColumn: 'entityId',
         apiPath: `/api/v1/${config.slug}`
       }
@@ -98,8 +98,8 @@ export class MetaSystemAdapter {
 
     return {
       entityType: entityConfig.slug,
-      tableName: entityConfig.slug,
-      metaTableName: `${entityConfig.slug}_metas`,
+      tableName: entityConfig.tableName || entityConfig.slug,
+      metaTableName: `${entityConfig.tableName || entityConfig.slug}_metas`,
       idColumn: 'entityId',
       apiPath: `/api/v1/${entityConfig.slug}`
     }

--- a/packages/core/src/lib/entities/migration-helper.ts
+++ b/packages/core/src/lib/entities/migration-helper.ts
@@ -133,8 +133,8 @@ function generateTableDefinition(
     includeComments: boolean
   }
 ): TableDefinition {
-  // Derive database config from slug (as per EntityConfig design)
-  const tableName = entityConfig.slug
+  // Use explicit tableName if defined, otherwise derive from slug
+  const tableName = entityConfig.tableName || entityConfig.slug
   const primaryKey = 'id' // Standard primary key name
 
   // Generate columns

--- a/packages/core/src/lib/entities/query-generator.ts
+++ b/packages/core/src/lib/entities/query-generator.ts
@@ -62,7 +62,7 @@ export function generateSelectQuery(
   const selectClause = selectFields.join(', ')
 
   // Build FROM clause with table name
-  const tableName = entityConfig.slug
+  const tableName = entityConfig.tableName || entityConfig.slug
   const fromClause = `FROM ${tableName}`
 
   // Build WHERE clause
@@ -144,7 +144,7 @@ export function generateInsertQuery(
   data: Record<string, unknown>,
   userId?: string
 ): QueryResult {
-  const tableName = entityConfig.slug
+  const tableName = entityConfig.tableName || entityConfig.slug
   const insertableFields = getInsertableFields(entityConfig)
   
   const fields: string[] = []
@@ -199,7 +199,7 @@ export function generateUpdateQuery(
   data: Record<string, unknown>,
   userId?: string
 ): QueryResult {
-  const tableName = entityConfig.slug
+  const tableName = entityConfig.tableName || entityConfig.slug
   const updatableFields = getUpdatableFields(entityConfig)
   
   const setConditions: string[] = []
@@ -253,7 +253,7 @@ export function generateDeleteQuery(
   id: string,
   userId?: string
 ): QueryResult {
-  const tableName = entityConfig.slug
+  const tableName = entityConfig.tableName || entityConfig.slug
   const params: unknown[] = [id]
   let paramIndex = 2
 
@@ -535,7 +535,7 @@ export function generateCountQuery(
   entityConfig: EntityConfig,
   where: WhereClause[] = []
 ): QueryResult {
-  const tableName = entityConfig.slug
+  const tableName = entityConfig.tableName || entityConfig.slug
   const whereConditions: string[] = []
   const params: unknown[] = []
   let paramIndex = 1
@@ -570,7 +570,7 @@ export function generateCountQuery(
 // Helper functions
 
 function generateSelectFields(entityConfig: EntityConfig): string[] {
-  const tableName = entityConfig.slug
+  const tableName = entityConfig.tableName || entityConfig.slug
   const fields = ["id"]
   
   // Add entity fields

--- a/packages/core/src/lib/services/pattern-usage.service.ts
+++ b/packages/core/src/lib/services/pattern-usage.service.ts
@@ -313,8 +313,8 @@ export class PatternUsageService {
         continue
       }
 
-      // Use the validated slug from config as table name (guaranteed safe)
-      const tableName = entityConfig.slug
+      // Use the validated tableName or slug from config as table name (guaranteed safe)
+      const tableName = entityConfig.tableName || entityConfig.slug
 
       try {
         // First, get available columns for this table to build a safe query

--- a/packages/create-nextspark-app/package.json
+++ b/packages/create-nextspark-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-nextspark-app",
-  "version": "0.1.0-beta.72",
+  "version": "0.1.0-beta.73",
   "description": "Create a new NextSpark SaaS project",
   "type": "module",
   "bin": {

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nextsparkjs/testing",
-  "version": "0.1.0-beta.72",
+  "version": "0.1.0-beta.73",
   "description": "Testing utilities for NextSpark applications - Selectors, POMs, and Cypress helpers",
   "license": "MIT",
   "author": "NextSpark <hello@nextspark.dev>",

--- a/plugins/ai/package.json
+++ b/plugins/ai/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nextsparkjs/plugin-ai",
-  "version": "0.1.0-beta.72",
+  "version": "0.1.0-beta.73",
   "private": false,
   "main": "./plugin.config.ts",
   "requiredPlugins": [],

--- a/plugins/amplitude/package.json
+++ b/plugins/amplitude/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nextsparkjs/plugin-amplitude",
-  "version": "0.1.0-beta.72",
+  "version": "0.1.0-beta.73",
   "private": false,
   "main": "./plugin.config.ts",
   "requiredPlugins": [],

--- a/plugins/langchain/package.json
+++ b/plugins/langchain/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nextsparkjs/plugin-langchain",
-  "version": "0.1.0-beta.72",
+  "version": "0.1.0-beta.73",
   "private": false,
   "main": "./plugin.config.ts",
   "requiredPlugins": [],

--- a/plugins/social-media-publisher/package.json
+++ b/plugins/social-media-publisher/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nextsparkjs/plugin-social-media-publisher",
-  "version": "0.1.0-beta.72",
+  "version": "0.1.0-beta.73",
   "private": false,
   "main": "./plugin.config.ts",
   "requiredPlugins": [],

--- a/themes/blog/package.json
+++ b/themes/blog/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nextsparkjs/theme-blog",
-  "version": "0.1.0-beta.72",
+  "version": "0.1.0-beta.73",
   "private": false,
   "type": "module",
   "main": "./config/theme.config.ts",

--- a/themes/crm/package.json
+++ b/themes/crm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nextsparkjs/theme-crm",
-  "version": "0.1.0-beta.72",
+  "version": "0.1.0-beta.73",
   "private": false,
   "type": "module",
   "main": "./config/theme.config.ts",

--- a/themes/default/package.json
+++ b/themes/default/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nextsparkjs/theme-default",
-  "version": "0.1.0-beta.72",
+  "version": "0.1.0-beta.73",
   "private": false,
   "type": "module",
   "main": "./config/theme.config.ts",

--- a/themes/productivity/package.json
+++ b/themes/productivity/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nextsparkjs/theme-productivity",
-  "version": "0.1.0-beta.72",
+  "version": "0.1.0-beta.73",
   "private": false,
   "type": "module",
   "main": "./config/theme.config.ts",


### PR DESCRIPTION
## Summary
- Fix tableName derivation to use `tableName || slug` pattern across core package
- Ensures entities with hyphenated slugs (e.g., `ai-history`) can use underscore-based table names (e.g., `ai_history`) for PostgreSQL compatibility
- PostgreSQL identifiers (indexes, constraints, triggers) cannot contain hyphens

## Changes
- `meta-adapter.ts`: getMetaConfig() and toMetaConfig()
- `migration-helper.ts`: generateTableDefinition()
- `query-generator.ts`: SELECT, INSERT, UPDATE, DELETE, COUNT queries
- `pattern-usage.service.ts`: enrichUsagesWithEntityInfo()

## Test plan
- [x] Build passes: `pnpm build:core`
- [x] Unit tests pass: `pnpm test:core`
- [x] Verification grep returns no results for remaining `.slug` used as table names

---
🤖 Generated with [Claude Code](https://claude.ai/code)