### PR TITLE
fix(theme): respect defaultMode config instead of system preference

### DIFF
--- a/packages/core/src/types/theme.ts
+++ b/packages/core/src/types/theme.ts
@@ -17,6 +17,8 @@ export interface ThemeConfig {
   description?: string
   author?: string
   enabled?: boolean
+  /** Default theme mode - controls next-themes behavior */
+  defaultMode?: 'light' | 'dark' | 'system'
   dependencies?: string[]
   plugins?: string[]
   styles?: {

--- a/packages/core/templates/app/layout.tsx
+++ b/packages/core/templates/app/layout.tsx
@@ -74,7 +74,7 @@ export default async function RootLayout({
           <NextThemeProvider
             attribute="class"
             defaultTheme={defaultTheme}
-            enableSystem
+            enableSystem={defaultTheme === 'system'}
             disableTransitionOnChange
           >
             <CustomThemeProvider>

--- a/packages/core/templates/app/layout.tsx
+++ b/packages/core/templates/app/layout.tsx
@@ -74,6 +74,7 @@ export default async function RootLayout({
           <NextThemeProvider
             attribute="class"
             defaultTheme={defaultTheme}
+            // Only detect OS preference when theme configures defaultMode: 'system'
             enableSystem={defaultTheme === 'system'}
             disableTransitionOnChange
           >


### PR DESCRIPTION
## Summary
- Fixed bug where `defaultMode: 'light'` or `defaultMode: 'dark'` in theme.config.ts was ignored when the user's OS had dark mode enabled
- `enableSystem` is now conditionally set based on the theme's `defaultMode` setting

## Problem
When a theme configured `defaultMode: 'light'`, users with dark mode enabled in their OS would still see the app in dark mode. The `next-themes` provider was always detecting system preference because `enableSystem` was hardcoded to `true`.

## Solution
Changed from:
```tsx
enableSystem
```

To:
```tsx
enableSystem={defaultTheme === 'system'}
```

Now `enableSystem` is only `true` when the theme explicitly wants to follow the system preference (`defaultMode: 'system'`).

## Test plan
- [x] Verified with Playwright (clean session) - shows light mode correctly
- [x] Verified with user's Chrome after clearing localStorage - shows light mode correctly
- [x] Theme with `defaultMode: 'light'` respects the setting regardless of OS preference

## Note for existing users
Users who previously visited the app may have `theme` stored in localStorage from when `enableSystem` was `true`. They may need to clear localStorage or the app could provide a migration/reset mechanism.

🤖 Generated with [Claude Code](https://claude.ai/code)