### PR TITLE
feat(core): theme settings with allowUserToggle support

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -354,14 +354,14 @@
     "typescript": "^5"
   },
   "dependencies": {
-    "@nextsparkjs/ui": "workspace:*",
+    "@nextsparkjs/ui": "^0.1.0-beta.2",
     "@codemirror/lang-json": "^6.0.2",
     "@dnd-kit/core": "^6.3.1",
     "@dnd-kit/sortable": "^10.0.0",
     "@dnd-kit/utilities": "^3.2.2",
     "@hookform/resolvers": "^5.2.1",
     "@inquirer/prompts": "^7.2.0",
-    "@nextsparkjs/testing": "0.1.0-beta.53",
+    "@nextsparkjs/testing": "^0.1.0-beta.75",
     "@radix-ui/react-accordion": "^1.2.12",
     "@radix-ui/react-alert-dialog": "^1.1.15",
     "@radix-ui/react-avatar": "^1.1.10",

--- a/packages/core/templates/app/layout.tsx
+++ b/packages/core/templates/app/layout.tsx
@@ -20,7 +20,7 @@ import { Toaster } from "@nextsparkjs/core/components/ui/sonner"
 import { TranslationContextManager } from "@nextsparkjs/core/providers/TranslationContextManager"
 import { PluginService } from '@nextsparkjs/core/lib/services'
 import { getMetadataOrDefault } from '@nextsparkjs/core/lib/template-resolver'
-import { getDefaultThemeMode } from '@nextsparkjs/core/lib/theme/get-default-theme-mode'
+import { getThemeSettings } from '@nextsparkjs/core/lib/theme/get-default-theme-mode'
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -56,7 +56,7 @@ export default async function RootLayout({
 
   const locale = await getUserLocale()
   const messages = await getMessages({ locale })
-  const defaultTheme = await getDefaultThemeMode()
+  const { defaultMode, allowUserToggle } = await getThemeSettings()
 
   return (
     <html lang={locale} suppressHydrationWarning>
@@ -73,9 +73,11 @@ export default async function RootLayout({
         <NextIntlClientProvider messages={messages}>
           <NextThemeProvider
             attribute="class"
-            defaultTheme={defaultTheme}
-            // Only detect OS preference when theme configures defaultMode: 'system'
-            enableSystem={defaultTheme === 'system'}
+            defaultTheme={defaultMode}
+            // When allowUserToggle is false, force the theme and ignore localStorage/system
+            forcedTheme={!allowUserToggle ? defaultMode : undefined}
+            // Only detect OS preference when theme configures defaultMode: 'system' AND user can toggle
+            enableSystem={allowUserToggle && defaultMode === 'system'}
             disableTransitionOnChange
           >
             <CustomThemeProvider>


### PR DESCRIPTION
## Summary
- Add `getThemeSettings()` function that returns both `defaultMode` and `allowUserToggle`
- Support `forcedTheme` in RootLayout when `allowUserToggle: false` in app.config.ts
- Update `@nextsparkjs/ui` and `@nextsparkjs/testing` package versions

## Changes

### Theme Settings API
- New `getThemeSettings()` returns `{ defaultMode, allowUserToggle }`
- New `getUserThemePreference()` reads user preference from profile metadata
- Deprecated `getDefaultThemeMode()` in favor of `getThemeSettings()`

### Layout Updates
- Uses `forcedTheme` prop when `allowUserToggle` is false
- `enableSystem` only active when user can toggle AND defaultMode is 'system'

### Dependencies
- `@nextsparkjs/ui`: `workspace:*` → `^0.1.0-beta.2`
- `@nextsparkjs/testing`: `0.1.0-beta.53` → `^0.1.0-beta.75`

## Test plan
- [ ] Verify theme respects `defaultMode` from theme.config.ts
- [ ] Test with `allowUserToggle: false` - theme should be forced
- [ ] Test with `allowUserToggle: true` - user preference should be read
- [ ] Verify no regressions in existing theme behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)