### PR TITLE
feat(workflow): add git worktree support for parallel development

### DIFF
--- a/.claude/commands/session/close.md
+++ b/.claude/commands/session/close.md
@@ -54,12 +54,24 @@ Closes the specified session.
 │     ↓                                                           │
 │  4. Worktree cleanup (if session used a worktree)               │
 │     - Check if worktree path exists in session metadata         │
-│     - Ask: "Remove worktree at <path>?"                         │
+│     - Check PR merge status:                                    │
+│       $ gh pr list --head <branch> --state merged               │
 │     │                                                           │
-│     ├─► YES: git worktree remove <path>                         │
-│     │        Delete branch if merged                            │
+│     ├─► PR MERGED: Auto-suggest removal                         │
+│     │   "PR merged! Removing worktree and branch..."            │
+│     │   $ git worktree remove <path>                            │
+│     │   $ git branch -d <branch>                                │
+│     │   (Still ask for confirmation before deleting)             │
 │     │                                                           │
-│     └─► NO: Keep worktree (user can remove later)               │
+│     ├─► PR OPEN: Ask what to do                                 │
+│     │   "PR still open. Remove worktree?"                       │
+│     │   [1] Remove worktree (keep branch)                       │
+│     │   [2] Keep worktree                                       │
+│     │                                                           │
+│     └─► NO PR: Ask with all options                             │
+│         [1] Remove worktree and delete branch                   │
+│         [2] Remove worktree but keep branch                     │
+│         [3] Keep worktree                                       │
 │     ↓                                                           │
 │  5. Archive?                                                    │
 │     [Yes, archive] [No, keep]                                   │
@@ -115,7 +127,46 @@ Archive session? [Yes/No]
 
 ## With Worktree
 
-If the session used a worktree:
+### PR Already Merged
+
+```
+🌳 WORKTREE CLEANUP
+
+This session used a worktree:
+  Path: G:/GitHub/nextspark/repo-add-phone-field
+  Branch: feature/add-phone-field
+
+✅ PR #42 was MERGED into main.
+
+Recommended: Remove worktree and clean up branch.
+
+$ git worktree remove ../repo-add-phone-field
+✓ Worktree removed
+
+$ git branch -d feature/add-phone-field
+✓ Branch deleted (was merged)
+
+$ git remote prune origin
+✓ Remote references cleaned
+```
+
+### PR Still Open
+
+```
+🌳 WORKTREE CLEANUP
+
+This session used a worktree:
+  Path: G:/GitHub/nextspark/repo-add-phone-field
+  Branch: feature/add-phone-field
+
+⏳ PR #42 is still OPEN (not merged yet).
+
+Options:
+[1] Remove worktree but keep branch (can re-create worktree later)
+[2] Keep worktree (continue working later)
+```
+
+### No PR Found
 
 ```
 🌳 WORKTREE CLEANUP
@@ -125,7 +176,7 @@ This session used a worktree:
   Branch: feature/add-phone-field
 
 Options:
-[1] Remove worktree and delete branch (if merged)
+[1] Remove worktree and delete branch
 [2] Remove worktree but keep branch
 [3] Keep worktree (remove later with: git worktree remove ../repo-add-phone-field)
 ```

--- a/.claude/commands/session/close.md
+++ b/.claude/commands/session/close.md
@@ -52,14 +52,23 @@ Closes the specified session.
 │     ↓                                                           │
 │  3. Execute session-close.sh                                    │
 │     ↓                                                           │
-│  4. Archive?                                                    │
+│  4. Worktree cleanup (if session used a worktree)               │
+│     - Check if worktree path exists in session metadata         │
+│     - Ask: "Remove worktree at <path>?"                         │
+│     │                                                           │
+│     ├─► YES: git worktree remove <path>                         │
+│     │        Delete branch if merged                            │
+│     │                                                           │
+│     └─► NO: Keep worktree (user can remove later)               │
+│     ↓                                                           │
+│  5. Archive?                                                    │
 │     [Yes, archive] [No, keep]                                   │
 │     ↓                                                           │
-│  5. Update task manager (if enabled)                            │
+│  6. Update task manager (if enabled)                            │
 │     - Post final comment                                        │
 │     - Change status to "done"                                   │
 │     ↓                                                           │
-│  6. Show summary                                                │
+│  7. Show summary                                                │
 │                                                                 │
 └─────────────────────────────────────────────────────────────────┘
 ```
@@ -100,6 +109,25 @@ All ACs completed: 4/4
 ✓ Session closed
 
 Archive session? [Yes/No]
+```
+
+---
+
+## With Worktree
+
+If the session used a worktree:
+
+```
+🌳 WORKTREE CLEANUP
+
+This session used a worktree:
+  Path: G:/GitHub/nextspark/repo-add-phone-field
+  Branch: feature/add-phone-field
+
+Options:
+[1] Remove worktree and delete branch (if merged)
+[2] Remove worktree but keep branch
+[3] Keep worktree (remove later with: git worktree remove ../repo-add-phone-field)
 ```
 
 ---

