### PR TITLE
refactor: deprecate agents.json and clean legacy ClickUp patterns

### DIFF
--- a/.claude/agents/api-tester.md
+++ b/.claude/agents/api-tester.md
@@ -70,14 +70,12 @@ curl -s http://localhost:5173/api/health || echo "Server not ready"
 ### 2. Read Test Credentials
 
 ```typescript
-// Read API keys from config
-await Read('.claude/config/agents.json')
-
-// Extract test credentials
+// Read test credentials from active theme's dev config
+// Located in: contents/themes/{activeTheme}/config/dev.config.ts → devKeyring
 const testCredentials = {
   superadmin: {
     email: 'superadmin@cypress.com',
-    password: 'configured_password', // From agents.json (testing.superadmin.password)
+    password: 'configured_password', // From theme dev.config → devKeyring
     apiKey: 'sk_test_...'
   },
   admin: {
@@ -264,7 +262,7 @@ await Read(`${sessionPath}/plan.md`)          // For expected endpoints
 await Read(`${sessionPath}/context.md`)       // For backend status
 await Read(`${sessionPath}/progress.md`)      // For current progress
 await Read(`${sessionPath}/tests.md`)         // For existing test documentation
-await Read('.claude/config/agents.json')        // For test credentials
+// Read test credentials from active theme's dev.config.ts → devKeyring
 ```
 
 ### Step 2: Execute Tests

--- a/.claude/agents/architecture-supervisor.md
+++ b/.claude/agents/architecture-supervisor.md
@@ -368,35 +368,6 @@ See: core/lib/entities/system-fields.ts
 - Phase 14-15: QA (manual + automation)
 - Phase 16-19: Finalization (review + unit tests + docs + demo)
 
-## ClickUp Configuration (MANDATORY REFERENCE)
-
-**BEFORE any ClickUp interaction, you MUST read the pre-configured ClickUp details:**
-
-All ClickUp connection details are pre-configured in `.claude/.claude/config/agents.json`. **NEVER search or fetch these values manually.** Always use the values from the configuration file:
-
-- **Workspace ID**: `tools.clickup.workspaceId`
-- **Space ID**: `tools.clickup.space.id`
-- **List ID**: `tools.clickup.defaultList.id`
-- **User**: `tools.clickup.user.name` / `tools.clickup.user.id`
-
-**Usage Pattern:**
-```typescript
-// ❌ NEVER DO THIS - Don't search for workspace/space/list
-const hierarchy = await clickup.getWorkspaceHierarchy()
-const spaces = await clickup.searchSpaces()
-
-// ✅ ALWAYS DO THIS - Use pre-configured values from .claude/config/agents.json
-// Read `.claude/.claude/config/agents.json` to get:
-// - Workspace ID: tools.clickup.workspaceId
-// - Space ID: tools.clickup.space.id
-// - List ID: tools.clickup.defaultList.id
-
-await clickup.updateTask(taskId, {
-  // Use task ID from notification, workspace pre-configured
-  description: updatedDescription
-})
-```
-
 ## Your Core Mission
 
 You are the guardian and visionary of the project's architectural integrity. Your primary responsibilities are:
@@ -1375,7 +1346,6 @@ Remember: Translate business requirements into actionable technical plans. Maint
 ## Context Files
 
 Always reference:
-- `.claude/.claude/config/agents.json` - For ClickUp configuration (Workspace ID, Space ID, List ID, credentials)
 - `.claude/skills/clickup-integration/templates/task.md` - For task template structure (Implementation Plan + QA Plan)
 - `.claude/skills/clickup-integration/mcp.md` - For ClickUp MCP usage guide
 - `.claude/config/workflow.md` - For complete development workflow and phase responsibilities

--- a/.claude/agents/backend-developer.md
+++ b/.claude/agents/backend-developer.md
@@ -80,30 +80,6 @@ At the start of task:execute, scope is documented in context.md showing allowed 
 
 **If backend-validator or api-tester FAIL:** They will call you back to fix issues before retrying.
 
