### PR TITLE
fix(ai): add team context to AIHistoryService operations

### DIFF
--- a/plugins/ai/docs/02-features/03-ai-history.md
+++ b/plugins/ai/docs/02-features/03-ai-history.md
@@ -81,6 +81,7 @@ import { AIHistoryService } from '@/contents/plugins/ai/lib/ai-history-service'
 ```typescript
 const historyId = await AIHistoryService.startOperation({
   userId: 'user-id',
+  teamId: 'team-id',
   operation: 'generate',
   model: 'gpt-4o-mini',
   provider: 'openai',
@@ -133,6 +134,7 @@ await AIHistoryService.failOperation({
 ```typescript
 {
   userId: string              // Required
+  teamId: string              // Required - team context for the operation
   operation: AIOperation      // 'generate' | 'refine' | 'analyze' | 'chat' | 'completion' | 'other'
   model: string               // Model name (e.g., 'gpt-4o-mini')
   provider?: AIProvider       // 'openai' | 'anthropic' | 'ollama'
@@ -147,6 +149,7 @@ await AIHistoryService.failOperation({
 ```typescript
 const historyId = await AIHistoryService.startOperation({
   userId: session.user.id,
+  teamId: session.user.activeTeamId,
   operation: 'generate',
   model: 'llama3.2:3b',
   provider: 'ollama'
@@ -225,6 +228,7 @@ try {
 ```typescript
 const historyId = await AIHistoryService.startOperation({
   userId: 'user-id',
+  teamId: 'team-id',
   operation: 'analyze',
   model: 'claude-3-5-haiku-20241022',
   relatedEntityType: 'clients',
@@ -249,6 +253,7 @@ PATCH /api/v1/plugin/ai/ai-history/:id
 // Generate product description
 const historyId = await AIHistoryService.startOperation({
   userId: session.user.id,
+  teamId: session.user.activeTeamId,
   operation: 'generate',
   model: 'gpt-4o-mini',
   relatedEntityType: 'products',
@@ -265,6 +270,7 @@ const historyId = await AIHistoryService.startOperation({
 // Analyze client data
 const historyId = await AIHistoryService.startOperation({
   userId: session.user.id,
+  teamId: session.user.activeTeamId,
   operation: 'analyze',
   model: 'claude-3-5-sonnet-20241022',
   relatedEntityType: 'clients',
@@ -279,6 +285,7 @@ const historyId = await AIHistoryService.startOperation({
 // Audit article content
 const historyId = await AIHistoryService.startOperation({
   userId: session.user.id,
+  teamId: session.user.activeTeamId,
   operation: 'analyze',
   model: 'gpt-4o',
   relatedEntityType: 'articles',
@@ -384,6 +391,7 @@ export async function generateProductDescription(productId: string) {
   // 1. Start operation tracking
   const historyId = await AIHistoryService.startOperation({
     userId: session.user.id,
+    teamId: session.user.activeTeamId,
     operation: 'generate',
     model: 'gpt-4o-mini',
     provider: 'openai',

--- a/plugins/ai/docs/04-use-cases/01-content-generation.md
+++ b/plugins/ai/docs/04-use-cases/01-content-generation.md
@@ -336,6 +336,7 @@ export async function generateAndSaveDescription(productId: string) {
   // Start operation tracking
   const historyId = await AIHistoryService.startOperation({
     userId: session.user.id,
+    teamId: session.user.activeTeamId,
     operation: 'generate',
     model: 'gpt-4o-mini',
     provider: 'openai',

--- a/plugins/ai/lib/ai-history-service.ts
+++ b/plugins/ai/lib/ai-history-service.ts
@@ -20,6 +20,7 @@ export type AIStatus = 'pending' | 'processing' | 'completed' | 'failed'
 
 export interface StartOperationParams {
   userId: string
+  teamId: string // Required - team context for the operation
   operation: AIOperation
   model: string
   provider?: AIProvider
@@ -75,6 +76,7 @@ export class AIHistoryService {
   static async startOperation(params: StartOperationParams): Promise<string> {
     const {
       userId,
+      teamId,
       operation,
       model,
       provider = 'anthropic',
@@ -86,6 +88,7 @@ export class AIHistoryService {
       const result = await queryOne<{ id: string }>(
         `INSERT INTO "ai_history" (
           "userId",
+          "teamId",
           operation,
           model,
           provider,
@@ -93,9 +96,9 @@ export class AIHistoryService {
           "relatedEntityId",
           status,
           "createdAt"
-        ) VALUES ($1, $2, $3, $4, $5, $6, $7, now())
+        ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, now())
         RETURNING id`,
-        [userId, operation, model, provider, relatedEntityType || null, relatedEntityId || null, 'pending']
+        [userId, teamId, operation, model, provider, relatedEntityType || null, relatedEntityId || null, 'pending']
       )
 
       if (!result) {


### PR DESCRIPTION
## Summary
- Add `teamId` as required parameter in `StartOperationParams` interface
- Include `teamId` in `ai_history` table INSERT operation
- Ensures AI operations are properly scoped to team context

## Context
This change aligns with recent PRs adding team context across the codebase:
- #40 - EntityDetailWrapper fetch calls
- #38 - useEntityQuery hooks

## Test plan
- [ ] Verify AI operations include teamId in database records
- [ ] Check that callers of `startOperation` pass teamId parameter

🤖 Generated with [Claude Code](https://claude.com/claude-code)