--- a/.claude/commands/session/start.md
+++ b/.claude/commands/session/start.md
@@ -109,8 +109,9 @@ Skips evaluation but still asks discovery questions for the selected workflow.
 │     │   ├── Testing?                                            │
 │     │   └── Documentation?                                      │
 │     │                                                           │
-│     ├── BLOCKS: 7 block-specific questions                      │
+│     ├── BLOCKS: 8 block-specific questions                      │
 │     │   ├── Task Manager?                                       │
+│     │   ├── Worktree? (parallel development)                    │
 │     │   ├── Block Type? (hero/features/cta/etc)                 │
 │     │   ├── Block Decision? (new/variant/modify)                │
 │     │   ├── Mock Source? (Stitch/UXPilot/Figma/Other)           │
@@ -118,8 +119,9 @@ Skips evaluation but still asks discovery questions for the selected workflow.
 │     │   ├── Testing?                                            │
 │     │   └── Documentation?                                      │
 │     │                                                           │
-│     ├── TASK: All 7 questions + conditional mock questions      │
+│     ├── TASK: All 8 questions + conditional mock questions      │
 │     │   ├── Task Manager?                                       │
+│     │   ├── Worktree? (parallel development)                    │
 │     │   ├── Database Policy?                                    │
 │     │   ├── Entity Type?                                        │
 │     │   ├── Blocks?                                             │
@@ -127,9 +129,19 @@ Skips evaluation but still asks discovery questions for the selected workflow.
 │     │   ├── Testing?                                            │
 │     │   └── Documentation?                                      │
 │     │                                                           │
-│     └── STORY: All 7 questions + conditional mock questions     │
+│     └── STORY: All 8 questions + conditional mock questions     │
 │     ↓                                                           │
 │  10. Collect discovery context                                  │
+│     ↓                                                           │
+│  PHASE B.5: WORKTREE SETUP (if worktree selected)               │
+│  ──────────────────────────────────────────────                 │
+│  9.5 If worktree = yes:                                         │
+│     ├── Create branch: feature/<session-slug>                   │
+│     ├── git worktree add <basePath>/repo-<slug> <branch>        │
+│     ├── Copy .env from main repo                                │
+│     ├── Run pnpm install (if autoInstall = true)                │
+│     ├── Store worktree path in session metadata                 │
+│     └── Show: "Worktree ready at <path>"                        │
 │     ↓                                                           │
 │  PHASE C: MOCK UPLOAD PAUSE (if mock selected)                  │
 │  ──────────────────────────────────────────────                 │
@@ -211,6 +223,16 @@ I need some context before we begin. Please answer:
 
 ─────────────────────────────────────────
 
+1b. WORKTREE
+   Work in a separate worktree? (for parallel development)
+
+   [1] No, work in current directory
+   [2] Yes, create new worktree
+
+> 1
+
+─────────────────────────────────────────
+
 2. DATABASE POLICY
    How should the database be handled?
 
@@ -281,6 +303,7 @@ I need some context before we begin. Please answer:
 
 Context collected:
 ├── Task Manager: ClickUp (abc123)
+├── Worktree: No (current directory)
 ├── Database: No changes
 ├── Entity: Modify users
 ├── Blocks: None
@@ -340,6 +363,7 @@ Continue with these precautions? [Yes/No]
 | Question | TWEAK | BLOCKS | TASK | STORY |
 |----------|:-----:|:------:|:----:|:-----:|
 | 1. Task Manager | ✓ | ✓ | ✓ | ✓ |
+| 1b. Worktree | - | ✓ | ✓ | ✓ |
 | 2. Database Policy | - | - | ✓ | ✓ |
 | 3. Entity Type | - | - | ✓ | ✓ |
 | 4. Blocks | - | ✓* | ✓ | ✓ |
@@ -363,6 +387,19 @@ Continue with these precautions? [Yes/No]
    - Yes, Jira (request task_id)
    - Yes, Linear (request task_id)
    - Yes, Asana (request task_id)
+
+1b. WORKTREE (TASK, STORY, BLOCKS only)
+   - Only shown if worktrees.enabled = true in workspace.json
+   - Useful for parallel feature development without switching branches
+   - No, work in current directory
+   - Yes, create new worktree
+     IF YES:
+     ├── Creates branch: feature/<session-slug> (or uses existing branch)
+     ├── Creates worktree at: <basePath>/repo-<session-slug>
+     ├── Runs pnpm install (if autoInstall = true)
+     └── All session work happens in the worktree directory
+   - NOTE: The worktree path is stored in session metadata
+     for cleanup on /session:close
 
 2. DATABASE POLICY
    - No database changes needed