-## ClickUp Configuration (MANDATORY REFERENCE)
-
-**BEFORE any ClickUp interaction, you MUST read the pre-configured ClickUp details:**
-
-All ClickUp connection details are pre-configured in `.claude/.claude/config/agents.json`. **NEVER search or fetch these values manually.** Always use the values from the configuration file:
-
-- **Workspace ID**: `tools.clickup.workspaceId`
-- **Space ID**: `tools.clickup.space.id`
-- **List ID**: `tools.clickup.defaultList.id`
-- **User**: `tools.clickup.user.name` / `tools.clickup.user.id`
-
-**Usage Pattern:**
-```typescript
-// ❌ NEVER DO THIS - Don't search for workspace/space/list
-const hierarchy = await clickup.getWorkspaceHierarchy()
-
-// ✅ ALWAYS DO THIS - Use pre-configured values from .claude/config/agents.json
-// Read .claude/config/agents.json to get Workspace ID, Space ID, List ID
-// Then interact with tasks directly
-
-await clickup.updateTaskStatus(taskId, "in progress")
-await clickup.addComment(taskId, "🚀 Starting backend development")
-```
-
 ## Entity Presets (USE AS REFERENCE)
 
 **When creating or modifying entities, use presets as reference:**
@@ -255,7 +231,8 @@ await Read('.rules/testing.md')     // For testing requirements
 await Read('.rules/planning.md')    // For complex tasks (3+ steps)
 
 // 2. Determine project context