@@ -437,6 +474,63 @@ During discovery, if user answers suggest more complexity:
 | `--force-complete` | Force STORY without evaluation |
 | `--no-risk-check` | Skip risk evaluation |
 | `--task <id>` | Link with existing task |
+
+---
+
+## Worktree Setup (when selected)
+
+When the user selects "Yes, create new worktree":
+
+```
+🌳 WORKTREE SETUP
+
+Creating worktree for parallel development...
+
+Branch: feature/add-phone-field
+Path: G:/GitHub/nextspark/repo-add-phone-field
+
+─────────────────────────────────────────
+
+$ git worktree add ../repo-add-phone-field -b feature/add-phone-field
+Preparing worktree (new branch 'feature/add-phone-field')
+HEAD is now at 49db548 ...
+
+$ cp .env ../repo-add-phone-field/.env
+✓ Environment copied
+
+$ cd ../repo-add-phone-field && pnpm install
+✓ Dependencies installed
+
+─────────────────────────────────────────
+
+✓ Worktree ready!
+
+Working directory: G:/GitHub/nextspark/repo-add-phone-field
+Branch: feature/add-phone-field
+
+⚠️ IMPORTANT: Open a new Claude Code terminal in the
+worktree directory to work on this feature:
+
+  cd G:/GitHub/nextspark/repo-add-phone-field
+
+All session files and work will happen there.
+To see all worktrees: git worktree list
+```
+
+### Worktree Commands
+
+```bash
+# Execute these from the MAIN repo (not the worktree):
+
+# List all active worktrees
+git worktree list
+
+# Remove a worktree after merging
+git worktree remove ../repo-add-phone-field
+
+# Prune stale worktree references
+git worktree prune
+```
 
 ---
 

--- a/.claude/commands/session/start.md
+++ b/.claude/commands/session/start.md
@@ -66,6 +66,18 @@ Skips evaluation but still asks discovery questions for the selected workflow.
 │  /session:start                                                  │
 ├─────────────────────────────────────────────────────────────────┤
 │                                                                 │
+│  PHASE 0: WORKTREE HEALTH CHECK (if worktrees.enabled)           │
+│  ──────────────────────────────────────────────                 │
+│  0. Scan for stale worktrees:                                   │
+│     $ git worktree list                                         │
+│     For each worktree (excluding main repo):                    │
+│       $ gh pr list --head <branch> --state merged --json number │
+│       IF PR merged AND worktree still exists:                   │
+│         → Warn: "Worktree <path> has merged PR #N. Remove?"     │
+│         → If yes: git worktree remove <path>                    │
+│                   git branch -d <branch>                        │
+│     Also run: git worktree prune (clean stale refs)             │
+│     ↓                                                           │
 │  PHASE A: EVALUATION                                            │
 │  ───────────────────                                            │
 │  1. Read user description                                       │

--- a/.claude/config/workspace.json
+++ b/.claude/config/workspace.json
@@ -35,6 +35,13 @@
     }
   },
 
+  "worktrees": {
+    "enabled": true,
+    "basePath": "..",
+    "autoInstall": true,
+    "cleanupOnClose": true
+  },
+
   "integrations": {
     "github": {
       "enabled": true

--- a/.claude/config/workspace.schema.json
+++ b/.claude/config/workspace.schema.json
@@ -49,6 +49,16 @@
         }
       }
     },
+    "worktrees": {
+      "type": "object",
+      "description": "Git worktree configuration for parallel feature development",
+      "properties": {
+        "enabled": { "type": "boolean", "description": "Show worktree question in session:start" },
+        "basePath": { "type": "string", "description": "Base directory for worktrees (relative to repo parent). Default: sibling to repo" },
+        "autoInstall": { "type": "boolean", "description": "Automatically run pnpm install in new worktrees" },
+        "cleanupOnClose": { "type": "boolean", "description": "Ask to remove worktree on session:close" }
+      }
+    },
     "integrations": {
       "type": "object",
       "properties": {


### PR DESCRIPTION
## Summary
- Add git worktree support to `/session:start` as discovery question Q1b (for TASK/STORY/BLOCKS workflows)
- When selected, automatically creates worktree with feature branch, copies `.env`, and runs `pnpm install`
- Add worktree cleanup step to `/session:close` with 3 options (remove+delete branch, remove only, keep)
- Add `worktrees` configuration section to `workspace.json` and `workspace.schema.json`

## Test plan
- [ ] Run `/session:start` with a TASK workflow and verify worktree question appears after Task Manager
- [ ] Select "Yes, create worktree" and verify branch + worktree are created correctly
- [ ] Verify `git worktree list` shows the new worktree
- [ ] Run `/session:close` and verify worktree cleanup options appear
- [ ] Set `worktrees.enabled: false` in workspace.json and verify question is skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)