-const isCore = await checkProjectContext()
+const context = await Read('.claude/config/context.json')
+const isCore = context.context === 'monorepo'
 
 // 3. Use TodoWrite for complex tasks
 if (task.stepsCount >= 3) {
@@ -720,8 +697,8 @@ ${sessionPath}/progress.md
 **After implementing each endpoint, you MUST test it:**
 
 ```bash
-# Use super admin API key from .claude/.claude/config/agents.json (testing.apiKey)
-API_KEY="<read from .claude/.claude/config/agents.json: testing.apiKey>"
+# Use super admin API key from active theme dev.config → devKeyring
+API_KEY="<from active theme dev.config → devKeyring>"
 
 # Test GET
 curl -X GET http://localhost:5173/api/v1/users/USER_ID \
@@ -1011,7 +988,6 @@ Do you approve this security addition?
 ## Context Files
 
 Always reference:
-- `.claude/.claude/config/agents.json` - For test credentials and API keys
 - `.claude/config/workflow.md` - For complete development workflow v4.0 (19 phases)
 - `${sessionPath}/plan.md` - For technical plan
 - `${sessionPath}/context.md` - For coordination context

--- a/.claude/agents/code-reviewer.md
+++ b/.claude/agents/code-reviewer.md
@@ -75,30 +75,6 @@ grep -rn "@/contents" core/ --include="*.ts" --include="*.tsx"
 **Pre-conditions:** qa-automation (Phase 15) MUST be PASSED
 **Post-conditions:** unit-test-writer (Phase 17) follows after my review
 
-## ClickUp Configuration (MANDATORY REFERENCE)
-
-**BEFORE any ClickUp interaction, you MUST read the pre-configured ClickUp details:**
-
-All ClickUp connection details are pre-configured in `.claude/.claude/config/agents.json`. **NEVER search or fetch these values manually.** Always use the values from the configuration file:
-
-- **Workspace ID**: `tools.clickup.workspaceId`
-- **Space ID**: `tools.clickup.space.id`
-- **List ID**: `tools.clickup.defaultList.id`
-- **User**: `tools.clickup.user.name` / `tools.clickup.user.id`
-
-**Usage Pattern:**
-```typescript
-// ❌ NEVER DO THIS - Don't search for workspace/space/list
-const hierarchy = await clickup.getWorkspaceHierarchy()
-
-// ✅ ALWAYS DO THIS - Use pre-configured values from .claude/config/agents.json
-// Read .claude/config/agents.json to get Workspace ID, Space ID, List ID
-// Then read task and add review comments
-
-const task = await clickup.getTaskById(taskId)
-await clickup.addComment(taskId, reviewMarkdown)
-```
-
 ## Core Responsibilities
 
 ### 1. Project Context Detection (CRITICAL FIRST STEP)
@@ -861,9 +837,7 @@ Structure your review as follows:
 - Performance acceptable
 - Project rules followed
 
-## Session-Based Workflow with ClickUp Integration (MANDATORY)
-
-**CRITICAL: Code Reviewer is one of the 3 agents that DOES write to ClickUp (PM, QA, Code Reviewer) - ONLY for review comments**
+## Session-Based Workflow (MANDATORY)
 
 ### When to Perform Code Review
 
@@ -1452,8 +1426,6 @@ export const ProfileForm = React.memo(({ user }: { user: User }) => {
 ## Context Files
 
 Always reference:
-- `.claude/.claude/config/agents.json` - For ClickUp configuration (Workspace ID, Space ID, List ID)
-- `.claude/skills/clickup-integration/mcp.md` - For ClickUp MCP usage guide (reading tasks, adding comments)
 - `.claude/config/workflow.md` - For complete development workflow (Phase 5: Code Review)
 - `.rules/` directory - For all project rules to validate against
 

--- a/.claude/agents/db-developer.md
+++ b/.claude/agents/db-developer.md
@@ -387,7 +387,7 @@ VALUES
 
   -- Super Admin (for Cypress tests) - uses different password
   ('55555555-5555-5555-5555-555555555555', 'Cypress Super Admin', 'superadmin@cypress.com', true,
-   -- This user may have a different password configured in agents.json
+   -- This user may have a different password configured in theme dev.config → devKeyring
    '3db9e98e2b4d3caca97fdf2783791cbc:34b293de615caf277a237773208858e960ea8aa10f1f5c5c309b632f192cac34d52ceafbd338385616f4929e4b1b6c055b67429c6722ffdb80b01d9bf4764866',
    NOW(), NOW())
 ON CONFLICT ("id") DO NOTHING;

--- a/.claude/agents/documentation-writer.md
+++ b/.claude/agents/documentation-writer.md
@@ -97,23 +97,6 @@ This will ensure you follow the correct patterns for:
 
 ---
 
-## ClickUp Configuration
-
-**CRITICAL**: Before starting work, read the ClickUp configuration:
-
-```typescript
-await Read('.claude/config/agents.json')
-```
-
-This file contains:
-- Pre-configured workspace ID
-- Team member IDs and names
-- ClickUp list IDs for different task types
-
-Use these IDs instead of looking them up each time.
-
----
-
 ## Parallel Execution with Task Tool
 
 You have access to the `Task` and `TaskOutput` tools for parallel execution. Use them wisely.
@@ -1099,13 +1082,7 @@ Before starting work, read these configuration files:
 await Read('core/docs/15-documentation-system/01-overview.md')
 await Read('core/docs/15-documentation-system/03-core-vs-theme-docs.md')
 
-// 2. ClickUp configuration (workspace ID, team members, list IDs)
-await Read('.claude/config/agents.json')
-
-// 3. ClickUp MCP tool documentation (how to use ClickUp tools)
-await Read('.claude/skills/clickup-integration/mcp.md')
-
-// 4. Session workflow guide (session file structure and patterns)
+// 2. Session workflow guide (session file structure and patterns)
 await Read('.claude/sessions/README.md')
 ```
 

--- a/.claude/agents/frontend-developer.md
+++ b/.claude/agents/frontend-developer.md
@@ -70,30 +70,6 @@ You are an elite Frontend Developer specializing in Next.js 15, TypeScript, Tail
 
 **If frontend-validator or functional-validator FAIL:** They will call you back to fix issues before retrying.
 
-## ClickUp Configuration (MANDATORY REFERENCE)
-
-**BEFORE any ClickUp interaction, you MUST read the pre-configured ClickUp details:**
-
-All ClickUp connection details are pre-configured in `.claude/.claude/config/agents.json`. **NEVER search or fetch these values manually.** Always use the values from the configuration file:
-
-- **Workspace ID**: `tools.clickup.workspaceId`
-- **Space ID**: `tools.clickup.space.id`
-- **List ID**: `tools.clickup.defaultList.id`
-- **User**: `tools.clickup.user.name` / `tools.clickup.user.id`
-
-**Usage Pattern:**
-```typescript
-// ❌ NEVER DO THIS - Don't search for workspace/space/list
-const hierarchy = await clickup.getWorkspaceHierarchy()
-
-// ✅ ALWAYS DO THIS - Use pre-configured values from .claude/config/agents.json
-// Read .claude/config/agents.json to get Workspace ID, Space ID, List ID
-// Then update task status and add comments directly with task ID
-
-await clickup.updateTaskStatus(taskId, "in progress")
-await clickup.addComment(taskId, "🚀 Starting frontend development")
-```
-
 ## Context Awareness
 
 **CRITICAL:** Before creating any components or files, read `.claude/config/context.json` to understand the environment.
@@ -1249,7 +1225,6 @@ Do you approve this addition or prefer I remove it?
 ## Context Files
 
 Always reference:
-- `.claude/.claude/config/agents.json` - For test credentials and configuration
 - `.claude/config/workflow.md` - For complete development workflow v4.0 (19 phases)
 - `${sessionPath}/plan.md` - For technical plan
 - `${sessionPath}/context.md` - For coordination context

--- a/.claude/commands/how-to/setup-claude-code.md
+++ b/.claude/commands/how-to/setup-claude-code.md
@@ -21,10 +21,9 @@ This is the **first step** when starting with NextSpark. Before you can use any 
 
 **What you'll configure:**
 1. `context.json` - Monorepo vs Consumer project type
-2. `workspace.json` - Your personal preferences and active user
+2. `workspace.json` - Your personal preferences, active user, and task manager config
 3. `team.json` - Team members and their platform IDs
 4. `github.json` - Git workflow conventions (branches, commits, PRs)
-5. `agents.json` - Credentials and API keys (sensitive)
 
 ---
 
@@ -60,12 +59,7 @@ This is the **first step** when starting with NextSpark. Before you can use any 
 │     - Set commit message patterns                              │
 │     - Create/update .claude/config/github.json                 │
 │     ↓                                                           │
-│  6. Step 5: Credentials Configuration                           │
-│     - ClickUp API key (if using)                               │
-│     - Test user credentials (for Cypress)                      │
-│     - Create/update .claude/config/agents.json                 │
-│     ↓                                                           │
-│  7. Validation                                                  │
+│  6. Validation                                                  │
 │     - Verify all config files exist                            │
 │     - Validate JSON syntax                                     │
 │     - Check required fields                                    │
@@ -85,7 +79,7 @@ This is the **first step** when starting with NextSpark. Before you can use any 
 
 ```
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-📚 STEP 1 OF 5: Project Context
+📚 STEP 1 OF 4: Project Context
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
 First, let's determine your project type.
@@ -123,7 +117,7 @@ What type of project is this?
 
 ```
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-📚 STEP 2 OF 5: Team Members
+📚 STEP 2 OF 4: Team Members
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
 Now let's configure your team. This enables:
@@ -206,7 +200,7 @@ Team Member #1:
 
 ```
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-📚 STEP 3 OF 5: Your Workspace
+📚 STEP 3 OF 4: Your Workspace
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
 This is YOUR personal workspace configuration.
@@ -219,11 +213,9 @@ Who are you? (Select from team members)
 [1] Pablo Capello
 [2] Other team member...
 
-What's your preferred language?
-
-[1] English
-[2] Spanish
-[3] Portuguese
+Preferred language: (use language already chosen in /how-to:start,
+or read from workspace.json preferences.language if available.
+Only ask if no language has been selected yet in this session.)
 
 Do you use a task manager?
 
@@ -271,7 +263,7 @@ Do you use a task manager?
 
 ```
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-📚 STEP 4 OF 5: Git Workflow
+📚 STEP 4 OF 4: Git Workflow
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
 Let's configure your git workflow conventions.
@@ -358,67 +350,6 @@ Commit message pattern?
 
 ---
 
-### Step 5: Credentials Configuration
-
-```
-━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-📚 STEP 5 OF 5: Credentials (Sensitive)
-━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-⚠️  IMPORTANT: This file contains sensitive data.
-    It's gitignored and should NEVER be committed.
-
-━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-Do you use ClickUp for task management?
-
-[1] Yes - I'll provide my API key
-[2] No - Skip ClickUp configuration
-
-Do you need test credentials for Cypress?
-
-[1] Yes - I'll provide superadmin email/password
-[2] No - I'll configure this later
-```
-
-**Create `.claude/config/agents.json`:**
-
-```json
-{
-  "project": {
-    "name": "My NextSpark App",
-    "isCore": false
-  },
-  "testing": {
-    "superadmin": {
-      "email": "superadmin@cypress.com",
-      "password": "Test1234"
-    },
-    "apiKey": "sk_test_..."
-  },
-  "tools": {
-    "clickup": {
-      "apiKey": "${CLICKUP_API_KEY}",
-      "workspaceId": "90132320273",
-      "space": {
-        "name": "My Space",
-        "id": "90139892186"
-      },
-      "defaultList": {
-        "name": "Backlog",
-        "id": "901300753108"
-      },
-      "user": {
-        "name": "Pablo Capello",
-        "id": "3020828"
-      }
-    }
-  }
-}
-```
-
----
-
 ## Validation
 
 After all steps are complete:
@@ -434,7 +365,6 @@ Validating your configuration...
 ✓ .claude/config/team.json        - Valid
 ✓ .claude/config/workspace.json   - Valid
 ✓ .claude/config/github.json      - Valid
-✓ .claude/config/agents.json      - Valid
 
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
@@ -445,8 +375,7 @@ Your configuration:
 ├── Active User: Pablo Capello
 ├── Language: Spanish
 ├── Task Manager: ClickUp (enabled)
-├── Git Flow: feature → develop → qa → main
-└── Credentials: Configured
+└── Git Flow: feature → develop → qa → main
 
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
@@ -465,9 +394,8 @@ What would you like to do next?
 |------|---------|---------|
 | `context.json` | Project type (monorepo/consumer) | Yes |
 | `team.json` | Team members and roles | Yes |
-| `workspace.json` | Personal preferences | No (per developer) |
+| `workspace.json` | Personal preferences + task manager config | No (per developer) |
 | `github.json` | Git workflow conventions | Yes |
-| `agents.json` | Credentials and API keys | No (gitignored) |
 
 ---
 

--- a/.claude/commands/how-to/start.md
+++ b/.claude/commands/how-to/start.md
@@ -32,24 +32,69 @@ This command presents an interactive menu of all available tutorials, organized 
 │  /how-to:start                                                   │
 ├─────────────────────────────────────────────────────────────────┤
 │                                                                 │
-│  1. Welcome & Introduction                                      │
-│     - Brief explanation of the how-to system                   │
+│  1. [MANDATORY] Language Selection                               │
+│     - Read workspace.json → preferences.language                │
+│     - Ask user preferred interaction language                   │
+│     - Suggest detected language as first (recommended) option   │
+│     - ALL subsequent interaction in chosen language             │
+│     ↓                                                           │
+│  2. Welcome & Introduction                                      │
+│     - Brief explanation of the how-to system (in user language) │
 │     - Show tutorial categories                                 │
 │     ↓                                                           │
-│  2. [MANDATORY] Ask user's learning goal                        │
+│  3. [MANDATORY] Ask user's learning goal                        │
 │     - "What would you like to learn?"                          │
 │     - Present categories as options                            │
 │     ↓                                                           │
-│  3. Show relevant tutorials                                     │
+│  4. Show relevant tutorials                                     │
 │     - List tutorials in selected category                      │
 │     - Suggest learning path if applicable                      │
 │     ↓                                                           │
-│  4. [MANDATORY] Launch selected tutorial                        │
+│  5. [MANDATORY] Launch selected tutorial                        │
 │     - Hand off to specific how-to command                      │
-│     - Preserve context for follow-up                           │
+│     - Preserve language context for follow-up                  │
 │                                                                 │
 └─────────────────────────────────────────────────────────────────┘
 ```
+
+### Step 1: Language Detection & Selection
+
+This is the **first interaction** before anything else.
+
+**Detection:**
+1. Read `.claude/config/workspace.json` → `preferences.language`
+2. Map the detected code to a language label
+
+**Language mapping:**
+| Code | Label |
+|------|-------|
+| `en` | English |
+| `es` | Español |
+| `it` | Italiano |
+| `fr` | Français |
+
+**Interaction:**
+- Use `AskUserQuestion` with the detected language as first option marked `(Recommended)`
+- Remaining options: the other 3 languages from the table above (excluding the detected one)
+- The user can also type a custom language via the "Other" open field
+
+**Example (detected `es`):**
+```
+┌─ Language / Idioma ──────────────────────────┐
+│                                               │
+│  [1] Español (Recommended)                    │
+│  [2] English                                  │
+│  [3] Italiano                                 │
+│  [4] Français                                 │
+│  [Other] Type your preferred language         │
+│                                               │
+└───────────────────────────────────────────────┘
+```
+
+**After selection:**
+- From this point forward, **ALL responses** must be in the chosen language
+- Internal documents (skills, how-to files) are read in their original language but Claude **always responds and explains in the user's chosen language**
+- This applies to the welcome message, categories, learning paths, tutorial content, and all follow-up interactions
 
 ---
 

--- a/.claude/config/workspace.json
+++ b/.claude/config/workspace.json
@@ -29,7 +29,7 @@
     "config": {
       "apiKey": "${CLICKUP_API_KEY}",
       "workspaceId": "",
-      "defaultSpace": "",
+      "defaultList": "",
       "useMcp": true,
       "mcpFallback": true
     }

--- a/.claude/config/workspace.schema.json
+++ b/.claude/config/workspace.schema.json
@@ -14,7 +14,7 @@
     "preferences": {
       "type": "object",
       "properties": {
-        "language": { "enum": ["es", "en", "pt"] },
+        "language": { "type": "string", "description": "User's preferred language (e.g., es, en, pt, fr, it, de)" },
         "defaultWorkflow": { "enum": ["quick", "standard", "complete"] },
         "autoCommit": { "type": "boolean" },
         "verboseOutput": { "type": "boolean" },
@@ -37,7 +37,16 @@
         "provider": { "enum": ["clickup", "jira", "notion", "asana", "linear", "custom"] },
         "syncWithSession": { "type": "boolean" },
         "autoUpdateStatus": { "type": "boolean" },
-        "config": { "type": "object" }
+        "config": {
+          "type": "object",
+          "properties": {
+            "apiKey": { "type": "string" },
+            "workspaceId": { "type": "string" },
+            "defaultList": { "type": "string" },
+            "useMcp": { "type": "boolean" },
+            "mcpFallback": { "type": "boolean" }
+          }
+        }
       }
     },
     "integrations": {


### PR DESCRIPTION
## Summary

- **Deprecate `agents.json`** — all config now lives in canonical sources (`workspace.json`, `context.json`, `team.json`, theme `dev.config`)
- **Remove ClickUp config blocks** from 5 non-PM agents (only `product-manager` interacts with external task managers)
- **Make `product-manager` task-manager-agnostic** — reads provider from `workspace.json → taskManager` instead of hardcoded ClickUp refs
- **Fix test credential references** — point to theme `dev.config → devKeyring` instead of `agents.json`
- **Update `workspace.schema.json`** — language field is now free-text `string` (no enum), added `defaultList` to `taskManager.config`
- **Remove Step 5** from `setup-claude-code.md` — renumbered to 4 steps

## Files Changed (13)

**Agents (9):** `api-tester`, `architecture-supervisor`, `backend-developer`, `code-reviewer`, `db-developer`, `documentation-writer`, `frontend-developer`, `product-manager`, `workflow-maintainer`

**Config (2):** `workspace.json`, `workspace.schema.json`

**Commands (2):** `setup-claude-code.md`, `start.md`

## Verification

- Zero `agents.json` references in `.claude/`
- Zero `tools.clickup` in non-PM agents
- Zero hardcoded ClickUp IDs
- All setup steps numbered "OF 4"

## Test plan

- [ ] Run `/how-to:setup-claude-code` from scratch — verify 4-step flow works
- [ ] Verify `product-manager` reads task manager config from `workspace.json`
- [ ] Verify no agent references `agents.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)