### PR TITLE
feat(walkme): guided tour and onboarding plugin

### DIFF
--- a/plugins/walkme/.env.example
+++ b/plugins/walkme/.env.example
@@ -1,0 +1,23 @@
+# ============================================
+# WALKME PLUGIN CONFIGURATION
+# ============================================
+# Copy this file to .env
+# Priority: Plugin .env > Root .env > Defaults
+
+# Enable/disable the plugin
+WALKME_ENABLED=true
+
+# Debug mode (logs extra info to console)
+WALKME_DEBUG=false
+
+# Auto-start tours on first visit
+WALKME_AUTO_START=true
+
+# Delay before starting auto tours (ms)
+WALKME_AUTO_START_DELAY=1000
+
+# Persist state in localStorage
+WALKME_PERSIST_STATE=true
+
+# Analytics integration (emit events)
+WALKME_ANALYTICS_ENABLED=false

--- a/plugins/walkme/.gitignore
+++ b/plugins/walkme/.gitignore
@@ -1,0 +1,22 @@
+# Environment variables with sensitive data
+.env
+.env.local
+.env.development.local
+.env.test.local
+.env.production.local
+
+# Plugin-specific ignores
+dist/
+*.log
+node_modules/
+.turbo/
+
+# IDE files
+.vscode/
+.idea/
+*.swp
+*.swo
+
+# OS files
+.DS_Store
+Thumbs.db

--- a/plugins/walkme/README.md
+++ b/plugins/walkme/README.md
@@ -1,0 +1,596 @@
+# @nextsparkjs/plugin-walkme
+
+Guided tours and onboarding system for NextSpark applications. Supports declarative tour definitions, multiple step types (tooltip, modal, spotlight, beacon), cross-page navigation, conditional triggers, localStorage persistence, full keyboard accessibility, and i18n.
+
+## Installation
+
+The plugin is available as an npm package or can be copied directly into your project.
+
+### npm (recommended)
+
+```bash
+pnpm add @nextsparkjs/plugin-walkme
+```
+
+### Manual
+
+Copy the `plugins/walkme/` directory to `contents/plugins/walkme/` in your NextSpark project.
+
+### Register the plugin
+
+Add `'walkme'` to your theme configuration:
+
+```typescript
+// contents/themes/<your-theme>/config/theme.config.ts
+export const themeConfig: ThemeConfig = {
+  plugins: ['walkme'],
+}
+```
+
+Rebuild the registry:
+
+```bash
+node core/scripts/build/registry.mjs
+```
+
+## Quick Start
+
+### 1. Define a tour
+
+```typescript
+import type { Tour } from '@nextsparkjs/plugin-walkme/types/walkme.types'
+
+const onboardingTour: Tour = {
+  id: 'getting-started',
+  name: 'Getting Started',
+  trigger: { type: 'onFirstVisit', delay: 1000 },
+  steps: [
+    {
+      id: 'welcome',
+      type: 'modal',
+      title: 'Welcome!',
+      content: 'Let us show you around the application.',
+      actions: ['next', 'skip'],
+    },
+    {
+      id: 'sidebar',
+      type: 'tooltip',
+      target: '[data-cy="sidebar-nav"]',
+      title: 'Navigation',
+      content: 'Use the sidebar to navigate between sections.',
+      position: 'right',
+      actions: ['next', 'prev', 'skip'],
+    },
+    {
+      id: 'create',
+      type: 'spotlight',
+      target: '[data-cy="create-button"]',
+      title: 'Create New Item',
+      content: 'Click here to create your first item.',
+      actions: ['complete', 'prev'],
+    },
+  ],
+}
+```
+
+### 2. Wrap your app with the provider
+
+```tsx
+import { WalkmeProvider } from '@nextsparkjs/plugin-walkme/components/WalkmeProvider'
+
+export default function Layout({ children }: { children: React.ReactNode }) {
+  return (
+    <WalkmeProvider tours={[onboardingTour]} autoStart>
+      {children}
+    </WalkmeProvider>
+  )
+}
+```
+
+### 3. (Optional) Control tours programmatically
+
+```tsx
+import { useWalkme } from '@nextsparkjs/plugin-walkme/hooks/useWalkme'
+
+function HelpButton() {
+  const { startTour, isActive } = useWalkme()
+
+  return (
+    <button onClick={() => startTour('getting-started')} disabled={isActive}>
+      Start Tour
+    </button>
+  )
+}
+```
+
+## Configuration
+
+### Tour
+
+| Property | Type | Required | Description |
+|---|---|---|---|
+| `id` | `string` | Yes | Unique identifier |
+| `name` | `string` | Yes | Human-readable name |
+| `description` | `string` | No | Tour description |
+| `trigger` | `TourTrigger` | Yes | When and how the tour activates |
+| `conditions` | `TourConditions` | No | Conditions that must be met to show the tour |
+| `steps` | `TourStep[]` | Yes | Ordered list of steps (minimum 1) |
+| `onComplete` | `() => void` | No | Callback on tour completion |
+| `onSkip` | `() => void` | No | Callback on tour skip |
+| `priority` | `number` | No | Auto-trigger ordering (lower = higher priority) |
+
+### TourStep
+
+| Property | Type | Required | Description |
+|---|---|---|---|
+| `id` | `string` | Yes | Unique step identifier |
+| `type` | `StepType` | Yes | `'tooltip'` \| `'modal'` \| `'spotlight'` \| `'beacon'` \| `'floating'` |
+| `title` | `string` | Yes | Step title |
+| `content` | `string` | Yes | Step body text |
+| `target` | `string` | Conditional | CSS selector or `data-walkme-target` value. Required for tooltip, spotlight, beacon |
+| `route` | `string` | No | Route path for cross-page steps |
+| `position` | `StepPosition` | No | `'top'` \| `'bottom'` \| `'left'` \| `'right'` \| `'auto'`. Default: `'auto'` |
+| `actions` | `StepAction[]` | Yes | Available actions: `'next'`, `'prev'`, `'skip'`, `'complete'`, `'close'` |
+| `delay` | `number` | No | Delay in ms before showing |
+| `autoAdvance` | `number` | No | Auto-advance after this many ms |
+| `beforeShow` | `() => void` | No | Callback before the step renders |
+| `afterShow` | `() => void` | No | Callback after the step renders |
+
+### Step Types
+
+- **`modal`** - Centered overlay modal. No target element required. Use for welcome screens and informational messages.
+- **`tooltip`** - Anchored tooltip positioned next to a target element. Requires `target`.
+- **`spotlight`** - Overlay with a cutout around the target element plus a tooltip. Requires `target`.
+- **`beacon`** - Pulsing indicator on a target element that expands on click. Requires `target`.
+- **`floating`** - Same as modal. Alias for centered content without a target.
+
+### TourTrigger
+
+| Property | Type | Required | Description |
+|---|---|---|---|
+| `type` | `TriggerType` | Yes | `'onFirstVisit'` \| `'onRouteEnter'` \| `'onEvent'` \| `'manual'` \| `'scheduled'` |
+| `delay` | `number` | No | Delay in ms before activating |
+| `route` | `string` | No | Route pattern for `onRouteEnter` (supports `*` and `**` wildcards) |
+| `event` | `string` | No | Event name for `onEvent` trigger |
+| `afterVisits` | `number` | No | Activate after N visits (for `scheduled`) |
+| `afterDays` | `number` | No | Activate after N days since first visit (for `scheduled`) |
+
+**Trigger types:**
+
+- `onFirstVisit` - Fires on the user's first page visit (visitCount === 1).
+- `onRouteEnter` - Fires when the user navigates to a matching route. Supports exact matches (`/dashboard`), wildcard (`/admin/*`), and glob (`/docs/**`).
+- `onEvent` - Fires when a custom event is emitted via `emitEvent()`.
+- `manual` - Never auto-triggers. Start programmatically with `startTour(tourId)`.
+- `scheduled` - Fires after a number of visits (`afterVisits`) or days since first visit (`afterDays`).
+
+### TourConditions
+
+All conditions use AND logic. Every specified condition must pass.
+
+| Property | Type | Description |
+|---|---|---|
+| `userRole` | `string[]` | User must have one of these roles |
+| `featureFlags` | `string[]` | All specified flags must be active |
+| `completedTours` | `string[]` | All specified tours must be completed first |
+| `notCompletedTours` | `string[]` | None of these tours should be completed |
+| `custom` | `(ctx: ConditionContext) => boolean` | Custom condition function |
+
+## WalkmeProvider Props
+
+| Prop | Type | Default | Description |
+|---|---|---|---|
+| `tours` | `Tour[]` | Required | Array of tour definitions (validated with Zod at runtime) |
+| `children` | `ReactNode` | Required | Application content |
+| `debug` | `boolean` | `false` | Enable debug logging to console |
+| `autoStart` | `boolean` | `true` | Auto-start eligible tours based on triggers |
+| `autoStartDelay` | `number` | `1000` | Default delay before auto-starting tours (ms) |
+| `persistState` | `boolean` | `true` | Persist tour state in localStorage |
+| `onTourStart` | `(event: TourEvent) => void` | - | Callback when a tour starts |
+| `onTourComplete` | `(event: TourEvent) => void` | - | Callback when a tour completes |
+| `onTourSkip` | `(event: TourEvent) => void` | - | Callback when a tour is skipped |
+| `onStepChange` | `(event: TourEvent) => void` | - | Callback when the active step changes |
+| `conditionContext` | `Partial<ConditionContext>` | - | External context for condition evaluation (userRole, featureFlags) |
+
+## Hooks
+
+### `useWalkme()`
+
+Main hook for controlling tours. Must be used within a `<WalkmeProvider>`.
+
+```tsx
+const {
+  // Tour control
+  startTour,      // (tourId: string) => void
+  pauseTour,      // () => void
+  resumeTour,     // () => void
+  skipTour,       // () => void
+  completeTour,   // () => void
+  resetTour,      // (tourId: string) => void
+  resetAllTours,  // () => void
+
+  // Step navigation
+  nextStep,       // () => void
+  prevStep,       // () => void
+  goToStep,       // (stepIndex: number) => void
+
+  // State
+  isActive,       // boolean - whether any tour is active
+  activeTourId,   // string | null
+  currentStepIndex, // number
+
+  // Queries
+  getActiveTour,  // () => Tour | null
+  getActiveStep,  // () => TourStep | null
+  isTourCompleted, // (tourId: string) => boolean
+  isTourActive,   // (tourId: string) => boolean
+
+  // Events
+  emitEvent,      // (eventName: string) => void
+} = useWalkme()
+```
+
+### `useTour(tourId)`
+
+Hook for tracking the state of a specific tour.
+
+```tsx
+const {
+  tour,           // Tour | null - full tour definition
+  isActive,       // boolean
+  isCompleted,    // boolean
+  isSkipped,      // boolean
+  currentStep,    // number (-1 if not active)
+  totalSteps,     // number
+  progress,       // number (0-100)
+  start,          // () => void - start this tour
+  reset,          // () => void - reset this tour
+} = useTour('getting-started')
+```
+
+### `useTourProgress()`
+
+Hook for tracking global completion progress across all tours.
+
+```tsx
+const {
+  completedTours,   // number
+  totalTours,       // number
+  percentage,       // number (0-100)
+  completedTourIds, // string[]
+  skippedTourIds,   // string[]
+  remainingTours,   // number
+} = useTourProgress()
+```
+
+## Examples
+
+### Single-Page Tour
+
+A basic onboarding flow on one page:
+
+```typescript
+const basicTour: Tour = {
+  id: 'getting-started',
+  name: 'Getting Started',
+  trigger: { type: 'onFirstVisit', delay: 1000 },
+  steps: [
+    {
+      id: 'welcome',
+      type: 'modal',
+      title: 'Welcome!',
+      content: 'Let us show you around.',
+      actions: ['next', 'skip'],
+    },
+    {
+      id: 'sidebar',
+      type: 'tooltip',
+      target: '[data-cy="sidebar-nav"]',
+      title: 'Navigation',
+      content: 'Use the sidebar to navigate.',
+      position: 'right',
+      actions: ['next', 'prev', 'skip'],
+    },
+    {
+      id: 'create',
+      type: 'spotlight',
+      target: '[data-cy="create-button"]',
+      title: 'Create Item',
+      content: 'Click here to create your first item.',
+      actions: ['complete', 'prev'],
+    },
+  ],
+}
+```
+
+### Cross-Page Tour
+
+Navigate users between pages during a tour:
+
+```typescript
+const crossPageTour: Tour = {
+  id: 'explore-app',
+  name: 'Explore the App',
+  trigger: { type: 'manual' },
+  conditions: { completedTours: ['getting-started'] },
+  steps: [
+    {
+      id: 'dashboard',
+      type: 'tooltip',
+      target: '[data-cy="dashboard-stats"]',
+      title: 'Your Stats',
+      content: 'Key metrics at a glance.',
+      position: 'bottom',
+      route: '/dashboard',
+      actions: ['next', 'skip'],
+    },
+    {
+      id: 'profile',
+      type: 'spotlight',
+      target: '[data-cy="profile-form"]',
+      title: 'Your Profile',
+      content: 'Complete your profile.',
+      route: '/settings/profile',
+      actions: ['complete', 'prev'],
+    },
+  ],
+}
+```
+
+When the tour reaches a step with a `route` that differs from the current page, the provider automatically navigates using `router.push()` and waits for the target element to appear.
+
+### Conditional Tour
+
+Show tours only to specific user roles or when feature flags are active:
+
+```typescript
+const adminTour: Tour = {
+  id: 'admin-features',
+  name: 'Admin Features',
+  priority: 10,
+  trigger: { type: 'onRouteEnter', route: '/admin/*', delay: 500 },
+  conditions: {
+    userRole: ['admin', 'superadmin'],
+    completedTours: ['getting-started'],
+    featureFlags: ['admin-panel-v2'],
+  },
+  steps: [
+    {
+      id: 'admin-welcome',
+      type: 'modal',
+      title: 'Admin Dashboard',
+      content: 'Here are the key admin features.',
+      actions: ['next', 'skip'],
+    },
+    // ...more steps
+  ],
+}
+```
+
+Pass the user context to the provider:
+
+```tsx
+<WalkmeProvider
+  tours={[adminTour]}
+  conditionContext={{
+    userRole: currentUser.role,
+    featureFlags: activeFlags,
+  }}
+>
+  <App />
+</WalkmeProvider>
+```
+
+### Programmatic Tour Control
+
+Start tours on demand and track completion:
+
+```tsx
+function OnboardingDashboard() {
+  const { startTour } = useWalkme()
+  const { completedTours, totalTours, percentage } = useTourProgress()
+  const intro = useTour('getting-started')
+
+  return (
+    <div>
+      <h2>Onboarding Progress: {percentage}%</h2>
+      <p>{completedTours} of {totalTours} tours completed</p>
+
+      {!intro.isCompleted && (
+        <button onClick={intro.start}>Start Getting Started Tour</button>
+      )}
+
+      <button onClick={() => startTour('advanced-features')}>
+        Show Advanced Features
+      </button>
+    </div>
+  )
+}
+```
+
+### Analytics Integration
+
+Track tour events for analytics:
+
+```tsx
+<WalkmeProvider
+  tours={tours}
+  onTourStart={(event) => {
+    analytics.track('tour_started', {
+      tourId: event.tourId,
+      tourName: event.tourName,
+    })
+  }}
+  onTourComplete={(event) => {
+    analytics.track('tour_completed', {
+      tourId: event.tourId,
+      totalSteps: event.totalSteps,
+    })
+  }}
+  onTourSkip={(event) => {
+    analytics.track('tour_skipped', {
+      tourId: event.tourId,
+      stepIndex: event.stepIndex,
+    })
+  }}
+  onStepChange={(event) => {
+    analytics.track('step_changed', {
+      tourId: event.tourId,
+      stepId: event.stepId,
+      stepIndex: event.stepIndex,
+    })
+  }}
+>
+```
+
+## Customization
+
+### Element Targeting
+
+Steps can target elements using:
+
+1. **CSS selectors** - `#my-id`, `.my-class`, `[data-cy="value"]`
+2. **data-walkme-target** - Add `data-walkme-target="name"` to any element, then reference as `target: "name"` (plain string without special CSS chars)
+3. **data-cy** - Standard test selectors: `target: '[data-cy="create-button"]'`
+
+If the target element is not found within 5 seconds, the step renders without an anchor and a warning is logged in debug mode.
+
+### Internationalization
+
+The plugin ships with English and Spanish translations under `plugins/walkme/messages/`. To add more languages, create a JSON file following the same structure:
+
+```json
+{
+  "walkme": {
+    "next": "Next",
+    "prev": "Previous",
+    "skip": "Skip tour",
+    "complete": "Complete",
+    "close": "Close",
+    "progress": "Step {current} of {total}",
+    "tourAvailable": "Tour available",
+    "beaconLabel": "Click to start guided tour",
+    "modalTitle": "Guided Tour",
+    "tooltipLabel": "Tour step",
+    "spotlightLabel": "Highlighted element",
+    "keyboardHint": "Press Arrow Right for next step, Escape to skip",
+    "tourCompleted": "Tour completed!",
+    "tourSkipped": "Tour skipped",
+    "errorTargetNotFound": "Element not found, skipping step",
+    "resumeTour": "Resume tour",
+    "restartTour": "Restart tour"
+  }
+}
+```
+
+### Keyboard Navigation
+
+When a tour is active:
+
+| Key | Action |
+|---|---|
+| Arrow Right | Next step |
+| Arrow Left | Previous step |
+| Escape | Skip tour |
+| Tab | Cycle focus within modals (focus trap) |
+
+### Accessibility
+
+- All interactive elements have ARIA labels and roles
+- Focus is trapped within modals
+- Focus is restored to the previously focused element when a tour ends
+- Progress bar uses `role="progressbar"` with `aria-valuenow`/`aria-valuemin`/`aria-valuemax`
+- Keyboard navigation is fully supported
+
+## Environment Variables
+
+| Variable | Default | Description |
+|---|---|---|
+| `WALKME_ENABLED` | `true` | Enable/disable the plugin |
+| `WALKME_DEBUG` | `false` | Debug mode |
+| `WALKME_AUTO_START` | `true` | Auto-start tours on first visit |
+| `WALKME_AUTO_START_DELAY` | `1000` | Delay before auto-starting (ms) |
+| `WALKME_PERSIST_STATE` | `true` | Persist state in localStorage |
+| `WALKME_ANALYTICS_ENABLED` | `false` | Enable analytics event emission |
+
+## Troubleshooting
+
+### Tour does not start automatically
+
+1. Check that `autoStart` is `true` on the provider (default).
+2. Verify the trigger type matches the situation (e.g., `onFirstVisit` only fires when `visitCount === 1`).
+3. Check that all conditions are met (role, feature flags, completed tours).
+4. Open debug mode (`debug={true}`) to see console logs.
+5. If using `persistState`, the tour may already be marked as completed or skipped in localStorage. Call `resetTour(tourId)` or clear `walkme-state` from localStorage.
+
+### Target element not found
+
+1. Ensure the target selector is correct and the element exists in the DOM.
+2. For dynamically rendered elements, the plugin waits up to 5 seconds using MutationObserver + polling.
+3. Use `data-walkme-target="name"` for elements that are hard to select with CSS.
+4. Enable debug mode to see warnings about missing targets.
+
+### Cross-page navigation not working
+
+1. Verify the `route` property on each step matches the actual path.
+2. The provider uses `router.push()` from `next/navigation`. Ensure you are using the App Router.
+3. If navigation fails, the step is automatically skipped and the tour advances.
+
+### State not persisting
+
+1. Check that `persistState` is `true` (default).
+2. Verify localStorage is available (not in private browsing mode or incognito with storage disabled).
+3. The state is stored under the key `walkme-state` in localStorage.
+
+## File Structure
+
+```
+plugins/walkme/
+  plugin.config.ts          # Plugin configuration
+  package.json              # Dependencies and metadata
+  .env.example              # Environment variable template
+  types/
+    walkme.types.ts         # All TypeScript type definitions
+  lib/
+    core.ts                 # Pure-function state machine (reducer + helpers)
+    validation.ts           # Zod schemas for tour config validation
+    storage.ts              # localStorage persistence adapter
+    targeting.ts            # DOM element targeting (CSS, data-walkme, data-cy)
+    positioning.ts          # @floating-ui/react wrapper for smart positioning
+    triggers.ts             # Tour trigger evaluation
+    conditions.ts           # Tour condition evaluation (AND logic)
+    plugin-env.ts           # Environment variable loader
+  hooks/
+    useWalkme.ts            # Main public hook (tour control + navigation)
+    useTour.ts              # Per-tour state hook
+    useTourProgress.ts      # Global completion progress hook
+    useTourState.ts         # Internal: state machine + localStorage sync
+  providers/
+    walkme-context.ts       # React Context definition
+  components/
+    WalkmeProvider.tsx      # Main provider (state, triggers, rendering)
+    WalkmeOverlay.tsx       # Semi-transparent backdrop overlay
+    WalkmeTooltip.tsx       # Positioned tooltip step
+    WalkmeModal.tsx         # Centered modal step with focus trap
+    WalkmeSpotlight.tsx     # Overlay with cutout + tooltip
+    WalkmeBeacon.tsx        # Pulsing indicator
+    WalkmeProgress.tsx      # Progress bar
+    WalkmeControls.tsx      # Navigation buttons (Next/Prev/Skip/Complete)
+  messages/
+    en.json                 # English translations
+    es.json                 # Spanish translations
+  examples/
+    basic-tour.ts           # Single-page tour example
+    cross-window-tour.ts    # Multi-page tour example
+    conditional-tour.ts     # Role-based conditional tour example
+  tests/
+    setup.ts                # Jest test setup
+    tsconfig.json           # Test-specific TypeScript config
+    lib/                    # Unit tests for all lib modules (165 tests)
+  jest.config.cjs           # Jest configuration
+```
+
+## Dependencies
+
+- **`@floating-ui/react`** ^0.27.0 - Smart positioning for tooltips and popovers
+
+Peer dependencies (provided by the host project): `react`, `react-dom`, `next`, `zod`, `next-intl`, `lucide-react`, `class-variance-authority`, `clsx`, `tailwind-merge`.

--- a/plugins/walkme/README.md
+++ b/plugins/walkme/README.md
@@ -482,6 +482,35 @@ The plugin ships with English and Spanish translations under `plugins/walkme/mes
 }
 ```
 
+### CSS Variables (Theming)
+
+All walkme components use CSS custom properties for styling. Override them in your global CSS or scoped styles:
+
+```css
+:root {
+  --walkme-bg: #ffffff;
+  --walkme-text: #111827;
+  --walkme-text-muted: #6b7280;
+  --walkme-primary: #3b82f6;
+  --walkme-border: #e5e7eb;
+  --walkme-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -2px rgba(0, 0, 0, 0.1);
+  --walkme-beacon-color: #3b82f6;
+  --walkme-overlay-color: rgba(0, 0, 0, 0.5);
+}
+
+/* Dark mode */
+.dark {
+  --walkme-bg: #1f2937;
+  --walkme-text: #f9fafb;
+  --walkme-text-muted: #9ca3af;
+  --walkme-primary: #60a5fa;
+  --walkme-border: #374151;
+  --walkme-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.3);
+  --walkme-beacon-color: #60a5fa;
+  --walkme-overlay-color: rgba(0, 0, 0, 0.7);
+}
+```
+
 ### Keyboard Navigation
 
 When a tour is active:

--- a/plugins/walkme/components/WalkmeBeacon.tsx
+++ b/plugins/walkme/components/WalkmeBeacon.tsx
@@ -1,0 +1,64 @@
+'use client'
+
+import { memo } from 'react'
+import { createPortal } from 'react-dom'
+import type { TourStep } from '../types/walkme.types'
+import { useStepPositioning } from '../lib/positioning'
+
+interface WalkmeBeaconProps {
+  step: TourStep
+  targetElement: HTMLElement | null
+  onClick: () => void
+  labels?: {
+    tourAvailable?: string
+  }
+}
+
+/**
+ * Pulsing beacon/hotspot indicator near a target element.
+ * Clicking it starts or advances the tour.
+ */
+export const WalkmeBeacon = memo(function WalkmeBeacon({
+  step,
+  targetElement,
+  onClick,
+  labels,
+}: WalkmeBeaconProps) {
+  const { refs, floatingStyles } = useStepPositioning(targetElement, {
+    placement: 'top-end',
+    offset: 4,
+    padding: 8,
+  })
+
+  if (typeof window === 'undefined') return null
+
+  return createPortal(
+    <button
+      ref={refs.setFloating}
+      data-cy="walkme-beacon"
+      data-walkme
+      onClick={onClick}
+      type="button"
+      role="button"
+      aria-label={step.title || labels?.tourAvailable || 'Tour available'}
+      tabIndex={0}
+      className="relative flex h-6 w-6 items-center justify-center rounded-full outline-none"
+      style={{
+        ...floatingStyles,
+        zIndex: 9999,
+      }}
+    >
+      {/* Pulse ring */}
+      <span
+        className="absolute inset-0 animate-ping rounded-full opacity-75"
+        style={{ backgroundColor: 'var(--walkme-beacon-color, #3b82f6)' }}
+      />
+      {/* Core dot */}
+      <span
+        className="relative h-3 w-3 rounded-full"
+        style={{ backgroundColor: 'var(--walkme-beacon-color, #3b82f6)' }}
+      />
+    </button>,
+    document.body,
+  )
+})

--- a/plugins/walkme/components/WalkmeBeacon.tsx
+++ b/plugins/walkme/components/WalkmeBeacon.tsx
@@ -42,7 +42,7 @@ export const WalkmeBeacon = memo(function WalkmeBeacon({
       role="button"
       aria-label={step.title || labels?.tourAvailable || 'Tour available'}
       tabIndex={0}
-      className="relative flex h-6 w-6 items-center justify-center rounded-full outline-none"
+      className="cursor-pointer relative flex h-6 w-6 items-center justify-center rounded-full outline-none"
       style={{
         ...floatingStyles,
         zIndex: 9999,

--- a/plugins/walkme/components/WalkmeControls.tsx
+++ b/plugins/walkme/components/WalkmeControls.tsx
@@ -53,7 +53,7 @@ export const WalkmeControls = memo(function WalkmeControls({
             type="button"
             className="rounded-lg px-3 py-1.5 text-sm transition-all duration-150 hover:opacity-80 active:scale-95"
             style={{
-              color: 'var(--walkme-text-muted)',
+              color: 'var(--walkme-text-muted, #6b7280)',
               backgroundColor: 'transparent',
             }}
           >
@@ -70,8 +70,8 @@ export const WalkmeControls = memo(function WalkmeControls({
             type="button"
             className="rounded-lg px-3.5 py-1.5 text-sm font-medium transition-all duration-150 hover:opacity-90 active:scale-95"
             style={{
-              color: 'var(--walkme-text)',
-              backgroundColor: 'var(--walkme-border)',
+              color: 'var(--walkme-text, #111827)',
+              backgroundColor: 'var(--walkme-border, #e5e7eb)',
             }}
           >
             {labels?.prev ?? 'Previous'}
@@ -85,7 +85,7 @@ export const WalkmeControls = memo(function WalkmeControls({
             type="button"
             className="rounded-lg px-4 py-1.5 text-sm font-semibold text-white transition-all duration-150 hover:brightness-110 active:scale-95"
             style={{
-              backgroundColor: 'var(--walkme-primary)',
+              backgroundColor: 'var(--walkme-primary, #3b82f6)',
             }}
           >
             {labels?.next ?? 'Next'}
@@ -99,7 +99,7 @@ export const WalkmeControls = memo(function WalkmeControls({
             type="button"
             className="rounded-lg px-4 py-1.5 text-sm font-semibold text-white transition-all duration-150 hover:brightness-110 active:scale-95"
             style={{
-              backgroundColor: 'var(--walkme-primary)',
+              backgroundColor: 'var(--walkme-primary, #3b82f6)',
             }}
           >
             {labels?.complete ?? 'Complete'}

--- a/plugins/walkme/components/WalkmeControls.tsx
+++ b/plugins/walkme/components/WalkmeControls.tsx
@@ -21,7 +21,7 @@ interface WalkmeControlsProps {
 
 /**
  * Navigation button group for tour steps.
- * Renders only the actions specified in the step configuration.
+ * Premium styling with hover/active states and proper spacing.
  */
 export const WalkmeControls = memo(function WalkmeControls({
   actions,
@@ -51,9 +51,9 @@ export const WalkmeControls = memo(function WalkmeControls({
             data-cy="walkme-btn-skip"
             onClick={onSkip}
             type="button"
-            className="rounded px-3 py-1.5 text-sm transition-colors"
+            className="rounded-lg px-3 py-1.5 text-sm transition-all duration-150 hover:opacity-80 active:scale-95"
             style={{
-              color: 'var(--walkme-text-muted, #6b7280)',
+              color: 'var(--walkme-text-muted)',
               backgroundColor: 'transparent',
             }}
           >
@@ -68,10 +68,10 @@ export const WalkmeControls = memo(function WalkmeControls({
             data-cy="walkme-btn-prev"
             onClick={onPrev}
             type="button"
-            className="rounded px-3 py-1.5 text-sm transition-colors"
+            className="rounded-lg px-3.5 py-1.5 text-sm font-medium transition-all duration-150 hover:opacity-90 active:scale-95"
             style={{
-              color: 'var(--walkme-text, #111827)',
-              backgroundColor: 'var(--walkme-border, #e5e7eb)',
+              color: 'var(--walkme-text)',
+              backgroundColor: 'var(--walkme-border)',
             }}
           >
             {labels?.prev ?? 'Previous'}
@@ -83,9 +83,9 @@ export const WalkmeControls = memo(function WalkmeControls({
             data-cy="walkme-btn-next"
             onClick={onNext}
             type="button"
-            className="rounded px-3 py-1.5 text-sm font-medium text-white transition-colors"
+            className="rounded-lg px-4 py-1.5 text-sm font-semibold text-white transition-all duration-150 hover:brightness-110 active:scale-95"
             style={{
-              backgroundColor: 'var(--walkme-primary, #3b82f6)',
+              backgroundColor: 'var(--walkme-primary)',
             }}
           >
             {labels?.next ?? 'Next'}
@@ -97,9 +97,9 @@ export const WalkmeControls = memo(function WalkmeControls({
             data-cy="walkme-btn-complete"
             onClick={onComplete}
             type="button"
-            className="rounded px-3 py-1.5 text-sm font-medium text-white transition-colors"
+            className="rounded-lg px-4 py-1.5 text-sm font-semibold text-white transition-all duration-150 hover:brightness-110 active:scale-95"
             style={{
-              backgroundColor: 'var(--walkme-primary, #3b82f6)',
+              backgroundColor: 'var(--walkme-primary)',
             }}
           >
             {labels?.complete ?? 'Complete'}

--- a/plugins/walkme/components/WalkmeControls.tsx
+++ b/plugins/walkme/components/WalkmeControls.tsx
@@ -1,0 +1,111 @@
+'use client'
+
+import { memo } from 'react'
+import type { StepAction } from '../types/walkme.types'
+
+interface WalkmeControlsProps {
+  actions: StepAction[]
+  onNext: () => void
+  onPrev: () => void
+  onSkip: () => void
+  onComplete: () => void
+  isFirst: boolean
+  isLast: boolean
+  labels?: {
+    next?: string
+    prev?: string
+    skip?: string
+    complete?: string
+  }
+}
+
+/**
+ * Navigation button group for tour steps.
+ * Renders only the actions specified in the step configuration.
+ */
+export const WalkmeControls = memo(function WalkmeControls({
+  actions,
+  onNext,
+  onPrev,
+  onSkip,
+  onComplete,
+  isFirst,
+  isLast,
+  labels,
+}: WalkmeControlsProps) {
+  const showPrev = actions.includes('prev') && !isFirst
+  const showNext = actions.includes('next') && !isLast
+  const showSkip = actions.includes('skip')
+  const showComplete =
+    actions.includes('complete') || (isLast && actions.includes('next'))
+
+  return (
+    <div
+      data-cy="walkme-controls"
+      data-walkme
+      className="flex items-center justify-between gap-2"
+    >
+      <div className="flex gap-2">
+        {showSkip && (
+          <button
+            data-cy="walkme-btn-skip"
+            onClick={onSkip}
+            type="button"
+            className="rounded px-3 py-1.5 text-sm transition-colors"
+            style={{
+              color: 'var(--walkme-text-muted, #6b7280)',
+              backgroundColor: 'transparent',
+            }}
+          >
+            {labels?.skip ?? 'Skip'}
+          </button>
+        )}
+      </div>
+
+      <div className="flex gap-2">
+        {showPrev && (
+          <button
+            data-cy="walkme-btn-prev"
+            onClick={onPrev}
+            type="button"
+            className="rounded px-3 py-1.5 text-sm transition-colors"
+            style={{
+              color: 'var(--walkme-text, #111827)',
+              backgroundColor: 'var(--walkme-border, #e5e7eb)',
+            }}
+          >
+            {labels?.prev ?? 'Previous'}
+          </button>
+        )}
+
+        {showNext && (
+          <button
+            data-cy="walkme-btn-next"
+            onClick={onNext}
+            type="button"
+            className="rounded px-3 py-1.5 text-sm font-medium text-white transition-colors"
+            style={{
+              backgroundColor: 'var(--walkme-primary, #3b82f6)',
+            }}
+          >
+            {labels?.next ?? 'Next'}
+          </button>
+        )}
+
+        {showComplete && (
+          <button
+            data-cy="walkme-btn-complete"
+            onClick={onComplete}
+            type="button"
+            className="rounded px-3 py-1.5 text-sm font-medium text-white transition-colors"
+            style={{
+              backgroundColor: 'var(--walkme-primary, #3b82f6)',
+            }}
+          >
+            {labels?.complete ?? 'Complete'}
+          </button>
+        )}
+      </div>
+    </div>
+  )
+})

--- a/plugins/walkme/components/WalkmeControls.tsx
+++ b/plugins/walkme/components/WalkmeControls.tsx
@@ -51,7 +51,7 @@ export const WalkmeControls = memo(function WalkmeControls({
             data-cy="walkme-btn-skip"
             onClick={onSkip}
             type="button"
-            className="rounded-lg px-3 py-1.5 text-sm transition-all duration-150 hover:opacity-80 active:scale-95"
+            className="cursor-pointer rounded-lg px-3 py-1.5 text-sm transition-all duration-150 hover:opacity-80 active:scale-95"
             style={{
               color: 'var(--walkme-text-muted, #6b7280)',
               backgroundColor: 'transparent',
@@ -68,7 +68,7 @@ export const WalkmeControls = memo(function WalkmeControls({
             data-cy="walkme-btn-prev"
             onClick={onPrev}
             type="button"
-            className="rounded-lg px-3.5 py-1.5 text-sm font-medium transition-all duration-150 hover:opacity-90 active:scale-95"
+            className="cursor-pointer rounded-lg px-3.5 py-1.5 text-sm font-medium transition-all duration-150 hover:opacity-90 active:scale-95"
             style={{
               color: 'var(--walkme-text, #111827)',
               backgroundColor: 'var(--walkme-border, #e5e7eb)',
@@ -83,7 +83,7 @@ export const WalkmeControls = memo(function WalkmeControls({
             data-cy="walkme-btn-next"
             onClick={onNext}
             type="button"
-            className="rounded-lg px-4 py-1.5 text-sm font-semibold text-white transition-all duration-150 hover:brightness-110 active:scale-95"
+            className="cursor-pointer rounded-lg px-4 py-1.5 text-sm font-semibold text-white transition-all duration-150 hover:brightness-110 active:scale-95"
             style={{
               backgroundColor: 'var(--walkme-primary, #3b82f6)',
             }}
@@ -97,7 +97,7 @@ export const WalkmeControls = memo(function WalkmeControls({
             data-cy="walkme-btn-complete"
             onClick={onComplete}
             type="button"
-            className="rounded-lg px-4 py-1.5 text-sm font-semibold text-white transition-all duration-150 hover:brightness-110 active:scale-95"
+            className="cursor-pointer rounded-lg px-4 py-1.5 text-sm font-semibold text-white transition-all duration-150 hover:brightness-110 active:scale-95"
             style={{
               backgroundColor: 'var(--walkme-primary, #3b82f6)',
             }}

--- a/plugins/walkme/components/WalkmeModal.tsx
+++ b/plugins/walkme/components/WalkmeModal.tsx
@@ -89,10 +89,10 @@ export const WalkmeModal = memo(function WalkmeModal({
       className="fixed left-1/2 top-1/2 w-[28rem] max-w-[calc(100vw-2rem)] -translate-x-1/2 -translate-y-1/2 rounded-2xl p-6 outline-none animate-in fade-in-0 zoom-in-95 duration-300"
       style={{
         zIndex: 9999,
-        backgroundColor: 'var(--walkme-bg)',
-        color: 'var(--walkme-text)',
-        border: '1px solid var(--walkme-border)',
-        boxShadow: 'var(--walkme-shadow)',
+        backgroundColor: 'var(--walkme-bg, #ffffff)',
+        color: 'var(--walkme-text, #111827)',
+        border: '1px solid var(--walkme-border, #e5e7eb)',
+        boxShadow: 'var(--walkme-shadow, 0 20px 25px -5px rgba(0,0,0,.1), 0 8px 10px -6px rgba(0,0,0,.1))',
       }}
     >
       {/* Close button */}
@@ -100,16 +100,10 @@ export const WalkmeModal = memo(function WalkmeModal({
         data-cy="walkme-btn-close"
         onClick={onSkip}
         type="button"
-        className="absolute right-3 top-3 rounded-lg p-1.5 transition-all duration-150 hover:scale-110 active:scale-95"
+        className="absolute right-3 top-3 rounded-lg p-1.5 transition-all duration-150 hover:scale-110 hover:bg-black/5 active:scale-95"
         style={{
-          color: 'var(--walkme-text-muted)',
+          color: 'var(--walkme-text-muted, #6b7280)',
           backgroundColor: 'transparent',
-        }}
-        onMouseEnter={(e) => {
-          e.currentTarget.style.backgroundColor = 'var(--walkme-border)'
-        }}
-        onMouseLeave={(e) => {
-          e.currentTarget.style.backgroundColor = 'transparent'
         }}
         aria-label={labels?.close ?? 'Close'}
       >
@@ -123,7 +117,7 @@ export const WalkmeModal = memo(function WalkmeModal({
       <p
         id={`walkme-modal-content-${step.id}`}
         className="mb-5 text-sm leading-relaxed"
-        style={{ color: 'var(--walkme-text-muted)' }}
+        style={{ color: 'var(--walkme-text-muted, #6b7280)' }}
       >
         {step.content}
       </p>

--- a/plugins/walkme/components/WalkmeModal.tsx
+++ b/plugins/walkme/components/WalkmeModal.tsx
@@ -2,7 +2,7 @@
 
 import { memo, useEffect, useRef } from 'react'
 import { createPortal } from 'react-dom'
-import { X } from 'lucide-react'
+import { X } from '@phosphor-icons/react'
 import type { TourStep } from '../types/walkme.types'
 import { WalkmeProgress } from './WalkmeProgress'
 import { WalkmeControls } from './WalkmeControls'
@@ -30,6 +30,7 @@ interface WalkmeModalProps {
 /**
  * Centered modal dialog for tour steps.
  * Includes focus trap and keyboard handling.
+ * Uses theme-aware CSS variables for premium dark/light mode support.
  */
 export const WalkmeModal = memo(function WalkmeModal({
   step,
@@ -85,13 +86,13 @@ export const WalkmeModal = memo(function WalkmeModal({
       aria-label={step.title}
       aria-describedby={`walkme-modal-content-${step.id}`}
       tabIndex={-1}
-      className="fixed left-1/2 top-1/2 w-[28rem] max-w-[calc(100vw-2rem)] -translate-x-1/2 -translate-y-1/2 rounded-xl p-6 shadow-2xl outline-none animate-in fade-in-0 zoom-in-95 duration-200"
+      className="fixed left-1/2 top-1/2 w-[28rem] max-w-[calc(100vw-2rem)] -translate-x-1/2 -translate-y-1/2 rounded-2xl p-6 outline-none animate-in fade-in-0 zoom-in-95 duration-300"
       style={{
         zIndex: 9999,
-        backgroundColor: 'var(--walkme-bg, #ffffff)',
-        color: 'var(--walkme-text, #111827)',
-        border: '1px solid var(--walkme-border, #e5e7eb)',
-        boxShadow: 'var(--walkme-shadow, 0 25px 50px -12px rgba(0, 0, 0, 0.25))',
+        backgroundColor: 'var(--walkme-bg)',
+        color: 'var(--walkme-text)',
+        border: '1px solid var(--walkme-border)',
+        boxShadow: 'var(--walkme-shadow)',
       }}
     >
       {/* Close button */}
@@ -99,21 +100,30 @@ export const WalkmeModal = memo(function WalkmeModal({
         data-cy="walkme-btn-close"
         onClick={onSkip}
         type="button"
-        className="absolute right-3 top-3 rounded-sm p-1 transition-colors"
-        style={{ color: 'var(--walkme-text-muted, #6b7280)' }}
+        className="absolute right-3 top-3 rounded-lg p-1.5 transition-all duration-150 hover:scale-110 active:scale-95"
+        style={{
+          color: 'var(--walkme-text-muted)',
+          backgroundColor: 'transparent',
+        }}
+        onMouseEnter={(e) => {
+          e.currentTarget.style.backgroundColor = 'var(--walkme-border)'
+        }}
+        onMouseLeave={(e) => {
+          e.currentTarget.style.backgroundColor = 'transparent'
+        }}
         aria-label={labels?.close ?? 'Close'}
       >
-        <X className="h-4 w-4" />
+        <X size={16} weight="bold" />
       </button>
 
       {/* Title */}
-      <h2 className="mb-2 pr-8 text-lg font-semibold">{step.title}</h2>
+      <h2 className="mb-2 pr-8 text-lg font-semibold tracking-tight">{step.title}</h2>
 
       {/* Content */}
       <p
         id={`walkme-modal-content-${step.id}`}
-        className="mb-4 text-sm leading-relaxed"
-        style={{ color: 'var(--walkme-text-muted, #6b7280)' }}
+        className="mb-5 text-sm leading-relaxed"
+        style={{ color: 'var(--walkme-text-muted)' }}
       >
         {step.content}
       </p>

--- a/plugins/walkme/components/WalkmeModal.tsx
+++ b/plugins/walkme/components/WalkmeModal.tsx
@@ -1,0 +1,140 @@
+'use client'
+
+import { memo, useEffect, useRef } from 'react'
+import { createPortal } from 'react-dom'
+import { X } from 'lucide-react'
+import type { TourStep } from '../types/walkme.types'
+import { WalkmeProgress } from './WalkmeProgress'
+import { WalkmeControls } from './WalkmeControls'
+
+interface WalkmeModalProps {
+  step: TourStep
+  onNext: () => void
+  onPrev: () => void
+  onSkip: () => void
+  onComplete: () => void
+  isFirst: boolean
+  isLast: boolean
+  currentIndex: number
+  totalSteps: number
+  labels?: {
+    close?: string
+    next?: string
+    prev?: string
+    skip?: string
+    complete?: string
+    progress?: string
+  }
+}
+
+/**
+ * Centered modal dialog for tour steps.
+ * Includes focus trap and keyboard handling.
+ */
+export const WalkmeModal = memo(function WalkmeModal({
+  step,
+  onNext,
+  onPrev,
+  onSkip,
+  onComplete,
+  isFirst,
+  isLast,
+  currentIndex,
+  totalSteps,
+  labels,
+}: WalkmeModalProps) {
+  const containerRef = useRef<HTMLDivElement>(null)
+
+  // Focus trap: keep focus within the modal
+  useEffect(() => {
+    containerRef.current?.focus()
+
+    const handleTab = (e: KeyboardEvent) => {
+      if (e.key !== 'Tab' || !containerRef.current) return
+
+      const focusable = containerRef.current.querySelectorAll<HTMLElement>(
+        'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])',
+      )
+      if (focusable.length === 0) return
+
+      const first = focusable[0]
+      const last = focusable[focusable.length - 1]
+
+      if (e.shiftKey && document.activeElement === first) {
+        e.preventDefault()
+        last.focus()
+      } else if (!e.shiftKey && document.activeElement === last) {
+        e.preventDefault()
+        first.focus()
+      }
+    }
+
+    document.addEventListener('keydown', handleTab)
+    return () => document.removeEventListener('keydown', handleTab)
+  }, [step.id])
+
+  if (typeof window === 'undefined') return null
+
+  return createPortal(
+    <div
+      ref={containerRef}
+      data-cy="walkme-modal"
+      data-walkme
+      role="dialog"
+      aria-modal="true"
+      aria-label={step.title}
+      aria-describedby={`walkme-modal-content-${step.id}`}
+      tabIndex={-1}
+      className="fixed left-1/2 top-1/2 w-[28rem] max-w-[calc(100vw-2rem)] -translate-x-1/2 -translate-y-1/2 rounded-xl p-6 shadow-2xl outline-none animate-in fade-in-0 zoom-in-95 duration-200"
+      style={{
+        zIndex: 9999,
+        backgroundColor: 'var(--walkme-bg, #ffffff)',
+        color: 'var(--walkme-text, #111827)',
+        border: '1px solid var(--walkme-border, #e5e7eb)',
+        boxShadow: 'var(--walkme-shadow, 0 25px 50px -12px rgba(0, 0, 0, 0.25))',
+      }}
+    >
+      {/* Close button */}
+      <button
+        data-cy="walkme-btn-close"
+        onClick={onSkip}
+        type="button"
+        className="absolute right-3 top-3 rounded-sm p-1 transition-colors"
+        style={{ color: 'var(--walkme-text-muted, #6b7280)' }}
+        aria-label={labels?.close ?? 'Close'}
+      >
+        <X className="h-4 w-4" />
+      </button>
+
+      {/* Title */}
+      <h2 className="mb-2 pr-8 text-lg font-semibold">{step.title}</h2>
+
+      {/* Content */}
+      <p
+        id={`walkme-modal-content-${step.id}`}
+        className="mb-4 text-sm leading-relaxed"
+        style={{ color: 'var(--walkme-text-muted, #6b7280)' }}
+      >
+        {step.content}
+      </p>
+
+      {/* Progress */}
+      <div className="mb-4">
+        <WalkmeProgress current={currentIndex} total={totalSteps} progressTemplate={labels?.progress} />
+      </div>
+
+      {/* Controls */}
+      <WalkmeControls
+        actions={step.actions}
+        onNext={onNext}
+        onPrev={onPrev}
+        onSkip={onSkip}
+        onComplete={onComplete}
+        isFirst={isFirst}
+        isLast={isLast}
+        labels={labels}
+      />
+    </div>,
+    document.body,
+  )
+})

--- a/plugins/walkme/components/WalkmeModal.tsx
+++ b/plugins/walkme/components/WalkmeModal.tsx
@@ -100,7 +100,7 @@ export const WalkmeModal = memo(function WalkmeModal({
         data-cy="walkme-btn-close"
         onClick={onSkip}
         type="button"
-        className="absolute right-3 top-3 rounded-lg p-1.5 transition-all duration-150 hover:scale-110 hover:bg-black/5 active:scale-95"
+        className="cursor-pointer absolute right-3 top-3 rounded-lg p-1.5 transition-all duration-150 hover:scale-110 hover:bg-black/5 active:scale-95"
         style={{
           color: 'var(--walkme-text-muted, #6b7280)',
           backgroundColor: 'transparent',

--- a/plugins/walkme/components/WalkmeOverlay.tsx
+++ b/plugins/walkme/components/WalkmeOverlay.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useEffect, useState, useCallback } from 'react'
+import { memo, useEffect, useState, useCallback } from 'react'
 import { createPortal } from 'react-dom'
 
 interface WalkmeOverlayProps {
@@ -15,7 +15,7 @@ interface WalkmeOverlayProps {
  * Supports an optional spotlight cutout to highlight a target element.
  * Dynamically tracks target position on scroll/resize.
  */
-export function WalkmeOverlay({
+export const WalkmeOverlay = memo(function WalkmeOverlay({
   visible,
   onClick,
   spotlightTarget,
@@ -74,7 +74,7 @@ export function WalkmeOverlay({
     />,
     document.body,
   )
-}
+})
 
 /** Generate a clip-path that cuts out a rectangle around the target element */
 function getSpotlightClipPath(

--- a/plugins/walkme/components/WalkmeOverlay.tsx
+++ b/plugins/walkme/components/WalkmeOverlay.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { memo } from 'react'
+import { useEffect, useState, useCallback } from 'react'
 import { createPortal } from 'react-dom'
 
 interface WalkmeOverlayProps {
@@ -13,19 +13,49 @@ interface WalkmeOverlayProps {
 /**
  * Full-screen dark backdrop overlay.
  * Supports an optional spotlight cutout to highlight a target element.
+ * Dynamically tracks target position on scroll/resize.
  */
-export const WalkmeOverlay = memo(function WalkmeOverlay({
+export function WalkmeOverlay({
   visible,
   onClick,
   spotlightTarget,
   spotlightPadding = 8,
 }: WalkmeOverlayProps) {
+  const [clipPath, setClipPath] = useState<string | undefined>(undefined)
+
+  const recalculate = useCallback(() => {
+    if (!spotlightTarget) {
+      setClipPath(undefined)
+      return
+    }
+    setClipPath(getSpotlightClipPath(spotlightTarget, spotlightPadding))
+  }, [spotlightTarget, spotlightPadding])
+
+  // Recalculate on mount and when target changes
+  useEffect(() => {
+    recalculate()
+  }, [recalculate])
+
+  // Track target position on scroll/resize (any scrollable container)
+  useEffect(() => {
+    if (!spotlightTarget) return
+
+    // Recalculate after a short delay to let any scrollIntoView settle
+    const initialTimer = setTimeout(recalculate, 100)
+
+    const handler = () => recalculate()
+    window.addEventListener('scroll', handler, true) // capture phase for nested scroll containers
+    window.addEventListener('resize', handler)
+
+    return () => {
+      clearTimeout(initialTimer)
+      window.removeEventListener('scroll', handler, true)
+      window.removeEventListener('resize', handler)
+    }
+  }, [spotlightTarget, recalculate])
+
   if (typeof window === 'undefined') return null
   if (!visible) return null
-
-  const clipPath = spotlightTarget
-    ? getSpotlightClipPath(spotlightTarget, spotlightPadding)
-    : undefined
 
   return createPortal(
     <div
@@ -35,14 +65,16 @@ export const WalkmeOverlay = memo(function WalkmeOverlay({
       className="fixed inset-0 transition-opacity duration-300 ease-in-out"
       style={{
         zIndex: 9998,
-        backgroundColor: 'var(--walkme-overlay-bg, rgba(0, 0, 0, 0.5))',
+        backgroundColor: 'var(--walkme-overlay-bg, rgba(0, 0, 0, 0.65))',
+        backdropFilter: 'blur(4px)',
+        WebkitBackdropFilter: 'blur(4px)',
         clipPath,
       }}
       aria-hidden="true"
     />,
     document.body,
   )
-})
+}
 
 /** Generate a clip-path that cuts out a rectangle around the target element */
 function getSpotlightClipPath(
@@ -52,8 +84,8 @@ function getSpotlightClipPath(
   const rect = target.getBoundingClientRect()
   const top = Math.max(0, rect.top - padding)
   const left = Math.max(0, rect.left - padding)
-  const bottom = rect.bottom + padding
-  const right = rect.right + padding
+  const bottom = Math.min(window.innerHeight, rect.bottom + padding)
+  const right = Math.min(window.innerWidth, rect.right + padding)
 
   // polygon that covers everything EXCEPT the target area
   return `polygon(

--- a/plugins/walkme/components/WalkmeOverlay.tsx
+++ b/plugins/walkme/components/WalkmeOverlay.tsx
@@ -1,0 +1,66 @@
+'use client'
+
+import { memo } from 'react'
+import { createPortal } from 'react-dom'
+
+interface WalkmeOverlayProps {
+  visible: boolean
+  onClick?: () => void
+  spotlightTarget?: HTMLElement | null
+  spotlightPadding?: number
+}
+
+/**
+ * Full-screen dark backdrop overlay.
+ * Supports an optional spotlight cutout to highlight a target element.
+ */
+export const WalkmeOverlay = memo(function WalkmeOverlay({
+  visible,
+  onClick,
+  spotlightTarget,
+  spotlightPadding = 8,
+}: WalkmeOverlayProps) {
+  if (typeof window === 'undefined') return null
+  if (!visible) return null
+
+  const clipPath = spotlightTarget
+    ? getSpotlightClipPath(spotlightTarget, spotlightPadding)
+    : undefined
+
+  return createPortal(
+    <div
+      data-cy="walkme-overlay"
+      data-walkme
+      onClick={onClick}
+      className="fixed inset-0 transition-opacity duration-300 ease-in-out"
+      style={{
+        zIndex: 9998,
+        backgroundColor: 'var(--walkme-overlay-bg, rgba(0, 0, 0, 0.5))',
+        clipPath,
+      }}
+      aria-hidden="true"
+    />,
+    document.body,
+  )
+})
+
+/** Generate a clip-path that cuts out a rectangle around the target element */
+function getSpotlightClipPath(
+  target: HTMLElement,
+  padding: number,
+): string {
+  const rect = target.getBoundingClientRect()
+  const top = Math.max(0, rect.top - padding)
+  const left = Math.max(0, rect.left - padding)
+  const bottom = rect.bottom + padding
+  const right = rect.right + padding
+
+  // polygon that covers everything EXCEPT the target area
+  return `polygon(
+    0% 0%, 0% 100%,
+    ${left}px 100%, ${left}px ${top}px,
+    ${right}px ${top}px, ${right}px ${bottom}px,
+    ${left}px ${bottom}px, ${left}px 100%,
+    100% 100%, 100% 0%
+  )`
+}

--- a/plugins/walkme/components/WalkmeProgress.tsx
+++ b/plugins/walkme/components/WalkmeProgress.tsx
@@ -27,7 +27,7 @@ export const WalkmeProgress = memo(function WalkmeProgress({
     <div data-cy="walkme-progress" data-walkme className="flex items-center gap-3">
       <div
         className="h-1 flex-1 overflow-hidden rounded-full"
-        style={{ backgroundColor: 'var(--walkme-border)' }}
+        style={{ backgroundColor: 'var(--walkme-border, #e5e7eb)' }}
         role="progressbar"
         aria-valuenow={current + 1}
         aria-valuemin={1}
@@ -38,13 +38,13 @@ export const WalkmeProgress = memo(function WalkmeProgress({
           className="h-full rounded-full transition-all duration-500 ease-out"
           style={{
             width: `${percentage}%`,
-            backgroundColor: 'var(--walkme-primary)',
+            backgroundColor: 'var(--walkme-primary, #3b82f6)',
           }}
         />
       </div>
       <span
         className="text-xs tabular-nums whitespace-nowrap"
-        style={{ color: 'var(--walkme-text-muted)' }}
+        style={{ color: 'var(--walkme-text-muted, #6b7280)' }}
       >
         {current + 1} / {total}
       </span>

--- a/plugins/walkme/components/WalkmeProgress.tsx
+++ b/plugins/walkme/components/WalkmeProgress.tsx
@@ -11,6 +11,7 @@ interface WalkmeProgressProps {
 
 /**
  * Progress bar indicator showing current step within a tour.
+ * Uses theme-aware CSS variables with smooth transitions.
  */
 export const WalkmeProgress = memo(function WalkmeProgress({
   current,
@@ -23,10 +24,10 @@ export const WalkmeProgress = memo(function WalkmeProgress({
     .replace('{total}', String(total))
 
   return (
-    <div data-cy="walkme-progress" data-walkme className="flex items-center gap-2">
+    <div data-cy="walkme-progress" data-walkme className="flex items-center gap-3">
       <div
-        className="h-1.5 flex-1 overflow-hidden rounded-full"
-        style={{ backgroundColor: 'var(--walkme-border, #e5e7eb)' }}
+        className="h-1 flex-1 overflow-hidden rounded-full"
+        style={{ backgroundColor: 'var(--walkme-border)' }}
         role="progressbar"
         aria-valuenow={current + 1}
         aria-valuemin={1}
@@ -34,16 +35,16 @@ export const WalkmeProgress = memo(function WalkmeProgress({
         aria-label={progressLabel}
       >
         <div
-          className="h-full rounded-full transition-all duration-300 ease-out"
+          className="h-full rounded-full transition-all duration-500 ease-out"
           style={{
             width: `${percentage}%`,
-            backgroundColor: 'var(--walkme-primary, #3b82f6)',
+            backgroundColor: 'var(--walkme-primary)',
           }}
         />
       </div>
       <span
-        className="text-xs whitespace-nowrap"
-        style={{ color: 'var(--walkme-text-muted, #6b7280)' }}
+        className="text-xs tabular-nums whitespace-nowrap"
+        style={{ color: 'var(--walkme-text-muted)' }}
       >
         {current + 1} / {total}
       </span>

--- a/plugins/walkme/components/WalkmeProgress.tsx
+++ b/plugins/walkme/components/WalkmeProgress.tsx
@@ -1,0 +1,52 @@
+'use client'
+
+import { memo } from 'react'
+
+interface WalkmeProgressProps {
+  current: number
+  total: number
+  /** Template string for progress label, e.g. "Step {current} of {total}" */
+  progressTemplate?: string
+}
+
+/**
+ * Progress bar indicator showing current step within a tour.
+ */
+export const WalkmeProgress = memo(function WalkmeProgress({
+  current,
+  total,
+  progressTemplate,
+}: WalkmeProgressProps) {
+  const percentage = total > 0 ? Math.round(((current + 1) / total) * 100) : 0
+  const progressLabel = (progressTemplate ?? 'Step {current} of {total}')
+    .replace('{current}', String(current + 1))
+    .replace('{total}', String(total))
+
+  return (
+    <div data-cy="walkme-progress" data-walkme className="flex items-center gap-2">
+      <div
+        className="h-1.5 flex-1 overflow-hidden rounded-full"
+        style={{ backgroundColor: 'var(--walkme-border, #e5e7eb)' }}
+        role="progressbar"
+        aria-valuenow={current + 1}
+        aria-valuemin={1}
+        aria-valuemax={total}
+        aria-label={progressLabel}
+      >
+        <div
+          className="h-full rounded-full transition-all duration-300 ease-out"
+          style={{
+            width: `${percentage}%`,
+            backgroundColor: 'var(--walkme-primary, #3b82f6)',
+          }}
+        />
+      </div>
+      <span
+        className="text-xs whitespace-nowrap"
+        style={{ color: 'var(--walkme-text-muted, #6b7280)' }}
+      >
+        {current + 1} / {total}
+      </span>
+    </div>
+  )
+})

--- a/plugins/walkme/components/WalkmeProvider.tsx
+++ b/plugins/walkme/components/WalkmeProvider.tsx
@@ -70,6 +70,7 @@ export function WalkmeProvider({
   onStepChange,
   conditionContext: externalConditionContext,
   labels: userLabels,
+  userId,
 }: WalkmeProviderProps) {
   const labels = useMemo<WalkmeLabels>(
     () => ({ ...DEFAULT_LABELS, ...userLabels }),
@@ -100,6 +101,7 @@ export function WalkmeProvider({
   const { state, dispatch, storage } = useTourState(validatedTours, {
     persistState,
     debug,
+    userId,
   })
 
   // ---------------------------------------------------------------------------
@@ -312,7 +314,7 @@ export function WalkmeProvider({
         dispatch({ type: 'NEXT_STEP' })
       }
     }
-  }, [state.activeTour?.currentStepIndex]) // eslint-disable-line react-hooks/exhaustive-deps
+  }, [state.activeTour?.currentStepIndex, Object.keys(state.tours).length]) // eslint-disable-line react-hooks/exhaustive-deps
 
   // Wait for target after route change
   useEffect(() => {
@@ -334,11 +336,13 @@ export function WalkmeProvider({
         )
       }
     })
-  }, [pathname]) // eslint-disable-line react-hooks/exhaustive-deps
+  }, [pathname, Object.keys(state.tours).length]) // eslint-disable-line react-hooks/exhaustive-deps
 
   // ---------------------------------------------------------------------------
   // Target Element Resolution
   // ---------------------------------------------------------------------------
+
+  const toursCount = Object.keys(state.tours).length
 
   useEffect(() => {
     // Clear stale target so floating tooltip unmounts and remounts fresh
@@ -380,7 +384,7 @@ export function WalkmeProvider({
       cancelled = true
       clearTimeout(findTimer)
     }
-  }, [state.activeTour?.currentStepIndex, state.activeTour?.status]) // eslint-disable-line react-hooks/exhaustive-deps
+  }, [state.activeTour?.currentStepIndex, state.activeTour?.status, toursCount]) // eslint-disable-line react-hooks/exhaustive-deps
 
   // ---------------------------------------------------------------------------
   // Step Change Analytics

--- a/plugins/walkme/components/WalkmeProvider.tsx
+++ b/plugins/walkme/components/WalkmeProvider.tsx
@@ -46,6 +46,16 @@ import { WalkmeBeacon } from './WalkmeBeacon'
  * </WalkmeProvider>
  * ```
  */
+const DEFAULT_LABELS: WalkmeLabels = {
+  next: 'Next',
+  prev: 'Previous',
+  skip: 'Skip',
+  complete: 'Complete',
+  close: 'Close',
+  progress: 'Step {current} of {total}',
+  tourAvailable: 'Tour available',
+}
+
 export function WalkmeProvider({
   tours: rawTours,
   children,
@@ -60,18 +70,9 @@ export function WalkmeProvider({
   conditionContext: externalConditionContext,
   labels: userLabels,
 }: WalkmeProviderProps) {
-  const defaultLabels: WalkmeLabels = {
-    next: 'Next',
-    prev: 'Previous',
-    skip: 'Skip',
-    complete: 'Complete',
-    close: 'Close',
-    progress: 'Step {current} of {total}',
-    tourAvailable: 'Tour available',
-  }
   const labels = useMemo<WalkmeLabels>(
-    () => ({ ...defaultLabels, ...userLabels }),
-    [userLabels], // eslint-disable-line react-hooks/exhaustive-deps
+    () => ({ ...DEFAULT_LABELS, ...userLabels }),
+    [userLabels],
   )
 
   const pathname = usePathname()
@@ -430,6 +431,8 @@ export function WalkmeProvider({
       if (triggerTimeoutRef.current) {
         clearTimeout(triggerTimeoutRef.current)
       }
+      targetElementRef.current = null
+      previousFocusRef.current = null
     }
   }, [])
 

--- a/plugins/walkme/components/WalkmeProvider.tsx
+++ b/plugins/walkme/components/WalkmeProvider.tsx
@@ -434,12 +434,16 @@ export function WalkmeProvider({
   }, [state.activeTour, nextStep, prevStep, skipTour])
 
   // ---------------------------------------------------------------------------
-  // Body Scroll Lock (prevent scrolling during active tour)
+  // Body Scroll Lock (only for modal/floating steps that cover the page)
   // ---------------------------------------------------------------------------
 
+  const activeStepType = getActiveStep(state)?.type
   useEffect(() => {
     const isActive = state.activeTour?.status === 'active'
     if (!isActive) return
+
+    // Only lock scroll for step types that cover the viewport
+    if (activeStepType !== 'modal' && activeStepType !== 'floating') return
 
     const { style } = document.body
     const originalOverflow = style.overflow
@@ -456,7 +460,7 @@ export function WalkmeProvider({
       style.overflow = originalOverflow
       style.paddingRight = originalPaddingRight
     }
-  }, [state.activeTour?.status])
+  }, [state.activeTour?.status, activeStepType])
 
   // ---------------------------------------------------------------------------
   // Cleanup

--- a/plugins/walkme/components/WalkmeProvider.tsx
+++ b/plugins/walkme/components/WalkmeProvider.tsx
@@ -1,0 +1,620 @@
+'use client'
+
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  type ReactNode,
+} from 'react'
+import { usePathname, useRouter } from 'next/navigation'
+import { WalkmeContext } from '../providers/walkme-context'
+import { useTourState } from '../hooks/useTourState'
+import { validateTours } from '../lib/validation'
+import { shouldTriggerTour, type TriggerEvaluationContext } from '../lib/triggers'
+import { evaluateConditions } from '../lib/conditions'
+import {
+  getActiveTour,
+  getActiveStep,
+  isFirstStep,
+  isLastStep,
+} from '../lib/core'
+import { findTarget, waitForTarget, scrollToElement } from '../lib/targeting'
+import type {
+  WalkmeProviderProps,
+  WalkmeContextValue,
+  TourEvent,
+  ConditionContext,
+  WalkmeLabels,
+} from '../types/walkme.types'
+import { WalkmeOverlay } from './WalkmeOverlay'
+import { WalkmeTooltip } from './WalkmeTooltip'
+import { WalkmeModal } from './WalkmeModal'
+import { WalkmeSpotlight } from './WalkmeSpotlight'
+import { WalkmeBeacon } from './WalkmeBeacon'
+
+/**
+ * WalkMe Provider Component
+ *
+ * Wraps the application (or a section) to provide guided tour functionality.
+ * Manages tour state, trigger evaluation, cross-page navigation, and rendering.
+ *
+ * @example
+ * ```tsx
+ * <WalkmeProvider tours={[introTour, featureTour]} autoStart>
+ *   <App />
+ * </WalkmeProvider>
+ * ```
+ */
+export function WalkmeProvider({
+  tours: rawTours,
+  children,
+  debug = false,
+  autoStart = true,
+  autoStartDelay = 1000,
+  persistState = true,
+  onTourStart,
+  onTourComplete,
+  onTourSkip,
+  onStepChange,
+  conditionContext: externalConditionContext,
+  labels: userLabels,
+}: WalkmeProviderProps) {
+  const defaultLabels: WalkmeLabels = {
+    next: 'Next',
+    prev: 'Previous',
+    skip: 'Skip',
+    complete: 'Complete',
+    close: 'Close',
+    progress: 'Step {current} of {total}',
+    tourAvailable: 'Tour available',
+  }
+  const labels = useMemo<WalkmeLabels>(
+    () => ({ ...defaultLabels, ...userLabels }),
+    [userLabels], // eslint-disable-line react-hooks/exhaustive-deps
+  )
+
+  const pathname = usePathname()
+  const router = useRouter()
+  const prevPathRef = useRef(pathname)
+  const customEventsRef = useRef<Set<string>>(new Set())
+  const previousFocusRef = useRef<HTMLElement | null>(null)
+  const triggerTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const targetElementRef = useRef<HTMLElement | null>(null)
+
+  // Validate tours on mount
+  const validatedTours = useMemo(() => {
+    const result = validateTours(rawTours)
+    if (!result.valid && debug) {
+      console.warn(
+        '[WalkMe] Some tours failed validation and were excluded:',
+        result.errors,
+      )
+    }
+    return result.validTours
+  }, [rawTours, debug])
+
+  // Core state management
+  const { state, dispatch, storage } = useTourState(validatedTours, {
+    persistState,
+    debug,
+  })
+
+  // ---------------------------------------------------------------------------
+  // Context value helpers
+  // ---------------------------------------------------------------------------
+
+  const startTour = useCallback(
+    (tourId: string) => {
+      const tour = state.tours[tourId]
+      if (!tour) {
+        if (debug) console.warn(`[WalkMe] Tour "${tourId}" not found`)
+        return
+      }
+
+      previousFocusRef.current = document.activeElement as HTMLElement | null
+      dispatch({ type: 'START_TOUR', tourId })
+
+      onTourStart?.({
+        type: 'tour_started',
+        tourId,
+        tourName: tour.name,
+        stepIndex: 0,
+        totalSteps: tour.steps.length,
+        timestamp: Date.now(),
+      })
+    },
+    [state.tours, dispatch, debug, onTourStart],
+  )
+
+  const pauseTour = useCallback(() => {
+    dispatch({ type: 'PAUSE_TOUR' })
+  }, [dispatch])
+
+  const resumeTour = useCallback(() => {
+    dispatch({ type: 'RESUME_TOUR' })
+  }, [dispatch])
+
+  const skipTour = useCallback(() => {
+    const tour = getActiveTour(state)
+    if (tour) {
+      onTourSkip?.({
+        type: 'tour_skipped',
+        tourId: tour.id,
+        tourName: tour.name,
+        stepIndex: state.activeTour?.currentStepIndex,
+        totalSteps: tour.steps.length,
+        timestamp: Date.now(),
+      })
+      tour.onSkip?.()
+    }
+    dispatch({ type: 'SKIP_TOUR' })
+    restoreFocus()
+  }, [state, dispatch, onTourSkip])
+
+  const completeTour = useCallback(() => {
+    const tour = getActiveTour(state)
+    if (tour) {
+      onTourComplete?.({
+        type: 'tour_completed',
+        tourId: tour.id,
+        tourName: tour.name,
+        totalSteps: tour.steps.length,
+        timestamp: Date.now(),
+      })
+      tour.onComplete?.()
+    }
+    dispatch({ type: 'COMPLETE_TOUR' })
+    restoreFocus()
+  }, [state, dispatch, onTourComplete])
+
+  const nextStep = useCallback(() => {
+    if (isLastStep(state)) {
+      completeTour()
+    } else {
+      dispatch({ type: 'NEXT_STEP' })
+    }
+  }, [state, dispatch, completeTour])
+
+  const prevStep = useCallback(() => {
+    dispatch({ type: 'PREV_STEP' })
+  }, [dispatch])
+
+  const goToStep = useCallback(
+    (stepIndex: number) => {
+      dispatch({ type: 'NAVIGATE_TO_STEP', stepIndex })
+    },
+    [dispatch],
+  )
+
+  const resetTour = useCallback(
+    (tourId: string) => {
+      dispatch({ type: 'RESET_TOUR', tourId })
+    },
+    [dispatch],
+  )
+
+  const resetAllTours = useCallback(() => {
+    dispatch({ type: 'RESET_ALL' })
+  }, [dispatch])
+
+  const isTourCompleted = useCallback(
+    (tourId: string) => state.completedTours.includes(tourId),
+    [state.completedTours],
+  )
+
+  const isTourActive = useCallback(
+    (tourId: string) => state.activeTour?.tourId === tourId,
+    [state.activeTour],
+  )
+
+  const emitEvent = useCallback(
+    (eventName: string) => {
+      customEventsRef.current.add(eventName)
+      // Re-evaluate triggers after event emission
+      evaluateTriggers()
+    },
+    [], // eslint-disable-line react-hooks/exhaustive-deps
+  )
+
+  function restoreFocus() {
+    if (previousFocusRef.current) {
+      previousFocusRef.current.focus()
+      previousFocusRef.current = null
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Trigger Evaluation
+  // ---------------------------------------------------------------------------
+
+  const evaluateTriggers = useCallback(() => {
+    if (!state.initialized || state.activeTour || !autoStart) return
+
+    const triggerContext: TriggerEvaluationContext = {
+      currentRoute: pathname,
+      visitCount: storage.getVisitCount(),
+      firstVisitDate: storage.getFirstVisitDate(),
+      completedTourIds: state.completedTours,
+      customEvents: customEventsRef.current,
+    }
+
+    const conditionCtx: ConditionContext = {
+      ...externalConditionContext,
+      completedTourIds: state.completedTours,
+      visitCount: storage.getVisitCount(),
+      firstVisitDate: storage.getFirstVisitDate() ?? undefined,
+    }
+
+    // Sort tours by priority (lower number = higher priority)
+    const sortedTours = Object.values(state.tours).sort(
+      (a, b) => (a.priority ?? 999) - (b.priority ?? 999),
+    )
+
+    for (const tour of sortedTours) {
+      if (state.completedTours.includes(tour.id)) continue
+      if (state.skippedTours.includes(tour.id)) continue
+
+      if (shouldTriggerTour(tour, triggerContext)) {
+        if (evaluateConditions(tour.conditions, conditionCtx)) {
+          const delay = tour.trigger.delay ?? autoStartDelay ?? 0
+
+          if (triggerTimeoutRef.current) {
+            clearTimeout(triggerTimeoutRef.current)
+          }
+
+          triggerTimeoutRef.current = setTimeout(() => {
+            startTour(tour.id)
+          }, delay)
+
+          break // Only trigger one tour at a time
+        }
+      }
+    }
+  }, [
+    state.initialized,
+    state.activeTour,
+    state.tours,
+    state.completedTours,
+    state.skippedTours,
+    autoStart,
+    pathname,
+    storage,
+    externalConditionContext,
+    autoStartDelay,
+    startTour,
+  ])
+
+  // Evaluate triggers on init and route change
+  useEffect(() => {
+    evaluateTriggers()
+  }, [evaluateTriggers])
+
+  // ---------------------------------------------------------------------------
+  // Cross-Page Navigation
+  // ---------------------------------------------------------------------------
+
+  useEffect(() => {
+    if (!state.activeTour || state.activeTour.status !== 'active') return
+
+    const activeStep = getActiveStep(state)
+    if (!activeStep?.route) return
+
+    // If step requires a different route, navigate
+    if (activeStep.route !== pathname) {
+      try {
+        router.push(activeStep.route)
+      } catch (err) {
+        if (debug) console.error('[WalkMe] Navigation failed:', err)
+        // Skip to next step on navigation failure
+        dispatch({ type: 'NEXT_STEP' })
+      }
+    }
+  }, [state.activeTour?.currentStepIndex]) // eslint-disable-line react-hooks/exhaustive-deps
+
+  // Wait for target after route change
+  useEffect(() => {
+    if (prevPathRef.current === pathname) return
+    prevPathRef.current = pathname
+
+    if (!state.activeTour || state.activeTour.status !== 'active') return
+
+    const activeStep = getActiveStep(state)
+    if (!activeStep?.target) return
+
+    waitForTarget(activeStep.target, { timeout: 5000 }).then((result) => {
+      if (result.found && result.element) {
+        targetElementRef.current = result.element
+        scrollToElement(result.element)
+      } else if (debug) {
+        console.warn(
+          `[WalkMe] Target "${activeStep.target}" not found after navigation`,
+        )
+      }
+    })
+  }, [pathname]) // eslint-disable-line react-hooks/exhaustive-deps
+
+  // ---------------------------------------------------------------------------
+  // Target Element Resolution
+  // ---------------------------------------------------------------------------
+
+  useEffect(() => {
+    if (!state.activeTour || state.activeTour.status !== 'active') return
+
+    const activeStep = getActiveStep(state)
+    if (!activeStep?.target) {
+      targetElementRef.current = null
+      return
+    }
+
+    // Try finding immediately
+    const result = findTarget(activeStep.target)
+    if (result.found && result.element) {
+      targetElementRef.current = result.element
+      scrollToElement(result.element)
+    } else {
+      // Wait for the element
+      waitForTarget(activeStep.target, { timeout: 5000 }).then((waitResult) => {
+        if (waitResult.found && waitResult.element) {
+          targetElementRef.current = waitResult.element
+          scrollToElement(waitResult.element)
+        } else {
+          targetElementRef.current = null
+          if (debug) {
+            console.warn(
+              `[WalkMe] Target "${activeStep.target}" not found, step may display without anchor`,
+            )
+          }
+        }
+      })
+    }
+  }, [state.activeTour?.currentStepIndex, state.activeTour?.status]) // eslint-disable-line react-hooks/exhaustive-deps
+
+  // ---------------------------------------------------------------------------
+  // Step Change Analytics
+  // ---------------------------------------------------------------------------
+
+  useEffect(() => {
+    if (!state.activeTour || state.activeTour.status !== 'active') return
+
+    const tour = state.tours[state.activeTour.tourId]
+    if (!tour) return
+
+    const activeStep = getActiveStep(state)
+
+    onStepChange?.({
+      type: 'step_changed',
+      tourId: tour.id,
+      tourName: tour.name,
+      stepId: activeStep?.id,
+      stepIndex: state.activeTour.currentStepIndex,
+      totalSteps: tour.steps.length,
+      timestamp: Date.now(),
+    })
+  }, [state.activeTour?.currentStepIndex]) // eslint-disable-line react-hooks/exhaustive-deps
+
+  // ---------------------------------------------------------------------------
+  // Keyboard Navigation
+  // ---------------------------------------------------------------------------
+
+  useEffect(() => {
+    if (!state.activeTour || state.activeTour.status !== 'active') return
+
+    const handleKeyDown = (e: KeyboardEvent) => {
+      switch (e.key) {
+        case 'ArrowRight':
+          e.preventDefault()
+          nextStep()
+          break
+        case 'ArrowLeft':
+          e.preventDefault()
+          prevStep()
+          break
+        case 'Escape':
+          e.preventDefault()
+          skipTour()
+          break
+      }
+    }
+
+    document.addEventListener('keydown', handleKeyDown)
+    return () => document.removeEventListener('keydown', handleKeyDown)
+  }, [state.activeTour, nextStep, prevStep, skipTour])
+
+  // ---------------------------------------------------------------------------
+  // Cleanup
+  // ---------------------------------------------------------------------------
+
+  useEffect(() => {
+    return () => {
+      if (triggerTimeoutRef.current) {
+        clearTimeout(triggerTimeoutRef.current)
+      }
+    }
+  }, [])
+
+  // ---------------------------------------------------------------------------
+  // Context Value
+  // ---------------------------------------------------------------------------
+
+  const contextValue = useMemo<WalkmeContextValue>(
+    () => ({
+      state,
+      startTour,
+      pauseTour,
+      resumeTour,
+      skipTour,
+      completeTour,
+      resetTour,
+      resetAllTours,
+      nextStep,
+      prevStep,
+      goToStep,
+      isTourCompleted,
+      isTourActive,
+      getActiveTour: () => getActiveTour(state),
+      getActiveStep: () => getActiveStep(state),
+      emitEvent,
+    }),
+    [
+      state,
+      startTour,
+      pauseTour,
+      resumeTour,
+      skipTour,
+      completeTour,
+      resetTour,
+      resetAllTours,
+      nextStep,
+      prevStep,
+      goToStep,
+      isTourCompleted,
+      isTourActive,
+      emitEvent,
+    ],
+  )
+
+  // ---------------------------------------------------------------------------
+  // Render
+  // ---------------------------------------------------------------------------
+
+  const activeTour = getActiveTour(state)
+  const activeStep = getActiveStep(state)
+  const showStep = activeTour && activeStep && state.activeTour?.status === 'active'
+
+  // Build screen reader announcement
+  const srAnnouncement = showStep && state.activeTour
+    ? labels.progress
+        .replace('{current}', String(state.activeTour.currentStepIndex + 1))
+        .replace('{total}', String(activeTour!.steps.length))
+      + ': ' + activeStep.title
+    : ''
+
+  return (
+    <WalkmeContext.Provider value={contextValue}>
+      {children}
+
+      {/* Screen reader live region for step announcements */}
+      <div
+        aria-live="polite"
+        aria-atomic="true"
+        className="sr-only"
+        style={{
+          position: 'absolute',
+          width: '1px',
+          height: '1px',
+          padding: 0,
+          margin: '-1px',
+          overflow: 'hidden',
+          clip: 'rect(0, 0, 0, 0)',
+          whiteSpace: 'nowrap',
+          borderWidth: 0,
+        }}
+      >
+        {srAnnouncement}
+      </div>
+
+      {showStep && state.activeTour && (
+        <StepRenderer
+          step={activeStep}
+          targetElement={targetElementRef.current}
+          onNext={nextStep}
+          onPrev={prevStep}
+          onSkip={skipTour}
+          onComplete={completeTour}
+          isFirst={isFirstStep(state)}
+          isLast={isLastStep(state)}
+          currentIndex={state.activeTour.currentStepIndex}
+          totalSteps={activeTour.steps.length}
+          labels={labels}
+        />
+      )}
+    </WalkmeContext.Provider>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Step Renderer (internal)
+// ---------------------------------------------------------------------------
+
+interface StepRendererProps {
+  step: NonNullable<ReturnType<typeof getActiveStep>>
+  targetElement: HTMLElement | null
+  onNext: () => void
+  onPrev: () => void
+  onSkip: () => void
+  onComplete: () => void
+  isFirst: boolean
+  isLast: boolean
+  currentIndex: number
+  totalSteps: number
+  labels: WalkmeLabels
+}
+
+function StepRenderer({
+  step,
+  targetElement,
+  onNext,
+  onPrev,
+  onSkip,
+  onComplete,
+  isFirst,
+  isLast,
+  currentIndex,
+  totalSteps,
+  labels,
+}: StepRendererProps) {
+  const commonProps = {
+    step,
+    onNext,
+    onPrev,
+    onSkip,
+    onComplete,
+    isFirst,
+    isLast,
+    currentIndex,
+    totalSteps,
+    labels,
+  }
+
+  switch (step.type) {
+    case 'modal':
+      return (
+        <>
+          <WalkmeOverlay visible />
+          <WalkmeModal {...commonProps} />
+        </>
+      )
+
+    case 'tooltip':
+      return (
+        <WalkmeTooltip {...commonProps} targetElement={targetElement} />
+      )
+
+    case 'spotlight':
+      return (
+        <WalkmeSpotlight {...commonProps} targetElement={targetElement} />
+      )
+
+    case 'beacon':
+      return (
+        <WalkmeBeacon
+          step={step}
+          targetElement={targetElement}
+          onClick={onNext}
+          labels={labels}
+        />
+      )
+
+    case 'floating':
+      return (
+        <>
+          <WalkmeOverlay visible />
+          <WalkmeModal {...commonProps} />
+        </>
+      )
+
+    default:
+      return null
+  }
+}

--- a/plugins/walkme/components/WalkmeSpotlight.tsx
+++ b/plugins/walkme/components/WalkmeSpotlight.tsx
@@ -89,10 +89,10 @@ export const WalkmeSpotlight = memo(function WalkmeSpotlight({
           style={{
             ...floatingStyles,
             zIndex: 9999,
-            backgroundColor: 'var(--walkme-bg)',
-            color: 'var(--walkme-text)',
-            border: '1px solid var(--walkme-border)',
-            boxShadow: 'var(--walkme-shadow)',
+            backgroundColor: 'var(--walkme-bg, #ffffff)',
+            color: 'var(--walkme-text, #111827)',
+            border: '1px solid var(--walkme-border, #e5e7eb)',
+            boxShadow: 'var(--walkme-shadow, 0 20px 25px -5px rgba(0,0,0,.1), 0 8px 10px -6px rgba(0,0,0,.1))',
             // Hide until floating-ui has stabilized after scroll
             opacity: isStable ? 1 : 0,
             transition: 'opacity 150ms ease-out',
@@ -103,7 +103,7 @@ export const WalkmeSpotlight = memo(function WalkmeSpotlight({
           <p
             id={`walkme-spotlight-content-${step.id}`}
             className="mb-3 text-sm leading-relaxed"
-            style={{ color: 'var(--walkme-text-muted)' }}
+            style={{ color: 'var(--walkme-text-muted, #6b7280)' }}
           >
             {step.content}
           </p>

--- a/plugins/walkme/components/WalkmeSpotlight.tsx
+++ b/plugins/walkme/components/WalkmeSpotlight.tsx
@@ -1,0 +1,123 @@
+'use client'
+
+import { memo, useEffect, useRef } from 'react'
+import { createPortal } from 'react-dom'
+import type { TourStep } from '../types/walkme.types'
+import { useStepPositioning, getPlacementFromPosition } from '../lib/positioning'
+import { WalkmeOverlay } from './WalkmeOverlay'
+import { WalkmeProgress } from './WalkmeProgress'
+import { WalkmeControls } from './WalkmeControls'
+
+interface WalkmeSpotlightProps {
+  step: TourStep
+  targetElement: HTMLElement | null
+  onNext: () => void
+  onPrev: () => void
+  onSkip: () => void
+  onComplete: () => void
+  isFirst: boolean
+  isLast: boolean
+  currentIndex: number
+  totalSteps: number
+  labels?: {
+    next?: string
+    prev?: string
+    skip?: string
+    complete?: string
+    progress?: string
+  }
+}
+
+/**
+ * Spotlight/highlight that illuminates a specific element
+ * with an overlay cutout and a tooltip explanation.
+ */
+export const WalkmeSpotlight = memo(function WalkmeSpotlight({
+  step,
+  targetElement,
+  onNext,
+  onPrev,
+  onSkip,
+  onComplete,
+  isFirst,
+  isLast,
+  currentIndex,
+  totalSteps,
+  labels,
+}: WalkmeSpotlightProps) {
+  const containerRef = useRef<HTMLDivElement>(null)
+
+  const { refs, floatingStyles } = useStepPositioning(targetElement, {
+    placement: getPlacementFromPosition(step.position ?? 'bottom'),
+    offset: 16,
+    padding: 8,
+  })
+
+  useEffect(() => {
+    containerRef.current?.focus()
+  }, [step.id])
+
+  if (typeof window === 'undefined') return null
+
+  return (
+    <>
+      {/* Overlay with cutout around target */}
+      <WalkmeOverlay
+        visible
+        spotlightTarget={targetElement}
+        spotlightPadding={8}
+      />
+
+      {/* Tooltip near the target */}
+      {createPortal(
+        <div
+          ref={(el) => {
+            refs.setFloating(el)
+            ;(containerRef as React.MutableRefObject<HTMLDivElement | null>).current = el
+          }}
+          data-cy="walkme-spotlight"
+          data-walkme
+          role="dialog"
+          aria-label={step.title}
+          aria-describedby={`walkme-spotlight-content-${step.id}`}
+          tabIndex={-1}
+          className="w-80 max-w-[calc(100vw-2rem)] rounded-lg p-4 shadow-lg outline-none animate-in fade-in-0 zoom-in-95 duration-200"
+          style={{
+            ...floatingStyles,
+            zIndex: 9999,
+            backgroundColor: 'var(--walkme-bg, #ffffff)',
+            color: 'var(--walkme-text, #111827)',
+            border: '1px solid var(--walkme-border, #e5e7eb)',
+            boxShadow: 'var(--walkme-shadow, 0 4px 6px -1px rgba(0, 0, 0, 0.1))',
+          }}
+        >
+          <h3 className="mb-1 text-sm font-semibold">{step.title}</h3>
+
+          <p
+            id={`walkme-spotlight-content-${step.id}`}
+            className="mb-3 text-sm"
+            style={{ color: 'var(--walkme-text-muted, #6b7280)' }}
+          >
+            {step.content}
+          </p>
+
+          <div className="mb-3">
+            <WalkmeProgress current={currentIndex} total={totalSteps} progressTemplate={labels?.progress} />
+          </div>
+
+          <WalkmeControls
+            actions={step.actions}
+            onNext={onNext}
+            onPrev={onPrev}
+            onSkip={onSkip}
+            onComplete={onComplete}
+            isFirst={isFirst}
+            isLast={isLast}
+            labels={labels}
+          />
+        </div>,
+        document.body,
+      )}
+    </>
+  )
+})

--- a/plugins/walkme/components/WalkmeTooltip.tsx
+++ b/plugins/walkme/components/WalkmeTooltip.tsx
@@ -1,0 +1,135 @@
+'use client'
+
+import { memo, useEffect, useRef } from 'react'
+import { createPortal } from 'react-dom'
+import type { TourStep } from '../types/walkme.types'
+import { useStepPositioning, getPlacementFromPosition } from '../lib/positioning'
+import { WalkmeProgress } from './WalkmeProgress'
+import { WalkmeControls } from './WalkmeControls'
+
+interface WalkmeTooltipProps {
+  step: TourStep
+  targetElement: HTMLElement | null
+  onNext: () => void
+  onPrev: () => void
+  onSkip: () => void
+  onComplete: () => void
+  isFirst: boolean
+  isLast: boolean
+  currentIndex: number
+  totalSteps: number
+  labels?: {
+    next?: string
+    prev?: string
+    skip?: string
+    complete?: string
+    progress?: string
+  }
+}
+
+/**
+ * Floating tooltip anchored to a target element.
+ * Uses @floating-ui/react for smart positioning.
+ */
+export const WalkmeTooltip = memo(function WalkmeTooltip({
+  step,
+  targetElement,
+  onNext,
+  onPrev,
+  onSkip,
+  onComplete,
+  isFirst,
+  isLast,
+  currentIndex,
+  totalSteps,
+  labels,
+}: WalkmeTooltipProps) {
+  const containerRef = useRef<HTMLDivElement>(null)
+
+  const { refs, floatingStyles, arrowRef, placement } = useStepPositioning(
+    targetElement,
+    {
+      placement: getPlacementFromPosition(step.position ?? 'auto'),
+      offset: 12,
+      padding: 8,
+    },
+  )
+
+  // Focus the tooltip when it appears
+  useEffect(() => {
+    containerRef.current?.focus()
+  }, [step.id])
+
+  if (typeof window === 'undefined') return null
+
+  return createPortal(
+    <div
+      ref={(el) => {
+        refs.setFloating(el)
+        ;(containerRef as React.MutableRefObject<HTMLDivElement | null>).current = el
+      }}
+      data-cy="walkme-tooltip"
+      data-walkme
+      role="dialog"
+      aria-label={step.title}
+      aria-describedby={`walkme-tooltip-content-${step.id}`}
+      tabIndex={-1}
+      className="w-80 max-w-[calc(100vw-2rem)] rounded-lg p-4 shadow-lg outline-none animate-in fade-in-0 zoom-in-95 duration-200"
+      style={{
+        ...floatingStyles,
+        zIndex: 9999,
+        backgroundColor: 'var(--walkme-bg, #ffffff)',
+        color: 'var(--walkme-text, #111827)',
+        border: '1px solid var(--walkme-border, #e5e7eb)',
+        boxShadow: 'var(--walkme-shadow, 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -2px rgba(0, 0, 0, 0.1))',
+      }}
+    >
+      {/* Arrow */}
+      <div
+        ref={arrowRef}
+        className="absolute h-2 w-2 rotate-45"
+        style={{
+          backgroundColor: 'var(--walkme-bg, #ffffff)',
+          border: '1px solid var(--walkme-border, #e5e7eb)',
+          ...(placement.startsWith('bottom')
+            ? { top: -5, borderBottom: 'none', borderRight: 'none' }
+            : placement.startsWith('top')
+              ? { bottom: -5, borderTop: 'none', borderLeft: 'none' }
+              : placement.startsWith('left')
+                ? { right: -5, borderLeft: 'none', borderTop: 'none' }
+                : { left: -5, borderRight: 'none', borderBottom: 'none' }),
+        }}
+      />
+
+      {/* Title */}
+      <h3 className="mb-1 text-sm font-semibold">{step.title}</h3>
+
+      {/* Content */}
+      <p
+        id={`walkme-tooltip-content-${step.id}`}
+        className="mb-3 text-sm"
+        style={{ color: 'var(--walkme-text-muted, #6b7280)' }}
+      >
+        {step.content}
+      </p>
+
+      {/* Progress */}
+      <div className="mb-3">
+        <WalkmeProgress current={currentIndex} total={totalSteps} progressTemplate={labels?.progress} />
+      </div>
+
+      {/* Controls */}
+      <WalkmeControls
+        actions={step.actions}
+        onNext={onNext}
+        onPrev={onPrev}
+        onSkip={onSkip}
+        onComplete={onComplete}
+        isFirst={isFirst}
+        isLast={isLast}
+        labels={labels}
+      />
+    </div>,
+    document.body,
+  )
+})

--- a/plugins/walkme/components/WalkmeTooltip.tsx
+++ b/plugins/walkme/components/WalkmeTooltip.tsx
@@ -30,6 +30,7 @@ interface WalkmeTooltipProps {
 /**
  * Floating tooltip anchored to a target element.
  * Uses @floating-ui/react for smart positioning.
+ * Theme-aware with CSS variables for premium dark/light mode.
  */
 export const WalkmeTooltip = memo(function WalkmeTooltip({
   step,
@@ -46,7 +47,7 @@ export const WalkmeTooltip = memo(function WalkmeTooltip({
 }: WalkmeTooltipProps) {
   const containerRef = useRef<HTMLDivElement>(null)
 
-  const { refs, floatingStyles, arrowRef, placement } = useStepPositioning(
+  const { refs, floatingStyles, arrowRef, placement, isStable } = useStepPositioning(
     targetElement,
     {
       placement: getPlacementFromPosition(step.position ?? 'auto'),
@@ -55,12 +56,13 @@ export const WalkmeTooltip = memo(function WalkmeTooltip({
     },
   )
 
-  // Focus the tooltip when it appears
+  // Focus the tooltip when positioning has stabilized
   useEffect(() => {
-    containerRef.current?.focus()
-  }, [step.id])
+    if (isStable) containerRef.current?.focus()
+  }, [isStable])
 
   if (typeof window === 'undefined') return null
+  if (!targetElement) return null
 
   return createPortal(
     <div
@@ -74,14 +76,17 @@ export const WalkmeTooltip = memo(function WalkmeTooltip({
       aria-label={step.title}
       aria-describedby={`walkme-tooltip-content-${step.id}`}
       tabIndex={-1}
-      className="w-80 max-w-[calc(100vw-2rem)] rounded-lg p-4 shadow-lg outline-none animate-in fade-in-0 zoom-in-95 duration-200"
+      className="w-80 max-w-[calc(100vw-2rem)] rounded-xl p-4 outline-none"
       style={{
         ...floatingStyles,
         zIndex: 9999,
-        backgroundColor: 'var(--walkme-bg, #ffffff)',
-        color: 'var(--walkme-text, #111827)',
-        border: '1px solid var(--walkme-border, #e5e7eb)',
-        boxShadow: 'var(--walkme-shadow, 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -2px rgba(0, 0, 0, 0.1))',
+        backgroundColor: 'var(--walkme-bg)',
+        color: 'var(--walkme-text)',
+        border: '1px solid var(--walkme-border)',
+        boxShadow: 'var(--walkme-shadow)',
+        // Hide until floating-ui has stabilized after scroll
+        opacity: isStable ? 1 : 0,
+        transition: 'opacity 150ms ease-out',
       }}
     >
       {/* Arrow */}
@@ -89,26 +94,19 @@ export const WalkmeTooltip = memo(function WalkmeTooltip({
         ref={arrowRef}
         className="absolute h-2 w-2 rotate-45"
         style={{
-          backgroundColor: 'var(--walkme-bg, #ffffff)',
-          border: '1px solid var(--walkme-border, #e5e7eb)',
-          ...(placement.startsWith('bottom')
-            ? { top: -5, borderBottom: 'none', borderRight: 'none' }
-            : placement.startsWith('top')
-              ? { bottom: -5, borderTop: 'none', borderLeft: 'none' }
-              : placement.startsWith('left')
-                ? { right: -5, borderLeft: 'none', borderTop: 'none' }
-                : { left: -5, borderRight: 'none', borderBottom: 'none' }),
+          backgroundColor: 'var(--walkme-bg)',
+          ...getArrowBorders(placement),
         }}
       />
 
       {/* Title */}
-      <h3 className="mb-1 text-sm font-semibold">{step.title}</h3>
+      <h3 className="mb-1 text-sm font-semibold tracking-tight">{step.title}</h3>
 
       {/* Content */}
       <p
         id={`walkme-tooltip-content-${step.id}`}
-        className="mb-3 text-sm"
-        style={{ color: 'var(--walkme-text-muted, #6b7280)' }}
+        className="mb-3 text-sm leading-relaxed"
+        style={{ color: 'var(--walkme-text-muted)' }}
       >
         {step.content}
       </p>
@@ -133,3 +131,22 @@ export const WalkmeTooltip = memo(function WalkmeTooltip({
     document.body,
   )
 })
+
+/** Build individual border-* styles to avoid mixing shorthand + individual properties */
+function getArrowBorders(placement: string): React.CSSProperties {
+  const b = '1px solid var(--walkme-border)'
+  if (placement.startsWith('bottom')) {
+    // Arrow points up — show top + left borders
+    return { top: -5, borderTop: b, borderLeft: b, borderBottom: 'none', borderRight: 'none' }
+  }
+  if (placement.startsWith('top')) {
+    // Arrow points down — show bottom + right borders
+    return { bottom: -5, borderBottom: b, borderRight: b, borderTop: 'none', borderLeft: 'none' }
+  }
+  if (placement.startsWith('left')) {
+    // Arrow points right — show right + bottom borders
+    return { right: -5, borderRight: b, borderBottom: b, borderTop: 'none', borderLeft: 'none' }
+  }
+  // Arrow points left — show top + left borders
+  return { left: -5, borderTop: b, borderLeft: b, borderBottom: 'none', borderRight: 'none' }
+}

--- a/plugins/walkme/components/WalkmeTooltip.tsx
+++ b/plugins/walkme/components/WalkmeTooltip.tsx
@@ -80,10 +80,10 @@ export const WalkmeTooltip = memo(function WalkmeTooltip({
       style={{
         ...floatingStyles,
         zIndex: 9999,
-        backgroundColor: 'var(--walkme-bg)',
-        color: 'var(--walkme-text)',
-        border: '1px solid var(--walkme-border)',
-        boxShadow: 'var(--walkme-shadow)',
+        backgroundColor: 'var(--walkme-bg, #ffffff)',
+        color: 'var(--walkme-text, #111827)',
+        border: '1px solid var(--walkme-border, #e5e7eb)',
+        boxShadow: 'var(--walkme-shadow, 0 20px 25px -5px rgba(0,0,0,.1), 0 8px 10px -6px rgba(0,0,0,.1))',
         // Hide until floating-ui has stabilized after scroll
         opacity: isStable ? 1 : 0,
         transition: 'opacity 150ms ease-out',
@@ -94,7 +94,7 @@ export const WalkmeTooltip = memo(function WalkmeTooltip({
         ref={arrowRef}
         className="absolute h-2 w-2 rotate-45"
         style={{
-          backgroundColor: 'var(--walkme-bg)',
+          backgroundColor: 'var(--walkme-bg, #ffffff)',
           ...getArrowBorders(placement),
         }}
       />
@@ -106,7 +106,7 @@ export const WalkmeTooltip = memo(function WalkmeTooltip({
       <p
         id={`walkme-tooltip-content-${step.id}`}
         className="mb-3 text-sm leading-relaxed"
-        style={{ color: 'var(--walkme-text-muted)' }}
+        style={{ color: 'var(--walkme-text-muted, #6b7280)' }}
       >
         {step.content}
       </p>
@@ -134,7 +134,7 @@ export const WalkmeTooltip = memo(function WalkmeTooltip({
 
 /** Build individual border-* styles to avoid mixing shorthand + individual properties */
 function getArrowBorders(placement: string): React.CSSProperties {
-  const b = '1px solid var(--walkme-border)'
+  const b = '1px solid var(--walkme-border, #e5e7eb)'
   if (placement.startsWith('bottom')) {
     // Arrow points up — show top + left borders
     return { top: -5, borderTop: b, borderLeft: b, borderBottom: 'none', borderRight: 'none' }

--- a/plugins/walkme/examples/basic-tour.ts
+++ b/plugins/walkme/examples/basic-tour.ts
@@ -1,0 +1,38 @@
+import type { Tour } from '../types/walkme.types'
+
+/**
+ * Basic single-page tour example.
+ * Shows a welcome modal, then highlights sidebar navigation and create button.
+ */
+export const basicTour: Tour = {
+  id: 'getting-started',
+  name: 'Getting Started',
+  description: 'Learn the basics of the application',
+  trigger: { type: 'onFirstVisit', delay: 1000 },
+  steps: [
+    {
+      id: 'welcome',
+      type: 'modal',
+      title: 'Welcome!',
+      content: 'Let us show you around the application. This quick tour will help you get started.',
+      actions: ['next', 'skip'],
+    },
+    {
+      id: 'sidebar',
+      type: 'tooltip',
+      target: '[data-cy="sidebar-nav"]',
+      title: 'Navigation',
+      content: 'Use the sidebar to navigate between different sections of the app.',
+      position: 'right',
+      actions: ['next', 'prev', 'skip'],
+    },
+    {
+      id: 'create-btn',
+      type: 'spotlight',
+      target: '[data-cy="create-button"]',
+      title: 'Create New Item',
+      content: 'Click here to create your first item. Give it a try!',
+      actions: ['complete', 'prev'],
+    },
+  ],
+}

--- a/plugins/walkme/examples/conditional-tour.ts
+++ b/plugins/walkme/examples/conditional-tour.ts
@@ -1,0 +1,56 @@
+import type { Tour } from '../types/walkme.types'
+
+/**
+ * Conditional tour example.
+ * Only shown to users with 'admin' role after they've completed the basic tour.
+ */
+export const adminFeaturesTour: Tour = {
+  id: 'admin-features',
+  name: 'Admin Features',
+  description: 'Tour of admin-only functionality',
+  priority: 10,
+  trigger: {
+    type: 'onRouteEnter',
+    route: '/admin/*',
+    delay: 500,
+  },
+  conditions: {
+    userRole: ['admin', 'superadmin'],
+    completedTours: ['getting-started'],
+    featureFlags: ['admin-panel-v2'],
+  },
+  steps: [
+    {
+      id: 'admin-welcome',
+      type: 'modal',
+      title: 'Admin Dashboard',
+      content: 'Welcome to the admin area. Here are the key features available to you.',
+      actions: ['next', 'skip'],
+    },
+    {
+      id: 'user-management',
+      type: 'tooltip',
+      target: '[data-cy="admin-users"]',
+      title: 'User Management',
+      content: 'Manage all user accounts, roles, and permissions from here.',
+      position: 'right',
+      actions: ['next', 'prev', 'skip'],
+    },
+    {
+      id: 'analytics',
+      type: 'spotlight',
+      target: '[data-cy="admin-analytics"]',
+      title: 'Analytics',
+      content: 'View detailed analytics and reports about app usage.',
+      actions: ['next', 'prev', 'skip'],
+    },
+    {
+      id: 'system-config',
+      type: 'beacon',
+      target: '[data-cy="admin-config"]',
+      title: 'System Configuration',
+      content: 'Advanced system settings are available here.',
+      actions: ['complete'],
+    },
+  ],
+}

--- a/plugins/walkme/examples/cross-window-tour.ts
+++ b/plugins/walkme/examples/cross-window-tour.ts
@@ -1,0 +1,54 @@
+import type { Tour } from '../types/walkme.types'
+
+/**
+ * Cross-window (multi-page) tour example.
+ * Navigates between dashboard and settings pages.
+ */
+export const crossWindowTour: Tour = {
+  id: 'explore-app',
+  name: 'Explore the App',
+  description: 'Tour across multiple pages',
+  trigger: { type: 'manual' },
+  conditions: {
+    completedTours: ['getting-started'],
+  },
+  steps: [
+    {
+      id: 'dashboard-overview',
+      type: 'modal',
+      title: 'Explore the App',
+      content: "Now that you know the basics, let's explore the key areas of the app.",
+      route: '/dashboard',
+      actions: ['next', 'skip'],
+    },
+    {
+      id: 'dashboard-stats',
+      type: 'tooltip',
+      target: '[data-cy="dashboard-stats"]',
+      title: 'Your Stats',
+      content: 'Here you can see your key metrics at a glance.',
+      position: 'bottom',
+      route: '/dashboard',
+      actions: ['next', 'prev', 'skip'],
+    },
+    {
+      id: 'settings-nav',
+      type: 'tooltip',
+      target: '[data-cy="nav-settings"]',
+      title: 'Settings',
+      content: "Let's head to settings to configure your profile.",
+      position: 'right',
+      route: '/dashboard',
+      actions: ['next', 'prev', 'skip'],
+    },
+    {
+      id: 'profile-settings',
+      type: 'spotlight',
+      target: '[data-cy="profile-form"]',
+      title: 'Your Profile',
+      content: 'Complete your profile information to get the most out of the app.',
+      route: '/settings/profile',
+      actions: ['complete', 'prev'],
+    },
+  ],
+}

--- a/plugins/walkme/hooks/useTour.ts
+++ b/plugins/walkme/hooks/useTour.ts
@@ -1,0 +1,52 @@
+'use client'
+
+import { useWalkmeContext } from '../providers/walkme-context'
+
+/**
+ * Hook for accessing the state of a specific tour.
+ *
+ * @param tourId - The ID of the tour to track
+ *
+ * @example
+ * ```tsx
+ * const { isCompleted, progress, start } = useTour('onboarding')
+ *
+ * if (!isCompleted) {
+ *   return <button onClick={start}>Start Onboarding</button>
+ * }
+ * ```
+ */
+export function useTour(tourId: string) {
+  const ctx = useWalkmeContext()
+  const tour = ctx.state.tours[tourId] ?? null
+  const isActive = ctx.state.activeTour?.tourId === tourId
+  const isCompleted = ctx.state.completedTours.includes(tourId)
+  const isSkipped = ctx.state.skippedTours.includes(tourId)
+  const currentStep = isActive ? (ctx.state.activeTour?.currentStepIndex ?? -1) : -1
+  const totalSteps = tour?.steps.length ?? 0
+  const progress =
+    totalSteps > 0 && currentStep >= 0
+      ? Math.round(((currentStep + 1) / totalSteps) * 100)
+      : 0
+
+  return {
+    /** The full tour definition (null if not found) */
+    tour,
+    /** Whether this tour is currently active */
+    isActive,
+    /** Whether this tour has been completed */
+    isCompleted,
+    /** Whether this tour has been skipped */
+    isSkipped,
+    /** Current step index (-1 if not active) */
+    currentStep,
+    /** Total number of steps */
+    totalSteps,
+    /** Progress percentage (0-100) */
+    progress,
+    /** Start this tour */
+    start: () => ctx.startTour(tourId),
+    /** Reset this tour (remove from completed/skipped) */
+    reset: () => ctx.resetTour(tourId),
+  }
+}

--- a/plugins/walkme/hooks/useTourProgress.ts
+++ b/plugins/walkme/hooks/useTourProgress.ts
@@ -1,0 +1,38 @@
+'use client'
+
+import { useWalkmeContext } from '../providers/walkme-context'
+
+/**
+ * Hook for tracking global tour completion progress.
+ *
+ * @example
+ * ```tsx
+ * const { completedTours, totalTours, percentage } = useTourProgress()
+ *
+ * return (
+ *   <div>Onboarding: {percentage}% complete ({completedTours}/{totalTours})</div>
+ * )
+ * ```
+ */
+export function useTourProgress() {
+  const ctx = useWalkmeContext()
+  const totalTours = Object.keys(ctx.state.tours).length
+  const completedTours = ctx.state.completedTours.length
+  const percentage =
+    totalTours > 0 ? Math.round((completedTours / totalTours) * 100) : 0
+
+  return {
+    /** Number of completed tours */
+    completedTours,
+    /** Total number of registered tours */
+    totalTours,
+    /** Completion percentage (0-100) */
+    percentage,
+    /** IDs of completed tours */
+    completedTourIds: ctx.state.completedTours,
+    /** IDs of skipped tours */
+    skippedTourIds: ctx.state.skippedTours,
+    /** Number of remaining tours */
+    remainingTours: totalTours - completedTours,
+  }
+}

--- a/plugins/walkme/hooks/useTourState.ts
+++ b/plugins/walkme/hooks/useTourState.ts
@@ -1,0 +1,111 @@
+'use client'
+
+import { useReducer, useEffect, useRef, useCallback } from 'react'
+import type { Tour, WalkmeState, WalkmeAction } from '../types/walkme.types'
+import { createInitialState, walkmeReducer } from '../lib/core'
+import { createStorageAdapter } from '../lib/storage'
+
+interface UseTourStateOptions {
+  persistState: boolean
+  debug: boolean
+}
+
+/**
+ * Internal hook that manages the core WalkMe state machine.
+ * Handles useReducer, localStorage persistence, and initial state loading.
+ */
+export function useTourState(tours: Tour[], options: UseTourStateOptions) {
+  const { persistState, debug } = options
+  const [state, dispatch] = useReducer(walkmeReducer, createInitialState())
+  const storageRef = useRef(createStorageAdapter())
+  const initialized = useRef(false)
+  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  // Initialize tours and restore persisted state on mount
+  useEffect(() => {
+    if (initialized.current) return
+    initialized.current = true
+
+    // Initialize with tour definitions
+    dispatch({ type: 'INITIALIZE', tours })
+
+    if (debug) {
+      dispatch({ type: 'SET_DEBUG', enabled: true })
+    }
+
+    // Restore persisted state
+    if (persistState) {
+      const storage = storageRef.current
+      const saved = storage.load()
+
+      if (saved) {
+        storage.incrementVisitCount()
+
+        dispatch({
+          type: 'RESTORE_STATE',
+          completedTours: saved.completedTours,
+          skippedTours: saved.skippedTours,
+          tourHistory: saved.tourHistory,
+          activeTour: saved.activeTour,
+        })
+      } else {
+        // First visit - initialize storage
+        storage.incrementVisitCount()
+        storage.setFirstVisitDate(new Date().toISOString())
+      }
+    }
+  }, []) // eslint-disable-line react-hooks/exhaustive-deps
+
+  // Persist state changes to localStorage (debounced)
+  useEffect(() => {
+    if (!persistState || !state.initialized) return
+
+    if (debounceRef.current) {
+      clearTimeout(debounceRef.current)
+    }
+
+    debounceRef.current = setTimeout(() => {
+      const storage = storageRef.current
+      const existing = storage.load()
+
+      storage.save({
+        version: 1,
+        completedTours: state.completedTours,
+        skippedTours: state.skippedTours,
+        activeTour: state.activeTour,
+        tourHistory: state.tourHistory,
+        visitCount: existing?.visitCount ?? 1,
+        firstVisitDate: existing?.firstVisitDate ?? new Date().toISOString(),
+      })
+    }, 100)
+
+    return () => {
+      if (debounceRef.current) {
+        clearTimeout(debounceRef.current)
+      }
+    }
+  }, [
+    persistState,
+    state.initialized,
+    state.completedTours,
+    state.skippedTours,
+    state.activeTour,
+    state.tourHistory,
+  ])
+
+  const stableDispatch = useCallback(
+    (action: WalkmeAction) => {
+      if (debug) {
+        console.log('[WalkMe]', action.type, action)
+      }
+      dispatch(action)
+    },
+    [debug],
+  )
+
+  return {
+    state,
+    dispatch: stableDispatch,
+    storage: storageRef.current,
+  }
+}

--- a/plugins/walkme/hooks/useWalkme.ts
+++ b/plugins/walkme/hooks/useWalkme.ts
@@ -1,0 +1,52 @@
+'use client'
+
+import { useWalkmeContext } from '../providers/walkme-context'
+import { getActiveTour, getActiveStep } from '../lib/core'
+
+/**
+ * Main public hook for controlling WalkMe tours.
+ *
+ * @example
+ * ```tsx
+ * const { startTour, isActive, nextStep } = useWalkme()
+ *
+ * return (
+ *   <button onClick={() => startTour('onboarding')}>
+ *     Start Tour
+ *   </button>
+ * )
+ * ```
+ */
+export function useWalkme() {
+  const ctx = useWalkmeContext()
+
+  return {
+    // Tour control
+    startTour: ctx.startTour,
+    pauseTour: ctx.pauseTour,
+    resumeTour: ctx.resumeTour,
+    skipTour: ctx.skipTour,
+    completeTour: ctx.completeTour,
+    resetTour: ctx.resetTour,
+    resetAllTours: ctx.resetAllTours,
+
+    // Step navigation
+    nextStep: ctx.nextStep,
+    prevStep: ctx.prevStep,
+    goToStep: ctx.goToStep,
+
+    // State queries
+    isActive: ctx.state.activeTour !== null,
+    activeTourId: ctx.state.activeTour?.tourId ?? null,
+    currentStepIndex: ctx.state.activeTour?.currentStepIndex ?? 0,
+
+    // Tour info helpers
+    getActiveTour: () => getActiveTour(ctx.state),
+    getActiveStep: () => getActiveStep(ctx.state),
+    isTourCompleted: ctx.isTourCompleted,
+    isTourActive: ctx.isTourActive,
+
+    // Custom events (for onEvent triggers)
+    emitEvent: ctx.emitEvent,
+  }
+}

--- a/plugins/walkme/jest.config.cjs
+++ b/plugins/walkme/jest.config.cjs
@@ -1,0 +1,27 @@
+/** @type {import('jest').Config} */
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'jsdom',
+  roots: ['<rootDir>/tests'],
+  testMatch: ['**/*.test.ts', '**/*.test.tsx'],
+  moduleNameMapper: {
+    '^~/(.*)$': '<rootDir>/$1',
+  },
+  setupFilesAfterEnv: ['<rootDir>/tests/setup.ts'],
+  transform: {
+    '^.+\\.tsx?$': ['ts-jest', {
+      tsconfig: '<rootDir>/tests/tsconfig.json',
+    }],
+  },
+  transformIgnorePatterns: [
+    '/node_modules/(?!(@floating-ui)/)',
+  ],
+  collectCoverageFrom: [
+    'lib/**/*.{ts,tsx}',
+    'hooks/**/*.{ts,tsx}',
+    '!**/*.d.ts',
+    '!**/index.ts',
+  ],
+  coverageDirectory: 'coverage',
+  verbose: true,
+}

--- a/plugins/walkme/lib/conditions.ts
+++ b/plugins/walkme/lib/conditions.ts
@@ -1,0 +1,113 @@
+/**
+ * WalkMe Conditions Module
+ *
+ * Conditional display evaluation for tours.
+ * All specified conditions must pass (AND logic).
+ */
+
+import type { TourConditions, ConditionContext } from '../types/walkme.types'
+
+// ---------------------------------------------------------------------------
+// Main Evaluation
+// ---------------------------------------------------------------------------
+
+/**
+ * Evaluate all conditions for a tour.
+ * Returns true if no conditions are specified or all conditions pass.
+ * Uses AND logic: every specified condition must be satisfied.
+ */
+export function evaluateConditions(
+  conditions: TourConditions | undefined,
+  context: ConditionContext,
+): boolean {
+  if (!conditions) return true
+
+  // Check user role
+  if (conditions.userRole && conditions.userRole.length > 0) {
+    if (!evaluateRoleCondition(conditions.userRole, context.userRole)) {
+      return false
+    }
+  }
+
+  // Check feature flags
+  if (conditions.featureFlags && conditions.featureFlags.length > 0) {
+    if (
+      !evaluateFeatureFlagCondition(
+        conditions.featureFlags,
+        context.featureFlags ?? [],
+      )
+    ) {
+      return false
+    }
+  }
+
+  // Check completed tours
+  if (conditions.completedTours && conditions.completedTours.length > 0) {
+    if (
+      !evaluateCompletedToursCondition(
+        conditions.completedTours,
+        context.completedTourIds,
+      )
+    ) {
+      return false
+    }
+  }
+
+  // Check not-completed tours
+  if (conditions.notCompletedTours && conditions.notCompletedTours.length > 0) {
+    if (
+      !evaluateNotCompletedCondition(
+        conditions.notCompletedTours,
+        context.completedTourIds,
+      )
+    ) {
+      return false
+    }
+  }
+
+  // Check custom condition
+  if (conditions.custom) {
+    if (!conditions.custom(context)) {
+      return false
+    }
+  }
+
+  return true
+}
+
+// ---------------------------------------------------------------------------
+// Individual Condition Evaluators
+// ---------------------------------------------------------------------------
+
+/** User role must be in the allowed list */
+export function evaluateRoleCondition(
+  roles: string[],
+  userRole: string | undefined,
+): boolean {
+  if (!userRole) return false
+  return roles.includes(userRole)
+}
+
+/** All specified feature flags must be active */
+export function evaluateFeatureFlagCondition(
+  requiredFlags: string[],
+  activeFlags: string[],
+): boolean {
+  return requiredFlags.every((flag) => activeFlags.includes(flag))
+}
+
+/** All specified tours must be completed */
+export function evaluateCompletedToursCondition(
+  requiredTours: string[],
+  completedTourIds: string[],
+): boolean {
+  return requiredTours.every((tourId) => completedTourIds.includes(tourId))
+}
+
+/** None of the specified tours should be completed */
+export function evaluateNotCompletedCondition(
+  excludedTours: string[],
+  completedTourIds: string[],
+): boolean {
+  return !excludedTours.some((tourId) => completedTourIds.includes(tourId))
+}

--- a/plugins/walkme/lib/core.ts
+++ b/plugins/walkme/lib/core.ts
@@ -1,0 +1,308 @@
+/**
+ * WalkMe Core Engine
+ *
+ * Pure-function state machine for managing guided tour state.
+ * All functions are side-effect free and testable without React.
+ */
+
+import type {
+  Tour,
+  TourStep,
+  TourState,
+  WalkmeState,
+  WalkmeAction,
+} from '../types/walkme.types'
+
+// ---------------------------------------------------------------------------
+// Initial State
+// ---------------------------------------------------------------------------
+
+/** Creates a fresh initial WalkmeState */
+export function createInitialState(): WalkmeState {
+  return {
+    tours: {},
+    activeTour: null,
+    completedTours: [],
+    skippedTours: [],
+    tourHistory: {},
+    initialized: false,
+    debug: false,
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Reducer
+// ---------------------------------------------------------------------------
+
+/** Main reducer for the WalkMe state machine */
+export function walkmeReducer(state: WalkmeState, action: WalkmeAction): WalkmeState {
+  switch (action.type) {
+    case 'INITIALIZE': {
+      const tours: Record<string, Tour> = {}
+      for (const tour of action.tours) {
+        tours[tour.id] = tour
+      }
+      return { ...state, tours, initialized: true }
+    }
+
+    case 'START_TOUR': {
+      if (state.activeTour) return state
+      const tour = state.tours[action.tourId]
+      if (!tour) return state
+      if (tour.steps.length === 0) return state
+
+      const tourState: TourState = {
+        tourId: action.tourId,
+        status: 'active',
+        currentStepIndex: 0,
+        startedAt: new Date().toISOString(),
+      }
+
+      return {
+        ...state,
+        activeTour: tourState,
+        tourHistory: { ...state.tourHistory, [action.tourId]: tourState },
+      }
+    }
+
+    case 'NEXT_STEP': {
+      if (!state.activeTour || state.activeTour.status !== 'active') return state
+      const tour = state.tours[state.activeTour.tourId]
+      if (!tour) return state
+
+      const nextIndex = state.activeTour.currentStepIndex + 1
+
+      // If we've passed the last step, complete the tour
+      if (nextIndex >= tour.steps.length) {
+        return completeTourState(state)
+      }
+
+      const updatedTour: TourState = {
+        ...state.activeTour,
+        currentStepIndex: nextIndex,
+      }
+
+      return {
+        ...state,
+        activeTour: updatedTour,
+        tourHistory: { ...state.tourHistory, [updatedTour.tourId]: updatedTour },
+      }
+    }
+
+    case 'PREV_STEP': {
+      if (!state.activeTour || state.activeTour.status !== 'active') return state
+      if (state.activeTour.currentStepIndex <= 0) return state
+
+      const updatedTour: TourState = {
+        ...state.activeTour,
+        currentStepIndex: state.activeTour.currentStepIndex - 1,
+      }
+
+      return {
+        ...state,
+        activeTour: updatedTour,
+        tourHistory: { ...state.tourHistory, [updatedTour.tourId]: updatedTour },
+      }
+    }
+
+    case 'NAVIGATE_TO_STEP': {
+      if (!state.activeTour || state.activeTour.status !== 'active') return state
+      const tour = state.tours[state.activeTour.tourId]
+      if (!tour) return state
+      if (action.stepIndex < 0 || action.stepIndex >= tour.steps.length) return state
+
+      const updatedTour: TourState = {
+        ...state.activeTour,
+        currentStepIndex: action.stepIndex,
+      }
+
+      return {
+        ...state,
+        activeTour: updatedTour,
+        tourHistory: { ...state.tourHistory, [updatedTour.tourId]: updatedTour },
+      }
+    }
+
+    case 'SKIP_TOUR': {
+      if (!state.activeTour) return state
+
+      const tourId = state.activeTour.tourId
+      const skippedState: TourState = {
+        ...state.activeTour,
+        status: 'skipped',
+        skippedAt: new Date().toISOString(),
+      }
+
+      return {
+        ...state,
+        activeTour: null,
+        skippedTours: state.skippedTours.includes(tourId)
+          ? state.skippedTours
+          : [...state.skippedTours, tourId],
+        tourHistory: { ...state.tourHistory, [tourId]: skippedState },
+      }
+    }
+
+    case 'COMPLETE_TOUR': {
+      if (!state.activeTour) return state
+      return completeTourState(state)
+    }
+
+    case 'PAUSE_TOUR': {
+      if (!state.activeTour || state.activeTour.status !== 'active') return state
+
+      const paused: TourState = {
+        ...state.activeTour,
+        status: 'paused',
+      }
+
+      return {
+        ...state,
+        activeTour: paused,
+        tourHistory: { ...state.tourHistory, [paused.tourId]: paused },
+      }
+    }
+
+    case 'RESUME_TOUR': {
+      if (!state.activeTour || state.activeTour.status !== 'paused') return state
+
+      const resumed: TourState = {
+        ...state.activeTour,
+        status: 'active',
+      }
+
+      return {
+        ...state,
+        activeTour: resumed,
+        tourHistory: { ...state.tourHistory, [resumed.tourId]: resumed },
+      }
+    }
+
+    case 'RESET_TOUR': {
+      const { [action.tourId]: _, ...remainingHistory } = state.tourHistory
+
+      return {
+        ...state,
+        activeTour:
+          state.activeTour?.tourId === action.tourId ? null : state.activeTour,
+        completedTours: state.completedTours.filter((id) => id !== action.tourId),
+        skippedTours: state.skippedTours.filter((id) => id !== action.tourId),
+        tourHistory: remainingHistory,
+      }
+    }
+
+    case 'RESET_ALL': {
+      return {
+        ...state,
+        activeTour: null,
+        completedTours: [],
+        skippedTours: [],
+        tourHistory: {},
+      }
+    }
+
+    case 'SET_DEBUG': {
+      return { ...state, debug: action.enabled }
+    }
+
+    case 'RESTORE_STATE': {
+      return {
+        ...state,
+        completedTours: action.completedTours,
+        skippedTours: action.skippedTours,
+        tourHistory: action.tourHistory,
+        activeTour: action.activeTour,
+      }
+    }
+
+    default:
+      return state
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function completeTourState(state: WalkmeState): WalkmeState {
+  if (!state.activeTour) return state
+
+  const tourId = state.activeTour.tourId
+  const completedState: TourState = {
+    ...state.activeTour,
+    status: 'completed',
+    completedAt: new Date().toISOString(),
+  }
+
+  return {
+    ...state,
+    activeTour: null,
+    completedTours: state.completedTours.includes(tourId)
+      ? state.completedTours
+      : [...state.completedTours, tourId],
+    tourHistory: { ...state.tourHistory, [tourId]: completedState },
+  }
+}
+
+/** Check if a tour can be started */
+export function canStartTour(state: WalkmeState, tourId: string): boolean {
+  if (state.activeTour) return false
+  const tour = state.tours[tourId]
+  if (!tour) return false
+  if (tour.steps.length === 0) return false
+  return true
+}
+
+/** Get the full Tour object for the currently active tour */
+export function getActiveTour(state: WalkmeState): Tour | null {
+  if (!state.activeTour) return null
+  return state.tours[state.activeTour.tourId] ?? null
+}
+
+/** Get the current TourStep for the active tour */
+export function getActiveStep(state: WalkmeState): TourStep | null {
+  const tour = getActiveTour(state)
+  if (!tour || !state.activeTour) return null
+  return tour.steps[state.activeTour.currentStepIndex] ?? null
+}
+
+/** Check if the current step is the first step */
+export function isFirstStep(state: WalkmeState): boolean {
+  if (!state.activeTour) return false
+  return state.activeTour.currentStepIndex === 0
+}
+
+/** Check if the current step is the last step */
+export function isLastStep(state: WalkmeState): boolean {
+  if (!state.activeTour) return false
+  const tour = state.tours[state.activeTour.tourId]
+  if (!tour) return false
+  return state.activeTour.currentStepIndex === tour.steps.length - 1
+}
+
+/** Get progress for a specific tour */
+export function getTourProgress(
+  state: WalkmeState,
+  tourId: string,
+): { current: number; total: number; percentage: number } {
+  const tour = state.tours[tourId]
+  if (!tour) return { current: 0, total: 0, percentage: 0 }
+
+  const total = tour.steps.length
+  const isActive = state.activeTour?.tourId === tourId
+  const current = isActive ? state.activeTour!.currentStepIndex + 1 : 0
+  const percentage = total > 0 ? Math.round((current / total) * 100) : 0
+
+  return { current, total, percentage }
+}
+
+/** Get global progress across all tours */
+export function getGlobalProgress(
+  state: WalkmeState,
+): { completed: number; total: number; percentage: number } {
+  const total = Object.keys(state.tours).length
+  const completed = state.completedTours.length
+  const percentage = total > 0 ? Math.round((completed / total) * 100) : 0
+
+  return { completed, total, percentage }
+}

--- a/plugins/walkme/lib/core.ts
+++ b/plugins/walkme/lib/core.ts
@@ -46,7 +46,14 @@ export function walkmeReducer(state: WalkmeState, action: WalkmeAction): WalkmeS
     }
 
     case 'START_TOUR': {
-      if (state.activeTour) return state
+      if (state.activeTour) {
+        if (state.debug) {
+          console.warn(
+            `[WalkMe] Cannot start tour "${action.tourId}" — tour "${state.activeTour.tourId}" is already active. Complete or skip it first.`,
+          )
+        }
+        return state
+      }
       const tour = state.tours[action.tourId]
       if (!tour) return state
       if (tour.steps.length === 0) return state

--- a/plugins/walkme/lib/core.ts
+++ b/plugins/walkme/lib/core.ts
@@ -45,6 +45,14 @@ export function walkmeReducer(state: WalkmeState, action: WalkmeAction): WalkmeS
       return { ...state, tours, initialized: true }
     }
 
+    case 'UPDATE_TOURS': {
+      const tours: Record<string, Tour> = { ...state.tours }
+      for (const tour of action.tours) {
+        tours[tour.id] = tour
+      }
+      return { ...state, tours }
+    }
+
     case 'START_TOUR': {
       if (state.activeTour) {
         if (state.debug) {

--- a/plugins/walkme/lib/plugin-env.ts
+++ b/plugins/walkme/lib/plugin-env.ts
@@ -1,0 +1,87 @@
+/**
+ * WalkMe Plugin Environment Configuration
+ *
+ * Uses centralized plugin environment loader from core.
+ * Provides type-safe access to WalkMe configuration.
+ */
+
+import { getPluginEnv } from '@nextsparkjs/core/lib/plugins/env-loader'
+
+interface WalkmePluginEnvConfig {
+  WALKME_ENABLED?: string
+  WALKME_DEBUG?: string
+  WALKME_AUTO_START?: string
+  WALKME_AUTO_START_DELAY?: string
+  WALKME_PERSIST_STATE?: string
+  WALKME_ANALYTICS_ENABLED?: string
+}
+
+class PluginEnvironment {
+  private static instance: PluginEnvironment
+  private config: WalkmePluginEnvConfig = {}
+  private loaded = false
+
+  private constructor() {
+    this.loadEnvironment()
+  }
+
+  public static getInstance(): PluginEnvironment {
+    if (!PluginEnvironment.instance) {
+      PluginEnvironment.instance = new PluginEnvironment()
+    }
+    return PluginEnvironment.instance
+  }
+
+  private loadEnvironment(forceReload: boolean = false): void {
+    if (this.loaded && !forceReload) return
+
+    try {
+      const env = getPluginEnv('walkme')
+
+      this.config = {
+        WALKME_ENABLED: env.WALKME_ENABLED || 'true',
+        WALKME_DEBUG: env.WALKME_DEBUG || 'false',
+        WALKME_AUTO_START: env.WALKME_AUTO_START || 'true',
+        WALKME_AUTO_START_DELAY: env.WALKME_AUTO_START_DELAY || '1000',
+        WALKME_PERSIST_STATE: env.WALKME_PERSIST_STATE || 'true',
+        WALKME_ANALYTICS_ENABLED: env.WALKME_ANALYTICS_ENABLED || 'false',
+      }
+
+      this.loaded = true
+    } catch (error) {
+      console.error('[WalkMe Plugin] Failed to load environment:', error)
+      this.loaded = true
+    }
+  }
+
+  public isPluginEnabled(): boolean {
+    return this.config.WALKME_ENABLED !== 'false'
+  }
+
+  public isDebugEnabled(): boolean {
+    return this.config.WALKME_DEBUG === 'true'
+  }
+
+  public isAutoStartEnabled(): boolean {
+    return this.config.WALKME_AUTO_START === 'true'
+  }
+
+  public getAutoStartDelay(): number {
+    return parseInt(this.config.WALKME_AUTO_START_DELAY || '1000', 10)
+  }
+
+  public isPersistStateEnabled(): boolean {
+    return this.config.WALKME_PERSIST_STATE !== 'false'
+  }
+
+  public isAnalyticsEnabled(): boolean {
+    return this.config.WALKME_ANALYTICS_ENABLED === 'true'
+  }
+
+  public reload(): void {
+    this.loaded = false
+    this.loadEnvironment(true)
+  }
+}
+
+export const pluginEnv = PluginEnvironment.getInstance()

--- a/plugins/walkme/lib/positioning.ts
+++ b/plugins/walkme/lib/positioning.ts
@@ -135,24 +135,24 @@ export function useStepPositioning(
     // Double rAF ensures any scrollIntoView (even 'instant') has
     // fully reflowed the layout before we hand the element to floating-ui.
     let cancelled = false
-    const rafOuter = requestAnimationFrame(() => {
-      const rafInner = requestAnimationFrame(() => {
+    const rafIds = { outer: 0, inner: 0, stable: 0 }
+
+    rafIds.outer = requestAnimationFrame(() => {
+      rafIds.inner = requestAnimationFrame(() => {
         if (cancelled) return
         refs.setReference(targetElement)
         // One more rAF for floating-ui to compute, then mark stable
-        requestAnimationFrame(() => {
+        rafIds.stable = requestAnimationFrame(() => {
           if (!cancelled) setIsStable(true)
         })
       })
-      // Store inner for cleanup (best-effort)
-      innerRafRef.current = rafInner
     })
-    const innerRafRef = { current: 0 }
 
     return () => {
       cancelled = true
-      cancelAnimationFrame(rafOuter)
-      cancelAnimationFrame(innerRafRef.current)
+      cancelAnimationFrame(rafIds.outer)
+      cancelAnimationFrame(rafIds.inner)
+      cancelAnimationFrame(rafIds.stable)
     }
   }, [targetElement, refs])
 

--- a/plugins/walkme/lib/positioning.ts
+++ b/plugins/walkme/lib/positioning.ts
@@ -1,0 +1,127 @@
+/**
+ * WalkMe Positioning Module
+ *
+ * Wrapper around @floating-ui/react for smart element positioning.
+ * Handles auto-flip, scroll tracking, viewport containment, and arrow placement.
+ */
+
+'use client'
+
+import { useRef } from 'react'
+import {
+  useFloating,
+  autoUpdate,
+  offset,
+  flip,
+  shift,
+  arrow,
+  type Placement,
+} from '@floating-ui/react'
+import type { StepPosition } from '../types/walkme.types'
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface PositionConfig {
+  placement: Placement
+  offset?: number
+  padding?: number
+  fallbackPlacements?: Placement[]
+}
+
+export interface StepPositioningResult {
+  refs: {
+    setReference: (el: HTMLElement | null) => void
+    setFloating: (el: HTMLElement | null) => void
+  }
+  floatingStyles: React.CSSProperties
+  placement: Placement
+  isPositioned: boolean
+  arrowRef: React.RefObject<HTMLDivElement | null>
+  middlewareData: Record<string, unknown>
+}
+
+// ---------------------------------------------------------------------------
+// Utilities
+// ---------------------------------------------------------------------------
+
+/** Map StepPosition to @floating-ui Placement */
+export function getPlacementFromPosition(position: StepPosition): Placement {
+  switch (position) {
+    case 'top':
+      return 'top'
+    case 'bottom':
+      return 'bottom'
+    case 'left':
+      return 'left'
+    case 'right':
+      return 'right'
+    case 'auto':
+    default:
+      return 'bottom'
+  }
+}
+
+/** Get current viewport information */
+export function getViewportInfo(): {
+  width: number
+  height: number
+  scrollX: number
+  scrollY: number
+} {
+  if (typeof window === 'undefined') {
+    return { width: 0, height: 0, scrollX: 0, scrollY: 0 }
+  }
+  return {
+    width: window.innerWidth,
+    height: window.innerHeight,
+    scrollX: window.scrollX,
+    scrollY: window.scrollY,
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Hook
+// ---------------------------------------------------------------------------
+
+/**
+ * Hook for positioning a floating step element relative to a target.
+ * Wraps @floating-ui/react with sensible defaults for WalkMe steps.
+ */
+export function useStepPositioning(
+  targetElement: HTMLElement | null,
+  config: PositionConfig,
+): StepPositioningResult {
+  const arrowRef = useRef<HTMLDivElement>(null)
+
+  const { refs, floatingStyles, placement, isPositioned, middlewareData } =
+    useFloating({
+      placement: config.placement,
+      elements: {
+        reference: targetElement,
+      },
+      whileElementsMounted: autoUpdate,
+      middleware: [
+        offset(config.offset ?? 8),
+        flip({
+          fallbackPlacements: config.fallbackPlacements,
+          padding: config.padding ?? 8,
+        }),
+        shift({ padding: config.padding ?? 8 }),
+        arrow({ element: arrowRef }),
+      ],
+    })
+
+  return {
+    refs: {
+      setReference: refs.setReference,
+      setFloating: refs.setFloating,
+    },
+    floatingStyles,
+    placement,
+    isPositioned,
+    arrowRef,
+    middlewareData,
+  }
+}

--- a/plugins/walkme/lib/storage.ts
+++ b/plugins/walkme/lib/storage.ts
@@ -1,0 +1,197 @@
+/**
+ * WalkMe Storage Module
+ *
+ * localStorage persistence adapter for tour state.
+ * Handles save/load, schema versioning, and graceful SSR fallbacks.
+ */
+
+import type { TourState, StorageSchema } from '../types/walkme.types'
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const STORAGE_KEY = 'walkme-state'
+const STORAGE_VERSION = 1
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface StorageAdapter {
+  load(): StorageSchema | null
+  save(state: StorageSchema): void
+  reset(): void
+  resetTour(tourId: string): void
+  getCompletedTours(): string[]
+  getSkippedTours(): string[]
+  getVisitCount(): number
+  incrementVisitCount(): void
+  getFirstVisitDate(): string | null
+  setFirstVisitDate(date: string): void
+  getActiveTour(): TourState | null
+  setActiveTour(tour: TourState | null): void
+}
+
+// ---------------------------------------------------------------------------
+// Utilities
+// ---------------------------------------------------------------------------
+
+/** Check if localStorage is available */
+export function isStorageAvailable(): boolean {
+  if (typeof window === 'undefined') return false
+  try {
+    const testKey = '__walkme_test__'
+    window.localStorage.setItem(testKey, '1')
+    window.localStorage.removeItem(testKey)
+    return true
+  } catch {
+    return false
+  }
+}
+
+/** Create a default empty storage schema */
+function createDefaultSchema(): StorageSchema {
+  return {
+    version: STORAGE_VERSION,
+    completedTours: [],
+    skippedTours: [],
+    activeTour: null,
+    tourHistory: {},
+    visitCount: 0,
+    firstVisitDate: new Date().toISOString(),
+  }
+}
+
+/** Migrate storage data from older versions */
+export function migrateStorage(data: unknown): StorageSchema {
+  if (!data || typeof data !== 'object') {
+    return createDefaultSchema()
+  }
+
+  const record = data as Record<string, unknown>
+
+  // Version 1 (current) - no migration needed, just validate shape
+  return {
+    version: STORAGE_VERSION,
+    completedTours: Array.isArray(record.completedTours)
+      ? (record.completedTours as string[])
+      : [],
+    skippedTours: Array.isArray(record.skippedTours)
+      ? (record.skippedTours as string[])
+      : [],
+    activeTour: record.activeTour as TourState | null ?? null,
+    tourHistory:
+      (record.tourHistory as Record<string, TourState>) ?? {},
+    visitCount:
+      typeof record.visitCount === 'number' ? record.visitCount : 0,
+    firstVisitDate:
+      typeof record.firstVisitDate === 'string'
+        ? record.firstVisitDate
+        : new Date().toISOString(),
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Factory
+// ---------------------------------------------------------------------------
+
+/** Create a storage adapter backed by localStorage */
+export function createStorageAdapter(): StorageAdapter {
+  const available = isStorageAvailable()
+
+  function read(): StorageSchema {
+    if (!available) return createDefaultSchema()
+
+    try {
+      const raw = window.localStorage.getItem(STORAGE_KEY)
+      if (!raw) return createDefaultSchema()
+
+      const parsed = JSON.parse(raw)
+      return migrateStorage(parsed)
+    } catch {
+      return createDefaultSchema()
+    }
+  }
+
+  function write(schema: StorageSchema): void {
+    if (!available) return
+
+    try {
+      window.localStorage.setItem(STORAGE_KEY, JSON.stringify(schema))
+    } catch {
+      // Storage full or unavailable - silently ignore
+    }
+  }
+
+  return {
+    load(): StorageSchema | null {
+      if (!available) return null
+      return read()
+    },
+
+    save(state: StorageSchema): void {
+      write(state)
+    },
+
+    reset(): void {
+      if (!available) return
+      try {
+        window.localStorage.removeItem(STORAGE_KEY)
+      } catch {
+        // Ignore
+      }
+    },
+
+    resetTour(tourId: string): void {
+      const state = read()
+      state.completedTours = state.completedTours.filter((id) => id !== tourId)
+      state.skippedTours = state.skippedTours.filter((id) => id !== tourId)
+      const { [tourId]: _, ...remainingHistory } = state.tourHistory
+      state.tourHistory = remainingHistory
+      if (state.activeTour?.tourId === tourId) {
+        state.activeTour = null
+      }
+      write(state)
+    },
+
+    getCompletedTours(): string[] {
+      return read().completedTours
+    },
+
+    getSkippedTours(): string[] {
+      return read().skippedTours
+    },
+
+    getVisitCount(): number {
+      return read().visitCount
+    },
+
+    incrementVisitCount(): void {
+      const state = read()
+      state.visitCount += 1
+      write(state)
+    },
+
+    getFirstVisitDate(): string | null {
+      const state = read()
+      return state.firstVisitDate || null
+    },
+
+    setFirstVisitDate(date: string): void {
+      const state = read()
+      state.firstVisitDate = date
+      write(state)
+    },
+
+    getActiveTour(): TourState | null {
+      return read().activeTour
+    },
+
+    setActiveTour(tour: TourState | null): void {
+      const state = read()
+      state.activeTour = tour
+      write(state)
+    },
+  }
+}

--- a/plugins/walkme/lib/storage.ts
+++ b/plugins/walkme/lib/storage.ts
@@ -11,8 +11,13 @@ import type { TourState, StorageSchema } from '../types/walkme.types'
 // Constants
 // ---------------------------------------------------------------------------
 
-const STORAGE_KEY = 'walkme-state'
+const STORAGE_KEY_PREFIX = 'walkme-state'
 const STORAGE_VERSION = 1
+
+/** Build the localStorage key, optionally scoped to a userId */
+function getStorageKey(userId?: string): string {
+  return userId ? `${STORAGE_KEY_PREFIX}-${userId}` : STORAGE_KEY_PREFIX
+}
 
 // ---------------------------------------------------------------------------
 // Types
@@ -96,15 +101,16 @@ export function migrateStorage(data: unknown): StorageSchema {
 // Factory
 // ---------------------------------------------------------------------------
 
-/** Create a storage adapter backed by localStorage */
-export function createStorageAdapter(): StorageAdapter {
+/** Create a storage adapter backed by localStorage, optionally scoped to a user */
+export function createStorageAdapter(userId?: string): StorageAdapter {
   const available = isStorageAvailable()
+  const storageKey = getStorageKey(userId)
 
   function read(): StorageSchema {
     if (!available) return createDefaultSchema()
 
     try {
-      const raw = window.localStorage.getItem(STORAGE_KEY)
+      const raw = window.localStorage.getItem(storageKey)
       if (!raw) return createDefaultSchema()
 
       const parsed = JSON.parse(raw)
@@ -118,7 +124,7 @@ export function createStorageAdapter(): StorageAdapter {
     if (!available) return
 
     try {
-      window.localStorage.setItem(STORAGE_KEY, JSON.stringify(schema))
+      window.localStorage.setItem(storageKey, JSON.stringify(schema))
     } catch {
       // Storage full or unavailable - silently ignore
     }
@@ -137,7 +143,7 @@ export function createStorageAdapter(): StorageAdapter {
     reset(): void {
       if (!available) return
       try {
-        window.localStorage.removeItem(STORAGE_KEY)
+        window.localStorage.removeItem(storageKey)
       } catch {
         // Ignore
       }

--- a/plugins/walkme/lib/targeting.ts
+++ b/plugins/walkme/lib/targeting.ts
@@ -175,7 +175,7 @@ export function scrollToElement(
   if (typeof window === 'undefined') return
 
   element.scrollIntoView({
-    behavior: options.behavior ?? 'smooth',
+    behavior: options.behavior ?? 'instant',
     block: options.block ?? 'center',
   })
 }

--- a/plugins/walkme/lib/targeting.ts
+++ b/plugins/walkme/lib/targeting.ts
@@ -1,0 +1,186 @@
+/**
+ * WalkMe Targeting Module
+ *
+ * DOM element targeting utilities for finding, waiting for,
+ * and interacting with target elements for tour steps.
+ */
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface TargetResult {
+  element: HTMLElement | null
+  found: boolean
+  selector: string
+  method: 'css' | 'data-walkme' | 'data-cy'
+}
+
+export interface WaitForTargetOptions {
+  /** Maximum time to wait in ms (default: 5000) */
+  timeout?: number
+  /** Polling interval in ms (default: 200) */
+  interval?: number
+}
+
+// ---------------------------------------------------------------------------
+// Element Finding
+// ---------------------------------------------------------------------------
+
+/**
+ * Find a target element using various selector strategies.
+ *
+ * Supports:
+ * 1. CSS selectors: `#id`, `.class`, `[attribute="value"]`
+ * 2. Data-walkme attribute shorthand: if selector has no CSS special chars,
+ *    tries `[data-walkme-target="selector"]` first
+ * 3. Data-cy attribute: `[data-cy="value"]`
+ */
+export function findTarget(selector: string): TargetResult {
+  if (typeof window === 'undefined') {
+    return { element: null, found: false, selector, method: 'css' }
+  }
+
+  // Try data-walkme-target first if selector looks like a plain name
+  if (/^[a-zA-Z0-9_-]+$/.test(selector)) {
+    const walkmeEl = document.querySelector<HTMLElement>(
+      `[data-walkme-target="${selector}"]`,
+    )
+    if (walkmeEl) {
+      return { element: walkmeEl, found: true, selector, method: 'data-walkme' }
+    }
+  }
+
+  // Try as CSS selector
+  try {
+    const el = document.querySelector<HTMLElement>(selector)
+    if (el) {
+      const method = selector.includes('data-cy') ? 'data-cy' : 'css'
+      return { element: el, found: true, selector, method }
+    }
+  } catch {
+    // Invalid selector - return not found
+  }
+
+  return { element: null, found: false, selector, method: 'css' }
+}
+
+/**
+ * Wait for a target element to appear in the DOM.
+ * Uses MutationObserver for efficient watching.
+ */
+export function waitForTarget(
+  selector: string,
+  options: WaitForTargetOptions = {},
+): Promise<TargetResult> {
+  const { timeout = 5000, interval = 200 } = options
+
+  return new Promise((resolve) => {
+    // Try immediately first
+    const immediate = findTarget(selector)
+    if (immediate.found) {
+      resolve(immediate)
+      return
+    }
+
+    if (typeof window === 'undefined') {
+      resolve({ element: null, found: false, selector, method: 'css' })
+      return
+    }
+
+    let resolved = false
+    let observer: MutationObserver | null = null
+    let timeoutId: ReturnType<typeof setTimeout> | null = null
+    let intervalId: ReturnType<typeof setInterval> | null = null
+
+    const cleanup = () => {
+      resolved = true
+      observer?.disconnect()
+      if (timeoutId) clearTimeout(timeoutId)
+      if (intervalId) clearInterval(intervalId)
+    }
+
+    // Set up timeout
+    timeoutId = setTimeout(() => {
+      if (!resolved) {
+        cleanup()
+        resolve({ element: null, found: false, selector, method: 'css' })
+      }
+    }, timeout)
+
+    // Poll as a fallback (MutationObserver doesn't catch everything)
+    intervalId = setInterval(() => {
+      if (resolved) return
+      const result = findTarget(selector)
+      if (result.found) {
+        cleanup()
+        resolve(result)
+      }
+    }, interval)
+
+    // MutationObserver for immediate detection
+    observer = new MutationObserver(() => {
+      if (resolved) return
+      const result = findTarget(selector)
+      if (result.found) {
+        cleanup()
+        resolve(result)
+      }
+    })
+
+    observer.observe(document.body, {
+      childList: true,
+      subtree: true,
+      attributes: true,
+      attributeFilter: ['data-walkme-target', 'data-cy', 'id', 'class'],
+    })
+  })
+}
+
+// ---------------------------------------------------------------------------
+// Element Utilities
+// ---------------------------------------------------------------------------
+
+/** Check if an element is visible (not hidden by CSS) */
+export function isElementVisible(element: HTMLElement): boolean {
+  if (typeof window === 'undefined') return false
+
+  const style = window.getComputedStyle(element)
+  return (
+    style.display !== 'none' &&
+    style.visibility !== 'hidden' &&
+    style.opacity !== '0' &&
+    element.offsetParent !== null
+  )
+}
+
+/** Check if an element is within the current viewport */
+export function isElementInViewport(element: HTMLElement): boolean {
+  if (typeof window === 'undefined') return false
+
+  const rect = element.getBoundingClientRect()
+  return (
+    rect.top >= 0 &&
+    rect.left >= 0 &&
+    rect.bottom <= window.innerHeight &&
+    rect.right <= window.innerWidth
+  )
+}
+
+/** Scroll the viewport to make an element visible */
+export function scrollToElement(
+  element: HTMLElement,
+  options: { behavior?: ScrollBehavior; block?: ScrollLogicalPosition } = {},
+): void {
+  if (typeof window === 'undefined') return
+
+  element.scrollIntoView({
+    behavior: options.behavior ?? 'smooth',
+    block: options.block ?? 'center',
+  })
+}
+
+/** Get the bounding rect of an element */
+export function getElementRect(element: HTMLElement): DOMRect {
+  return element.getBoundingClientRect()
+}

--- a/plugins/walkme/lib/triggers.ts
+++ b/plugins/walkme/lib/triggers.ts
@@ -1,0 +1,127 @@
+/**
+ * WalkMe Triggers Module
+ *
+ * Tour trigger evaluation system.
+ * Determines when a tour should be automatically activated.
+ */
+
+import type { Tour, TourTrigger } from '../types/walkme.types'
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface TriggerEvaluationContext {
+  /** Current page route/pathname */
+  currentRoute: string
+  /** Total number of page visits */
+  visitCount: number
+  /** ISO date string of first visit */
+  firstVisitDate: string | null
+  /** IDs of completed tours */
+  completedTourIds: string[]
+  /** Set of custom events that have been emitted */
+  customEvents: Set<string>
+}
+
+// ---------------------------------------------------------------------------
+// Main Evaluation
+// ---------------------------------------------------------------------------
+
+/**
+ * Evaluate whether a tour should be triggered based on its trigger config
+ * and the current context. Does NOT check conditions (that's a separate step).
+ */
+export function shouldTriggerTour(
+  tour: Tour,
+  context: TriggerEvaluationContext,
+): boolean {
+  const { trigger } = tour
+
+  switch (trigger.type) {
+    case 'onFirstVisit':
+      return evaluateOnFirstVisit(trigger, context)
+    case 'onRouteEnter':
+      return evaluateOnRouteEnter(trigger, context)
+    case 'onEvent':
+      return evaluateOnEvent(trigger, context)
+    case 'manual':
+      return false // Manual tours are started programmatically only
+    case 'scheduled':
+      return evaluateScheduled(trigger, context)
+    default:
+      return false
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Individual Trigger Evaluators
+// ---------------------------------------------------------------------------
+
+/** First visit: triggers only when visitCount === 1 */
+export function evaluateOnFirstVisit(
+  _trigger: TourTrigger,
+  context: TriggerEvaluationContext,
+): boolean {
+  return context.visitCount === 1
+}
+
+/** Route enter: triggers when current route matches the trigger's route pattern */
+export function evaluateOnRouteEnter(
+  trigger: TourTrigger,
+  context: TriggerEvaluationContext,
+): boolean {
+  if (!trigger.route) return false
+
+  const pattern = trigger.route
+  const route = context.currentRoute
+
+  // Exact match
+  if (pattern === route) return true
+
+  // Wildcard match: /dashboard/* matches /dashboard/anything
+  if (pattern.endsWith('/*')) {
+    const prefix = pattern.slice(0, -2)
+    return route.startsWith(prefix)
+  }
+
+  // Glob match: /dashboard/** matches /dashboard/a/b/c
+  if (pattern.endsWith('/**')) {
+    const prefix = pattern.slice(0, -3)
+    return route.startsWith(prefix)
+  }
+
+  return false
+}
+
+/** Event trigger: activates when a specific custom event has been emitted */
+export function evaluateOnEvent(
+  trigger: TourTrigger,
+  context: TriggerEvaluationContext,
+): boolean {
+  if (!trigger.event) return false
+  return context.customEvents.has(trigger.event)
+}
+
+/** Scheduled trigger: activates after N visits or N days since first visit */
+export function evaluateScheduled(
+  trigger: TourTrigger,
+  context: TriggerEvaluationContext,
+): boolean {
+  // Check visit-based threshold
+  if (trigger.afterVisits !== undefined) {
+    if (context.visitCount >= trigger.afterVisits) return true
+  }
+
+  // Check day-based threshold
+  if (trigger.afterDays !== undefined && context.firstVisitDate) {
+    const firstVisit = new Date(context.firstVisitDate)
+    const now = new Date()
+    const daysSinceFirstVisit = Math.floor(
+      (now.getTime() - firstVisit.getTime()) / (1000 * 60 * 60 * 24),
+    )
+    if (daysSinceFirstVisit >= trigger.afterDays) return true
+  }
+
+  return false
+}

--- a/plugins/walkme/lib/validation.ts
+++ b/plugins/walkme/lib/validation.ts
@@ -6,7 +6,7 @@
  */
 
 import { z } from 'zod'
-import type { Tour } from '../types/walkme.types'
+import type { Tour, TourStep as TourStepType } from '../types/walkme.types'
 
 // ---------------------------------------------------------------------------
 // Schemas
@@ -79,7 +79,10 @@ export function validateTour(
 ): { valid: boolean; errors?: z.ZodError; tour?: Tour } {
   const result = TourSchema.safeParse(tour)
   if (result.success) {
-    return { valid: true, tour: result.data as unknown as Tour }
+    // Zod's output matches our Tour type structurally; functions (onComplete,
+    // onSkip, beforeShow, afterShow, custom) are validated as z.function() but
+    // their signatures aren't preserved in the inferred type, so we cast once here.
+    return { valid: true, tour: result.data as Tour }
   }
   return { valid: false, errors: result.error }
 }
@@ -94,7 +97,7 @@ export function validateTours(
   for (const tour of tours) {
     const result = TourSchema.safeParse(tour)
     if (result.success) {
-      validTours.push(result.data as unknown as Tour)
+      validTours.push(result.data as Tour)
     } else {
       errors.push(result.error)
     }
@@ -110,10 +113,10 @@ export function validateTours(
 /** Validate a single step configuration */
 export function validateStep(
   step: unknown,
-): { valid: boolean; errors?: z.ZodError } {
+): { valid: boolean; errors?: z.ZodError; step?: TourStepType } {
   const result = TourStepSchema.safeParse(step)
   if (result.success) {
-    return { valid: true }
+    return { valid: true, step: result.data as TourStepType }
   }
   return { valid: false, errors: result.error }
 }

--- a/plugins/walkme/lib/validation.ts
+++ b/plugins/walkme/lib/validation.ts
@@ -1,0 +1,119 @@
+/**
+ * WalkMe Validation Module
+ *
+ * Zod schemas for runtime validation of tour configurations.
+ * Ensures tour definitions are well-formed before they're used.
+ */
+
+import { z } from 'zod'
+import type { Tour } from '../types/walkme.types'
+
+// ---------------------------------------------------------------------------
+// Schemas
+// ---------------------------------------------------------------------------
+
+export const TourTriggerSchema = z.object({
+  type: z.enum(['onFirstVisit', 'onRouteEnter', 'onEvent', 'manual', 'scheduled']),
+  delay: z.number().min(0).optional(),
+  route: z.string().optional(),
+  event: z.string().optional(),
+  afterVisits: z.number().min(1).optional(),
+  afterDays: z.number().min(0).optional(),
+})
+
+export const TourConditionsSchema = z.object({
+  userRole: z.array(z.string()).optional(),
+  featureFlags: z.array(z.string()).optional(),
+  completedTours: z.array(z.string()).optional(),
+  notCompletedTours: z.array(z.string()).optional(),
+  custom: z.function().optional(),
+}).optional()
+
+export const TourStepSchema = z.object({
+  id: z.string().min(1),
+  type: z.enum(['tooltip', 'modal', 'spotlight', 'beacon', 'floating']),
+  title: z.string().min(1),
+  content: z.string(),
+  target: z.string().optional(),
+  route: z.string().optional(),
+  position: z.enum(['top', 'bottom', 'left', 'right', 'auto']).optional(),
+  actions: z.array(z.enum(['next', 'prev', 'skip', 'complete', 'close'])).min(1),
+  delay: z.number().min(0).optional(),
+  autoAdvance: z.number().min(0).optional(),
+  beforeShow: z.function().optional(),
+  afterShow: z.function().optional(),
+}).refine(
+  (step) => {
+    // tooltip, spotlight, and beacon require a target
+    if (['tooltip', 'spotlight', 'beacon'].includes(step.type)) {
+      return !!step.target
+    }
+    return true
+  },
+  {
+    message: 'Steps of type tooltip, spotlight, and beacon require a target selector',
+  },
+)
+
+export const TourSchema = z.object({
+  id: z.string().min(1),
+  name: z.string().min(1),
+  description: z.string().optional(),
+  trigger: TourTriggerSchema,
+  conditions: TourConditionsSchema,
+  steps: z.array(TourStepSchema).min(1),
+  onComplete: z.function().optional(),
+  onSkip: z.function().optional(),
+  priority: z.number().optional(),
+})
+
+export const TourArraySchema = z.array(TourSchema)
+
+// ---------------------------------------------------------------------------
+// Validation Functions
+// ---------------------------------------------------------------------------
+
+/** Validate a single tour configuration */
+export function validateTour(
+  tour: unknown,
+): { valid: boolean; errors?: z.ZodError; tour?: Tour } {
+  const result = TourSchema.safeParse(tour)
+  if (result.success) {
+    return { valid: true, tour: result.data as unknown as Tour }
+  }
+  return { valid: false, errors: result.error }
+}
+
+/** Validate an array of tours, returning only the valid ones */
+export function validateTours(
+  tours: unknown[],
+): { valid: boolean; errors?: z.ZodError[]; validTours: Tour[] } {
+  const validTours: Tour[] = []
+  const errors: z.ZodError[] = []
+
+  for (const tour of tours) {
+    const result = TourSchema.safeParse(tour)
+    if (result.success) {
+      validTours.push(result.data as unknown as Tour)
+    } else {
+      errors.push(result.error)
+    }
+  }
+
+  return {
+    valid: errors.length === 0,
+    errors: errors.length > 0 ? errors : undefined,
+    validTours,
+  }
+}
+
+/** Validate a single step configuration */
+export function validateStep(
+  step: unknown,
+): { valid: boolean; errors?: z.ZodError } {
+  const result = TourStepSchema.safeParse(step)
+  if (result.success) {
+    return { valid: true }
+  }
+  return { valid: false, errors: result.error }
+}

--- a/plugins/walkme/messages/en.json
+++ b/plugins/walkme/messages/en.json
@@ -1,0 +1,21 @@
+{
+  "walkme": {
+    "next": "Next",
+    "prev": "Previous",
+    "skip": "Skip tour",
+    "complete": "Complete",
+    "close": "Close",
+    "progress": "Step {current} of {total}",
+    "tourAvailable": "Tour available",
+    "beaconLabel": "Click to start guided tour",
+    "modalTitle": "Guided Tour",
+    "tooltipLabel": "Tour step",
+    "spotlightLabel": "Highlighted element",
+    "keyboardHint": "Press Arrow Right for next step, Escape to skip",
+    "tourCompleted": "Tour completed!",
+    "tourSkipped": "Tour skipped",
+    "errorTargetNotFound": "Element not found, skipping step",
+    "resumeTour": "Resume tour",
+    "restartTour": "Restart tour"
+  }
+}

--- a/plugins/walkme/messages/es.json
+++ b/plugins/walkme/messages/es.json
@@ -1,0 +1,21 @@
+{
+  "walkme": {
+    "next": "Siguiente",
+    "prev": "Anterior",
+    "skip": "Saltar tour",
+    "complete": "Completar",
+    "close": "Cerrar",
+    "progress": "Paso {current} de {total}",
+    "tourAvailable": "Tour disponible",
+    "beaconLabel": "Haz clic para iniciar el tour guiado",
+    "modalTitle": "Tour Guiado",
+    "tooltipLabel": "Paso del tour",
+    "spotlightLabel": "Elemento destacado",
+    "keyboardHint": "Presiona flecha derecha para siguiente paso, Escape para saltar",
+    "tourCompleted": "Tour completado!",
+    "tourSkipped": "Tour saltado",
+    "errorTargetNotFound": "Elemento no encontrado, saltando paso",
+    "resumeTour": "Reanudar tour",
+    "restartTour": "Reiniciar tour"
+  }
+}

--- a/plugins/walkme/package.json
+++ b/plugins/walkme/package.json
@@ -6,6 +6,7 @@
   "requiredPlugins": [],
   "dependencies": {},
   "peerDependencies": {
+    "@phosphor-icons/react": "^2.0.0",
     "next": "^15.0.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0"

--- a/plugins/walkme/package.json
+++ b/plugins/walkme/package.json
@@ -4,20 +4,11 @@
   "private": false,
   "main": "./plugin.config.ts",
   "requiredPlugins": [],
-  "dependencies": {
-    "@floating-ui/react": "^0.27.0"
-  },
+  "dependencies": {},
   "peerDependencies": {
-    "@nextsparkjs/core": "workspace:*",
     "next": "^15.0.0",
     "react": "^19.0.0",
-    "react-dom": "^19.0.0",
-    "zod": "^4.0.0",
-    "next-intl": "^4.0.0",
-    "lucide-react": "^0.539.0",
-    "class-variance-authority": "^0.7.0",
-    "clsx": "^2.0.0",
-    "tailwind-merge": "^3.0.0"
+    "react-dom": "^19.0.0"
   },
   "nextspark": {
     "type": "plugin",

--- a/plugins/walkme/package.json
+++ b/plugins/walkme/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "@nextsparkjs/plugin-walkme",
+  "version": "1.0.0",
+  "private": false,
+  "main": "./plugin.config.ts",
+  "requiredPlugins": [],
+  "dependencies": {
+    "@floating-ui/react": "^0.27.0"
+  },
+  "peerDependencies": {
+    "@nextsparkjs/core": "workspace:*",
+    "next": "^15.0.0",
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0",
+    "zod": "^4.0.0",
+    "next-intl": "^4.0.0",
+    "lucide-react": "^0.539.0",
+    "class-variance-authority": "^0.7.0",
+    "clsx": "^2.0.0",
+    "tailwind-merge": "^3.0.0"
+  },
+  "nextspark": {
+    "type": "plugin",
+    "name": "walkme"
+  }
+}

--- a/plugins/walkme/plugin.config.ts
+++ b/plugins/walkme/plugin.config.ts
@@ -1,0 +1,26 @@
+/**
+ * WalkMe Plugin Configuration
+ *
+ * Guided tours and onboarding system for NextSpark applications.
+ * Provides declarative tour definitions, multi-step tooltips, modals,
+ * spotlights, beacons, cross-page navigation, and full persistence.
+ */
+
+import type { PluginConfig } from '@nextsparkjs/core/types/plugin'
+
+export const walkmePluginConfig: PluginConfig = {
+  name: 'walkme',
+  displayName: 'WalkMe',
+  version: '1.0.0',
+  description: 'Guided tours and onboarding system for NextSpark applications',
+  enabled: true,
+  dependencies: [],
+  api: {},
+  hooks: {
+    onLoad: async () => {
+      console.log('[WalkMe Plugin] Loaded - guided tours system ready')
+    },
+  },
+}
+
+export default walkmePluginConfig

--- a/plugins/walkme/providers/walkme-context.ts
+++ b/plugins/walkme/providers/walkme-context.ts
@@ -1,0 +1,17 @@
+'use client'
+
+import { createContext, useContext } from 'react'
+import type { WalkmeContextValue } from '../types/walkme.types'
+
+export const WalkmeContext = createContext<WalkmeContextValue | null>(null)
+
+export function useWalkmeContext(): WalkmeContextValue {
+  const context = useContext(WalkmeContext)
+  if (!context) {
+    throw new Error(
+      'useWalkmeContext must be used within a <WalkmeProvider>. ' +
+        'Wrap your app or page with <WalkmeProvider tours={[...]}> to use WalkMe hooks.',
+    )
+  }
+  return context
+}

--- a/plugins/walkme/tests/lib/conditions.test.ts
+++ b/plugins/walkme/tests/lib/conditions.test.ts
@@ -1,0 +1,172 @@
+import type { ConditionContext, TourConditions } from '../../types/walkme.types'
+import {
+  evaluateConditions,
+  evaluateRoleCondition,
+  evaluateFeatureFlagCondition,
+  evaluateCompletedToursCondition,
+  evaluateNotCompletedCondition,
+} from '../../lib/conditions'
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+function createContext(overrides: Partial<ConditionContext> = {}): ConditionContext {
+  return {
+    userRole: 'user',
+    featureFlags: [],
+    completedTourIds: [],
+    visitCount: 1,
+    ...overrides,
+  }
+}
+
+// ---------------------------------------------------------------------------
+// evaluateConditions (integration)
+// ---------------------------------------------------------------------------
+
+describe('evaluateConditions', () => {
+  it('returns true when conditions is undefined', () => {
+    expect(evaluateConditions(undefined, createContext())).toBe(true)
+  })
+
+  it('returns true when conditions is empty object', () => {
+    expect(evaluateConditions({}, createContext())).toBe(true)
+  })
+
+  it('returns true when all conditions pass', () => {
+    const conditions: TourConditions = {
+      userRole: ['admin', 'superadmin'],
+      featureFlags: ['feature-a'],
+      completedTours: ['onboarding'],
+    }
+    const ctx = createContext({
+      userRole: 'admin',
+      featureFlags: ['feature-a', 'feature-b'],
+      completedTourIds: ['onboarding'],
+    })
+    expect(evaluateConditions(conditions, ctx)).toBe(true)
+  })
+
+  it('returns false when role check fails (AND logic)', () => {
+    const conditions: TourConditions = {
+      userRole: ['admin'],
+      featureFlags: ['feature-a'],
+    }
+    const ctx = createContext({
+      userRole: 'user',
+      featureFlags: ['feature-a'],
+    })
+    expect(evaluateConditions(conditions, ctx)).toBe(false)
+  })
+
+  it('returns false when feature flag check fails', () => {
+    const conditions: TourConditions = {
+      featureFlags: ['feature-x'],
+    }
+    const ctx = createContext({ featureFlags: ['feature-y'] })
+    expect(evaluateConditions(conditions, ctx)).toBe(false)
+  })
+
+  it('returns false when completedTours check fails', () => {
+    const conditions: TourConditions = {
+      completedTours: ['required-tour'],
+    }
+    const ctx = createContext({ completedTourIds: [] })
+    expect(evaluateConditions(conditions, ctx)).toBe(false)
+  })
+
+  it('returns false when notCompletedTours check fails', () => {
+    const conditions: TourConditions = {
+      notCompletedTours: ['excluded-tour'],
+    }
+    const ctx = createContext({ completedTourIds: ['excluded-tour'] })
+    expect(evaluateConditions(conditions, ctx)).toBe(false)
+  })
+
+  it('evaluates custom condition function', () => {
+    const conditions: TourConditions = {
+      custom: (ctx) => ctx.visitCount > 3,
+    }
+    expect(evaluateConditions(conditions, createContext({ visitCount: 5 }))).toBe(true)
+    expect(evaluateConditions(conditions, createContext({ visitCount: 1 }))).toBe(false)
+  })
+
+  it('skips empty arrays in conditions', () => {
+    const conditions: TourConditions = {
+      userRole: [],
+      featureFlags: [],
+      completedTours: [],
+      notCompletedTours: [],
+    }
+    expect(evaluateConditions(conditions, createContext())).toBe(true)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// evaluateRoleCondition
+// ---------------------------------------------------------------------------
+
+describe('evaluateRoleCondition', () => {
+  it('returns true when user role is in allowed list', () => {
+    expect(evaluateRoleCondition(['admin', 'editor'], 'admin')).toBe(true)
+  })
+
+  it('returns false when user role is not in allowed list', () => {
+    expect(evaluateRoleCondition(['admin', 'editor'], 'user')).toBe(false)
+  })
+
+  it('returns false when user role is undefined', () => {
+    expect(evaluateRoleCondition(['admin'], undefined)).toBe(false)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// evaluateFeatureFlagCondition
+// ---------------------------------------------------------------------------
+
+describe('evaluateFeatureFlagCondition', () => {
+  it('returns true when all required flags are active', () => {
+    expect(evaluateFeatureFlagCondition(['a', 'b'], ['a', 'b', 'c'])).toBe(true)
+  })
+
+  it('returns false when a required flag is missing', () => {
+    expect(evaluateFeatureFlagCondition(['a', 'b'], ['a'])).toBe(false)
+  })
+
+  it('returns true when required flags is empty', () => {
+    expect(evaluateFeatureFlagCondition([], ['a'])).toBe(true)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// evaluateCompletedToursCondition
+// ---------------------------------------------------------------------------
+
+describe('evaluateCompletedToursCondition', () => {
+  it('returns true when all required tours are completed', () => {
+    expect(evaluateCompletedToursCondition(['t1', 't2'], ['t1', 't2', 't3'])).toBe(true)
+  })
+
+  it('returns false when a required tour is not completed', () => {
+    expect(evaluateCompletedToursCondition(['t1', 't2'], ['t1'])).toBe(false)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// evaluateNotCompletedCondition
+// ---------------------------------------------------------------------------
+
+describe('evaluateNotCompletedCondition', () => {
+  it('returns true when none of the excluded tours are completed', () => {
+    expect(evaluateNotCompletedCondition(['t1', 't2'], ['t3'])).toBe(true)
+  })
+
+  it('returns false when any excluded tour is completed', () => {
+    expect(evaluateNotCompletedCondition(['t1', 't2'], ['t2'])).toBe(false)
+  })
+
+  it('returns true when excluded list is empty', () => {
+    expect(evaluateNotCompletedCondition([], ['t1'])).toBe(true)
+  })
+})

--- a/plugins/walkme/tests/lib/core.test.ts
+++ b/plugins/walkme/tests/lib/core.test.ts
@@ -1,0 +1,514 @@
+import type { Tour, WalkmeState } from '../../types/walkme.types'
+import {
+  createInitialState,
+  walkmeReducer,
+  canStartTour,
+  getActiveTour,
+  getActiveStep,
+  isFirstStep,
+  isLastStep,
+  getTourProgress,
+  getGlobalProgress,
+} from '../../lib/core'
+
+// ---------------------------------------------------------------------------
+// Test Fixtures
+// ---------------------------------------------------------------------------
+
+const mockTour: Tour = {
+  id: 'test-tour',
+  name: 'Test Tour',
+  trigger: { type: 'manual' },
+  steps: [
+    { id: 'step-1', type: 'modal', title: 'Step 1', content: 'First', actions: ['next'] },
+    { id: 'step-2', type: 'tooltip', target: '#el', title: 'Step 2', content: 'Second', actions: ['next', 'prev'] },
+    { id: 'step-3', type: 'spotlight', target: '#el2', title: 'Step 3', content: 'Third', actions: ['complete'] },
+  ],
+}
+
+const emptyTour: Tour = {
+  id: 'empty-tour',
+  name: 'Empty Tour',
+  trigger: { type: 'manual' },
+  steps: [],
+}
+
+function initState(tours: Tour[] = [mockTour]): WalkmeState {
+  return walkmeReducer(createInitialState(), { type: 'INITIALIZE', tours })
+}
+
+function startedState(): WalkmeState {
+  const s = initState()
+  return walkmeReducer(s, { type: 'START_TOUR', tourId: 'test-tour' })
+}
+
+// ---------------------------------------------------------------------------
+// createInitialState
+// ---------------------------------------------------------------------------
+
+describe('createInitialState', () => {
+  it('returns a clean initial state', () => {
+    const state = createInitialState()
+    expect(state.tours).toEqual({})
+    expect(state.activeTour).toBeNull()
+    expect(state.completedTours).toEqual([])
+    expect(state.skippedTours).toEqual([])
+    expect(state.tourHistory).toEqual({})
+    expect(state.initialized).toBe(false)
+    expect(state.debug).toBe(false)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// walkmeReducer - INITIALIZE
+// ---------------------------------------------------------------------------
+
+describe('walkmeReducer INITIALIZE', () => {
+  it('registers tours and sets initialized to true', () => {
+    const state = initState()
+    expect(state.initialized).toBe(true)
+    expect(state.tours['test-tour']).toBeDefined()
+    expect(state.tours['test-tour'].name).toBe('Test Tour')
+  })
+
+  it('handles multiple tours', () => {
+    const state = initState([mockTour, { ...mockTour, id: 'tour-2', name: 'Tour 2' }])
+    expect(Object.keys(state.tours)).toHaveLength(2)
+  })
+
+  it('handles empty tour array', () => {
+    const state = initState([])
+    expect(state.initialized).toBe(true)
+    expect(Object.keys(state.tours)).toHaveLength(0)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// walkmeReducer - START_TOUR
+// ---------------------------------------------------------------------------
+
+describe('walkmeReducer START_TOUR', () => {
+  it('starts a tour and sets activeTour', () => {
+    const state = startedState()
+    expect(state.activeTour).not.toBeNull()
+    expect(state.activeTour!.tourId).toBe('test-tour')
+    expect(state.activeTour!.status).toBe('active')
+    expect(state.activeTour!.currentStepIndex).toBe(0)
+    expect(state.activeTour!.startedAt).toBeTruthy()
+  })
+
+  it('does nothing if a tour is already active', () => {
+    const state = startedState()
+    const state2 = walkmeReducer(state, { type: 'START_TOUR', tourId: 'test-tour' })
+    expect(state2).toBe(state)
+  })
+
+  it('does nothing for unknown tour id', () => {
+    const state = initState()
+    const state2 = walkmeReducer(state, { type: 'START_TOUR', tourId: 'nonexistent' })
+    expect(state2).toBe(state)
+  })
+
+  it('does nothing for empty tours (no steps)', () => {
+    const state = initState([emptyTour])
+    const state2 = walkmeReducer(state, { type: 'START_TOUR', tourId: 'empty-tour' })
+    expect(state2).toBe(state)
+  })
+
+  it('records tour history on start', () => {
+    const state = startedState()
+    expect(state.tourHistory['test-tour']).toBeDefined()
+    expect(state.tourHistory['test-tour'].status).toBe('active')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// walkmeReducer - NEXT_STEP
+// ---------------------------------------------------------------------------
+
+describe('walkmeReducer NEXT_STEP', () => {
+  it('advances the step index', () => {
+    const state = walkmeReducer(startedState(), { type: 'NEXT_STEP' })
+    expect(state.activeTour!.currentStepIndex).toBe(1)
+  })
+
+  it('completes the tour when advancing past last step', () => {
+    let state = startedState()
+    state = walkmeReducer(state, { type: 'NEXT_STEP' }) // → step 1
+    state = walkmeReducer(state, { type: 'NEXT_STEP' }) // → step 2
+    state = walkmeReducer(state, { type: 'NEXT_STEP' }) // → completes
+    expect(state.activeTour).toBeNull()
+    expect(state.completedTours).toContain('test-tour')
+  })
+
+  it('does nothing when no active tour', () => {
+    const state = initState()
+    const state2 = walkmeReducer(state, { type: 'NEXT_STEP' })
+    expect(state2).toBe(state)
+  })
+
+  it('does nothing when tour is paused', () => {
+    let state = startedState()
+    state = walkmeReducer(state, { type: 'PAUSE_TOUR' })
+    const state2 = walkmeReducer(state, { type: 'NEXT_STEP' })
+    expect(state2).toBe(state)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// walkmeReducer - PREV_STEP
+// ---------------------------------------------------------------------------
+
+describe('walkmeReducer PREV_STEP', () => {
+  it('decrements the step index', () => {
+    let state = startedState()
+    state = walkmeReducer(state, { type: 'NEXT_STEP' }) // → step 1
+    state = walkmeReducer(state, { type: 'PREV_STEP' }) // → step 0
+    expect(state.activeTour!.currentStepIndex).toBe(0)
+  })
+
+  it('does nothing at step 0', () => {
+    const state = startedState()
+    const state2 = walkmeReducer(state, { type: 'PREV_STEP' })
+    expect(state2).toBe(state)
+  })
+
+  it('does nothing when no active tour', () => {
+    const state = initState()
+    const state2 = walkmeReducer(state, { type: 'PREV_STEP' })
+    expect(state2).toBe(state)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// walkmeReducer - NAVIGATE_TO_STEP
+// ---------------------------------------------------------------------------
+
+describe('walkmeReducer NAVIGATE_TO_STEP', () => {
+  it('jumps to a specific step', () => {
+    const state = walkmeReducer(startedState(), { type: 'NAVIGATE_TO_STEP', stepIndex: 2 })
+    expect(state.activeTour!.currentStepIndex).toBe(2)
+  })
+
+  it('rejects negative index', () => {
+    const state = startedState()
+    const state2 = walkmeReducer(state, { type: 'NAVIGATE_TO_STEP', stepIndex: -1 })
+    expect(state2).toBe(state)
+  })
+
+  it('rejects out of bounds index', () => {
+    const state = startedState()
+    const state2 = walkmeReducer(state, { type: 'NAVIGATE_TO_STEP', stepIndex: 99 })
+    expect(state2).toBe(state)
+  })
+
+  it('does nothing when no active tour', () => {
+    const state = initState()
+    const state2 = walkmeReducer(state, { type: 'NAVIGATE_TO_STEP', stepIndex: 0 })
+    expect(state2).toBe(state)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// walkmeReducer - SKIP_TOUR
+// ---------------------------------------------------------------------------
+
+describe('walkmeReducer SKIP_TOUR', () => {
+  it('skips the active tour', () => {
+    const state = walkmeReducer(startedState(), { type: 'SKIP_TOUR' })
+    expect(state.activeTour).toBeNull()
+    expect(state.skippedTours).toContain('test-tour')
+    expect(state.tourHistory['test-tour'].status).toBe('skipped')
+  })
+
+  it('does not duplicate in skippedTours', () => {
+    let state = startedState()
+    state = walkmeReducer(state, { type: 'SKIP_TOUR' })
+    // Start and skip again
+    state = walkmeReducer(state, { type: 'START_TOUR', tourId: 'test-tour' })
+    state = walkmeReducer(state, { type: 'SKIP_TOUR' })
+    expect(state.skippedTours.filter((id) => id === 'test-tour')).toHaveLength(1)
+  })
+
+  it('does nothing when no active tour', () => {
+    const state = initState()
+    const state2 = walkmeReducer(state, { type: 'SKIP_TOUR' })
+    expect(state2).toBe(state)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// walkmeReducer - COMPLETE_TOUR
+// ---------------------------------------------------------------------------
+
+describe('walkmeReducer COMPLETE_TOUR', () => {
+  it('completes the active tour', () => {
+    const state = walkmeReducer(startedState(), { type: 'COMPLETE_TOUR' })
+    expect(state.activeTour).toBeNull()
+    expect(state.completedTours).toContain('test-tour')
+    expect(state.tourHistory['test-tour'].status).toBe('completed')
+  })
+
+  it('does not duplicate in completedTours', () => {
+    let state = startedState()
+    state = walkmeReducer(state, { type: 'COMPLETE_TOUR' })
+    state = walkmeReducer(state, { type: 'START_TOUR', tourId: 'test-tour' })
+    state = walkmeReducer(state, { type: 'COMPLETE_TOUR' })
+    expect(state.completedTours.filter((id) => id === 'test-tour')).toHaveLength(1)
+  })
+
+  it('does nothing when no active tour', () => {
+    const state = initState()
+    const state2 = walkmeReducer(state, { type: 'COMPLETE_TOUR' })
+    expect(state2).toBe(state)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// walkmeReducer - PAUSE/RESUME
+// ---------------------------------------------------------------------------
+
+describe('walkmeReducer PAUSE_TOUR / RESUME_TOUR', () => {
+  it('pauses an active tour', () => {
+    const state = walkmeReducer(startedState(), { type: 'PAUSE_TOUR' })
+    expect(state.activeTour!.status).toBe('paused')
+  })
+
+  it('resumes a paused tour', () => {
+    let state = walkmeReducer(startedState(), { type: 'PAUSE_TOUR' })
+    state = walkmeReducer(state, { type: 'RESUME_TOUR' })
+    expect(state.activeTour!.status).toBe('active')
+  })
+
+  it('pause does nothing when already paused', () => {
+    let state = walkmeReducer(startedState(), { type: 'PAUSE_TOUR' })
+    const state2 = walkmeReducer(state, { type: 'PAUSE_TOUR' })
+    expect(state2).toBe(state)
+  })
+
+  it('resume does nothing when not paused', () => {
+    const state = startedState()
+    const state2 = walkmeReducer(state, { type: 'RESUME_TOUR' })
+    expect(state2).toBe(state)
+  })
+
+  it('pause does nothing when no active tour', () => {
+    const state = initState()
+    const state2 = walkmeReducer(state, { type: 'PAUSE_TOUR' })
+    expect(state2).toBe(state)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// walkmeReducer - RESET_TOUR
+// ---------------------------------------------------------------------------
+
+describe('walkmeReducer RESET_TOUR', () => {
+  it('resets a specific tour from completed', () => {
+    let state = startedState()
+    state = walkmeReducer(state, { type: 'COMPLETE_TOUR' })
+    state = walkmeReducer(state, { type: 'RESET_TOUR', tourId: 'test-tour' })
+    expect(state.completedTours).not.toContain('test-tour')
+    expect(state.tourHistory['test-tour']).toBeUndefined()
+  })
+
+  it('resets a specific tour from skipped', () => {
+    let state = startedState()
+    state = walkmeReducer(state, { type: 'SKIP_TOUR' })
+    state = walkmeReducer(state, { type: 'RESET_TOUR', tourId: 'test-tour' })
+    expect(state.skippedTours).not.toContain('test-tour')
+  })
+
+  it('clears activeTour if it matches the tour being reset', () => {
+    const state = walkmeReducer(startedState(), { type: 'RESET_TOUR', tourId: 'test-tour' })
+    expect(state.activeTour).toBeNull()
+  })
+
+  it('does not clear activeTour if it does not match', () => {
+    const state = walkmeReducer(startedState(), { type: 'RESET_TOUR', tourId: 'some-other-tour' })
+    expect(state.activeTour).not.toBeNull()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// walkmeReducer - RESET_ALL
+// ---------------------------------------------------------------------------
+
+describe('walkmeReducer RESET_ALL', () => {
+  it('resets all state', () => {
+    let state = startedState()
+    state = walkmeReducer(state, { type: 'COMPLETE_TOUR' })
+    state = walkmeReducer(state, { type: 'RESET_ALL' })
+    expect(state.activeTour).toBeNull()
+    expect(state.completedTours).toEqual([])
+    expect(state.skippedTours).toEqual([])
+    expect(state.tourHistory).toEqual({})
+    // tours and initialized should still be set
+    expect(state.tours['test-tour']).toBeDefined()
+    expect(state.initialized).toBe(true)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// walkmeReducer - SET_DEBUG
+// ---------------------------------------------------------------------------
+
+describe('walkmeReducer SET_DEBUG', () => {
+  it('enables debug mode', () => {
+    const state = walkmeReducer(createInitialState(), { type: 'SET_DEBUG', enabled: true })
+    expect(state.debug).toBe(true)
+  })
+
+  it('disables debug mode', () => {
+    let state = walkmeReducer(createInitialState(), { type: 'SET_DEBUG', enabled: true })
+    state = walkmeReducer(state, { type: 'SET_DEBUG', enabled: false })
+    expect(state.debug).toBe(false)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// walkmeReducer - RESTORE_STATE
+// ---------------------------------------------------------------------------
+
+describe('walkmeReducer RESTORE_STATE', () => {
+  it('restores persisted state', () => {
+    const state = walkmeReducer(initState(), {
+      type: 'RESTORE_STATE',
+      completedTours: ['tour-a'],
+      skippedTours: ['tour-b'],
+      tourHistory: {},
+      activeTour: null,
+    })
+    expect(state.completedTours).toEqual(['tour-a'])
+    expect(state.skippedTours).toEqual(['tour-b'])
+  })
+})
+
+// ---------------------------------------------------------------------------
+// walkmeReducer - unknown action
+// ---------------------------------------------------------------------------
+
+describe('walkmeReducer unknown action', () => {
+  it('returns state unchanged for unknown action type', () => {
+    const state = initState()
+    const state2 = walkmeReducer(state, { type: 'UNKNOWN' } as any)
+    expect(state2).toBe(state)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Helper functions
+// ---------------------------------------------------------------------------
+
+describe('canStartTour', () => {
+  it('returns true when tour exists and no active tour', () => {
+    expect(canStartTour(initState(), 'test-tour')).toBe(true)
+  })
+
+  it('returns false when a tour is already active', () => {
+    expect(canStartTour(startedState(), 'test-tour')).toBe(false)
+  })
+
+  it('returns false for unknown tour id', () => {
+    expect(canStartTour(initState(), 'nonexistent')).toBe(false)
+  })
+
+  it('returns false for empty tour (no steps)', () => {
+    expect(canStartTour(initState([emptyTour]), 'empty-tour')).toBe(false)
+  })
+})
+
+describe('getActiveTour', () => {
+  it('returns the active Tour object', () => {
+    const tour = getActiveTour(startedState())
+    expect(tour).not.toBeNull()
+    expect(tour!.id).toBe('test-tour')
+  })
+
+  it('returns null when no active tour', () => {
+    expect(getActiveTour(initState())).toBeNull()
+  })
+})
+
+describe('getActiveStep', () => {
+  it('returns the current step', () => {
+    const step = getActiveStep(startedState())
+    expect(step).not.toBeNull()
+    expect(step!.id).toBe('step-1')
+  })
+
+  it('returns null when no active tour', () => {
+    expect(getActiveStep(initState())).toBeNull()
+  })
+})
+
+describe('isFirstStep', () => {
+  it('returns true at step 0', () => {
+    expect(isFirstStep(startedState())).toBe(true)
+  })
+
+  it('returns false at step > 0', () => {
+    const state = walkmeReducer(startedState(), { type: 'NEXT_STEP' })
+    expect(isFirstStep(state)).toBe(false)
+  })
+
+  it('returns false when no active tour', () => {
+    expect(isFirstStep(initState())).toBe(false)
+  })
+})
+
+describe('isLastStep', () => {
+  it('returns false at step 0 with 3 steps', () => {
+    expect(isLastStep(startedState())).toBe(false)
+  })
+
+  it('returns true at last step', () => {
+    let state = startedState()
+    state = walkmeReducer(state, { type: 'NEXT_STEP' })
+    state = walkmeReducer(state, { type: 'NEXT_STEP' })
+    expect(isLastStep(state)).toBe(true)
+  })
+
+  it('returns false when no active tour', () => {
+    expect(isLastStep(initState())).toBe(false)
+  })
+})
+
+describe('getTourProgress', () => {
+  it('returns progress for active tour', () => {
+    const progress = getTourProgress(startedState(), 'test-tour')
+    expect(progress.current).toBe(1)
+    expect(progress.total).toBe(3)
+    expect(progress.percentage).toBe(33)
+  })
+
+  it('returns 0 progress for non-active tour', () => {
+    const progress = getTourProgress(initState(), 'test-tour')
+    expect(progress.current).toBe(0)
+    expect(progress.total).toBe(3)
+    expect(progress.percentage).toBe(0)
+  })
+
+  it('returns zero for unknown tour', () => {
+    const progress = getTourProgress(initState(), 'nonexistent')
+    expect(progress).toEqual({ current: 0, total: 0, percentage: 0 })
+  })
+})
+
+describe('getGlobalProgress', () => {
+  it('returns 0% when no tours completed', () => {
+    const progress = getGlobalProgress(initState())
+    expect(progress.completed).toBe(0)
+    expect(progress.total).toBe(1)
+    expect(progress.percentage).toBe(0)
+  })
+
+  it('returns 100% when all tours completed', () => {
+    let state = startedState()
+    state = walkmeReducer(state, { type: 'COMPLETE_TOUR' })
+    const progress = getGlobalProgress(state)
+    expect(progress.completed).toBe(1)
+    expect(progress.total).toBe(1)
+    expect(progress.percentage).toBe(100)
+  })
+})

--- a/plugins/walkme/tests/lib/positioning.test.ts
+++ b/plugins/walkme/tests/lib/positioning.test.ts
@@ -1,0 +1,43 @@
+import { getPlacementFromPosition, getViewportInfo } from '../../lib/positioning'
+
+// ---------------------------------------------------------------------------
+// getPlacementFromPosition
+// ---------------------------------------------------------------------------
+
+describe('getPlacementFromPosition', () => {
+  it('maps "top" to "top"', () => {
+    expect(getPlacementFromPosition('top')).toBe('top')
+  })
+
+  it('maps "bottom" to "bottom"', () => {
+    expect(getPlacementFromPosition('bottom')).toBe('bottom')
+  })
+
+  it('maps "left" to "left"', () => {
+    expect(getPlacementFromPosition('left')).toBe('left')
+  })
+
+  it('maps "right" to "right"', () => {
+    expect(getPlacementFromPosition('right')).toBe('right')
+  })
+
+  it('maps "auto" to "bottom" (default)', () => {
+    expect(getPlacementFromPosition('auto')).toBe('bottom')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// getViewportInfo
+// ---------------------------------------------------------------------------
+
+describe('getViewportInfo', () => {
+  it('returns viewport dimensions from window', () => {
+    const info = getViewportInfo()
+    expect(info).toHaveProperty('width')
+    expect(info).toHaveProperty('height')
+    expect(info).toHaveProperty('scrollX')
+    expect(info).toHaveProperty('scrollY')
+    expect(typeof info.width).toBe('number')
+    expect(typeof info.height).toBe('number')
+  })
+})

--- a/plugins/walkme/tests/lib/storage.test.ts
+++ b/plugins/walkme/tests/lib/storage.test.ts
@@ -1,0 +1,232 @@
+import {
+  isStorageAvailable,
+  migrateStorage,
+  createStorageAdapter,
+} from '../../lib/storage'
+
+// ---------------------------------------------------------------------------
+// isStorageAvailable
+// ---------------------------------------------------------------------------
+
+describe('isStorageAvailable', () => {
+  it('returns true when localStorage is available', () => {
+    expect(isStorageAvailable()).toBe(true)
+  })
+
+  it('returns false when localStorage throws', () => {
+    const original = window.localStorage.setItem
+    ;(window.localStorage.setItem as jest.Mock).mockImplementationOnce(() => {
+      throw new Error('Storage disabled')
+    })
+    expect(isStorageAvailable()).toBe(false)
+    window.localStorage.setItem = original
+  })
+})
+
+// ---------------------------------------------------------------------------
+// migrateStorage
+// ---------------------------------------------------------------------------
+
+describe('migrateStorage', () => {
+  it('returns default schema for null input', () => {
+    const result = migrateStorage(null)
+    expect(result.version).toBe(1)
+    expect(result.completedTours).toEqual([])
+    expect(result.skippedTours).toEqual([])
+    expect(result.activeTour).toBeNull()
+    expect(result.tourHistory).toEqual({})
+    expect(result.visitCount).toBe(0)
+    expect(result.firstVisitDate).toBeTruthy()
+  })
+
+  it('returns default schema for non-object input', () => {
+    const result = migrateStorage('invalid')
+    expect(result.version).toBe(1)
+    expect(result.completedTours).toEqual([])
+  })
+
+  it('preserves valid data during migration', () => {
+    const result = migrateStorage({
+      completedTours: ['tour-a', 'tour-b'],
+      skippedTours: ['tour-c'],
+      visitCount: 5,
+      firstVisitDate: '2024-01-01T00:00:00.000Z',
+    })
+    expect(result.completedTours).toEqual(['tour-a', 'tour-b'])
+    expect(result.skippedTours).toEqual(['tour-c'])
+    expect(result.visitCount).toBe(5)
+    expect(result.firstVisitDate).toBe('2024-01-01T00:00:00.000Z')
+  })
+
+  it('handles missing fields gracefully', () => {
+    const result = migrateStorage({})
+    expect(result.completedTours).toEqual([])
+    expect(result.skippedTours).toEqual([])
+    expect(result.visitCount).toBe(0)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// createStorageAdapter
+// ---------------------------------------------------------------------------
+
+describe('createStorageAdapter', () => {
+  let adapter: ReturnType<typeof createStorageAdapter>
+
+  beforeEach(() => {
+    adapter = createStorageAdapter()
+  })
+
+  describe('load / save', () => {
+    it('returns null on first load (no data)', () => {
+      // localStorage starts empty in our mock, but load still creates a schema
+      // because the adapter calls read() which returns default
+      const data = adapter.load()
+      // load returns null if localStorage has nothing, but read() creates default
+      // Actually looking at the code: load returns read() which creates default if no raw data
+      expect(data).toBeDefined()
+      expect(data!.completedTours).toEqual([])
+    })
+
+    it('saves and loads state correctly', () => {
+      const schema = {
+        version: 1,
+        completedTours: ['tour-1'],
+        skippedTours: [],
+        activeTour: null,
+        tourHistory: {},
+        visitCount: 3,
+        firstVisitDate: '2024-01-01T00:00:00.000Z',
+      }
+      adapter.save(schema)
+      const loaded = adapter.load()
+      expect(loaded!.completedTours).toEqual(['tour-1'])
+      expect(loaded!.visitCount).toBe(3)
+    })
+  })
+
+  describe('reset', () => {
+    it('clears all stored data', () => {
+      adapter.save({
+        version: 1,
+        completedTours: ['tour-1'],
+        skippedTours: [],
+        activeTour: null,
+        tourHistory: {},
+        visitCount: 1,
+        firstVisitDate: '2024-01-01T00:00:00.000Z',
+      })
+      adapter.reset()
+      // After reset, load should return fresh default data
+      const loaded = adapter.load()
+      expect(loaded!.completedTours).toEqual([])
+    })
+  })
+
+  describe('resetTour', () => {
+    it('removes a specific tour from completed/skipped', () => {
+      adapter.save({
+        version: 1,
+        completedTours: ['tour-a', 'tour-b'],
+        skippedTours: ['tour-a'],
+        activeTour: null,
+        tourHistory: {
+          'tour-a': { tourId: 'tour-a', status: 'completed', currentStepIndex: 0, startedAt: '' },
+        },
+        visitCount: 1,
+        firstVisitDate: '2024-01-01T00:00:00.000Z',
+      })
+
+      adapter.resetTour('tour-a')
+      const loaded = adapter.load()
+      expect(loaded!.completedTours).toEqual(['tour-b'])
+      expect(loaded!.skippedTours).toEqual([])
+      expect(loaded!.tourHistory['tour-a']).toBeUndefined()
+    })
+
+    it('clears activeTour if it matches', () => {
+      adapter.save({
+        version: 1,
+        completedTours: [],
+        skippedTours: [],
+        activeTour: { tourId: 'tour-x', status: 'active', currentStepIndex: 0, startedAt: '' },
+        tourHistory: {},
+        visitCount: 1,
+        firstVisitDate: '2024-01-01T00:00:00.000Z',
+      })
+
+      adapter.resetTour('tour-x')
+      const loaded = adapter.load()
+      expect(loaded!.activeTour).toBeNull()
+    })
+  })
+
+  describe('getCompletedTours / getSkippedTours', () => {
+    it('returns empty arrays by default', () => {
+      expect(adapter.getCompletedTours()).toEqual([])
+      expect(adapter.getSkippedTours()).toEqual([])
+    })
+
+    it('returns stored values', () => {
+      adapter.save({
+        version: 1,
+        completedTours: ['a'],
+        skippedTours: ['b'],
+        activeTour: null,
+        tourHistory: {},
+        visitCount: 0,
+        firstVisitDate: '2024-01-01T00:00:00.000Z',
+      })
+      expect(adapter.getCompletedTours()).toEqual(['a'])
+      expect(adapter.getSkippedTours()).toEqual(['b'])
+    })
+  })
+
+  describe('visitCount', () => {
+    it('starts at 0', () => {
+      expect(adapter.getVisitCount()).toBe(0)
+    })
+
+    it('increments visit count', () => {
+      adapter.incrementVisitCount()
+      expect(adapter.getVisitCount()).toBe(1)
+      adapter.incrementVisitCount()
+      expect(adapter.getVisitCount()).toBe(2)
+    })
+  })
+
+  describe('firstVisitDate', () => {
+    it('returns a date string by default', () => {
+      // The default schema sets firstVisitDate to now
+      const date = adapter.getFirstVisitDate()
+      expect(date).toBeTruthy()
+    })
+
+    it('sets and gets first visit date', () => {
+      adapter.setFirstVisitDate('2025-06-01T00:00:00.000Z')
+      expect(adapter.getFirstVisitDate()).toBe('2025-06-01T00:00:00.000Z')
+    })
+  })
+
+  describe('activeTour', () => {
+    it('returns null by default', () => {
+      expect(adapter.getActiveTour()).toBeNull()
+    })
+
+    it('sets and gets active tour', () => {
+      const tour = { tourId: 'tour-1', status: 'active' as const, currentStepIndex: 2, startedAt: '2024-01-01T00:00:00.000Z' }
+      adapter.setActiveTour(tour)
+      const loaded = adapter.getActiveTour()
+      expect(loaded).not.toBeNull()
+      expect(loaded!.tourId).toBe('tour-1')
+      expect(loaded!.currentStepIndex).toBe(2)
+    })
+
+    it('clears active tour with null', () => {
+      const tour = { tourId: 'tour-1', status: 'active' as const, currentStepIndex: 0, startedAt: '' }
+      adapter.setActiveTour(tour)
+      adapter.setActiveTour(null)
+      expect(adapter.getActiveTour()).toBeNull()
+    })
+  })
+})

--- a/plugins/walkme/tests/lib/targeting.test.ts
+++ b/plugins/walkme/tests/lib/targeting.test.ts
@@ -1,0 +1,191 @@
+import {
+  findTarget,
+  waitForTarget,
+  isElementVisible,
+  isElementInViewport,
+  scrollToElement,
+  getElementRect,
+} from '../../lib/targeting'
+
+// ---------------------------------------------------------------------------
+// findTarget
+// ---------------------------------------------------------------------------
+
+describe('findTarget', () => {
+  afterEach(() => {
+    document.body.innerHTML = ''
+  })
+
+  it('finds element by data-walkme-target for plain name selectors', () => {
+    const el = document.createElement('div')
+    el.setAttribute('data-walkme-target', 'my-target')
+    document.body.appendChild(el)
+
+    const result = findTarget('my-target')
+    expect(result.found).toBe(true)
+    expect(result.element).toBe(el)
+    expect(result.method).toBe('data-walkme')
+  })
+
+  it('finds element by CSS selector', () => {
+    const el = document.createElement('div')
+    el.id = 'my-element'
+    document.body.appendChild(el)
+
+    const result = findTarget('#my-element')
+    expect(result.found).toBe(true)
+    expect(result.element).toBe(el)
+    expect(result.method).toBe('css')
+  })
+
+  it('finds element by data-cy attribute', () => {
+    const el = document.createElement('button')
+    el.setAttribute('data-cy', 'create-button')
+    document.body.appendChild(el)
+
+    const result = findTarget('[data-cy="create-button"]')
+    expect(result.found).toBe(true)
+    expect(result.element).toBe(el)
+    expect(result.method).toBe('data-cy')
+  })
+
+  it('returns not found for missing element', () => {
+    const result = findTarget('#nonexistent')
+    expect(result.found).toBe(false)
+    expect(result.element).toBeNull()
+  })
+
+  it('returns not found for invalid CSS selector', () => {
+    const result = findTarget('[[[invalid')
+    expect(result.found).toBe(false)
+    expect(result.element).toBeNull()
+  })
+
+  it('prefers data-walkme-target over CSS for plain names', () => {
+    const walkmeEl = document.createElement('div')
+    walkmeEl.setAttribute('data-walkme-target', 'sidebar')
+    document.body.appendChild(walkmeEl)
+
+    // Also create an element with id="sidebar"
+    const idEl = document.createElement('div')
+    idEl.id = 'sidebar'
+    document.body.appendChild(idEl)
+
+    const result = findTarget('sidebar')
+    expect(result.found).toBe(true)
+    expect(result.method).toBe('data-walkme')
+    expect(result.element).toBe(walkmeEl)
+  })
+
+  it('falls back to CSS when data-walkme-target not found', () => {
+    const el = document.createElement('div')
+    el.className = 'my-class'
+    document.body.appendChild(el)
+
+    const result = findTarget('.my-class')
+    expect(result.found).toBe(true)
+    expect(result.method).toBe('css')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// waitForTarget
+// ---------------------------------------------------------------------------
+
+describe('waitForTarget', () => {
+  afterEach(() => {
+    document.body.innerHTML = ''
+  })
+
+  it('resolves immediately if element exists', async () => {
+    const el = document.createElement('div')
+    el.id = 'existing'
+    document.body.appendChild(el)
+
+    const result = await waitForTarget('#existing')
+    expect(result.found).toBe(true)
+    expect(result.element).toBe(el)
+  })
+
+  it('resolves not found after timeout', async () => {
+    const result = await waitForTarget('#nonexistent', { timeout: 100, interval: 50 })
+    expect(result.found).toBe(false)
+    expect(result.element).toBeNull()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// isElementVisible
+// ---------------------------------------------------------------------------
+
+describe('isElementVisible', () => {
+  it('returns true for visible element', () => {
+    const el = document.createElement('div')
+    document.body.appendChild(el)
+    // jsdom defaults: display is '', visibility is '', opacity is ''
+    // getComputedStyle in jsdom returns empty strings, not 'none' or 'hidden'
+    // However, offsetParent is null for elements not in a rendered layout
+    // In jsdom, offsetParent is always null, so this will return false
+    const result = isElementVisible(el)
+    // jsdom limitation: offsetParent is always null
+    expect(typeof result).toBe('boolean')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// isElementInViewport
+// ---------------------------------------------------------------------------
+
+describe('isElementInViewport', () => {
+  it('checks viewport bounds', () => {
+    const el = document.createElement('div')
+    document.body.appendChild(el)
+    // getBoundingClientRect returns all zeros in jsdom
+    const result = isElementInViewport(el)
+    // In jsdom all rect values are 0, and 0 >= 0 is true, 0 <= innerHeight is true
+    expect(typeof result).toBe('boolean')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// scrollToElement
+// ---------------------------------------------------------------------------
+
+describe('scrollToElement', () => {
+  it('calls scrollIntoView on the element', () => {
+    const el = document.createElement('div')
+    document.body.appendChild(el)
+    scrollToElement(el)
+    expect(el.scrollIntoView).toHaveBeenCalledWith({
+      behavior: 'smooth',
+      block: 'center',
+    })
+  })
+
+  it('accepts custom options', () => {
+    const el = document.createElement('div')
+    document.body.appendChild(el)
+    scrollToElement(el, { behavior: 'instant', block: 'start' })
+    expect(el.scrollIntoView).toHaveBeenCalledWith({
+      behavior: 'instant',
+      block: 'start',
+    })
+  })
+})
+
+// ---------------------------------------------------------------------------
+// getElementRect
+// ---------------------------------------------------------------------------
+
+describe('getElementRect', () => {
+  it('returns a rect object with expected properties', () => {
+    const el = document.createElement('div')
+    document.body.appendChild(el)
+    const rect = getElementRect(el)
+    expect(rect).toHaveProperty('top')
+    expect(rect).toHaveProperty('left')
+    expect(rect).toHaveProperty('width')
+    expect(rect).toHaveProperty('height')
+    expect(typeof rect.top).toBe('number')
+  })
+})

--- a/plugins/walkme/tests/lib/triggers.test.ts
+++ b/plugins/walkme/tests/lib/triggers.test.ts
@@ -1,0 +1,198 @@
+import type { Tour } from '../../types/walkme.types'
+import {
+  shouldTriggerTour,
+  evaluateOnFirstVisit,
+  evaluateOnRouteEnter,
+  evaluateOnEvent,
+  evaluateScheduled,
+  type TriggerEvaluationContext,
+} from '../../lib/triggers'
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+function createContext(overrides: Partial<TriggerEvaluationContext> = {}): TriggerEvaluationContext {
+  return {
+    currentRoute: '/dashboard',
+    visitCount: 1,
+    firstVisitDate: new Date().toISOString(),
+    completedTourIds: [],
+    customEvents: new Set(),
+    ...overrides,
+  }
+}
+
+function createTour(trigger: Tour['trigger']): Tour {
+  return {
+    id: 'test',
+    name: 'Test',
+    trigger,
+    steps: [{ id: 's1', type: 'modal', title: 'T', content: 'C', actions: ['next'] }],
+  }
+}
+
+// ---------------------------------------------------------------------------
+// shouldTriggerTour
+// ---------------------------------------------------------------------------
+
+describe('shouldTriggerTour', () => {
+  it('delegates to onFirstVisit evaluator', () => {
+    const tour = createTour({ type: 'onFirstVisit' })
+    expect(shouldTriggerTour(tour, createContext({ visitCount: 1 }))).toBe(true)
+    expect(shouldTriggerTour(tour, createContext({ visitCount: 2 }))).toBe(false)
+  })
+
+  it('returns false for manual trigger', () => {
+    const tour = createTour({ type: 'manual' })
+    expect(shouldTriggerTour(tour, createContext())).toBe(false)
+  })
+
+  it('returns false for unknown trigger type', () => {
+    const tour = createTour({ type: 'unknown' as any })
+    expect(shouldTriggerTour(tour, createContext())).toBe(false)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// evaluateOnFirstVisit
+// ---------------------------------------------------------------------------
+
+describe('evaluateOnFirstVisit', () => {
+  it('returns true when visitCount is 1', () => {
+    expect(evaluateOnFirstVisit({ type: 'onFirstVisit' }, createContext({ visitCount: 1 }))).toBe(true)
+  })
+
+  it('returns false when visitCount is > 1', () => {
+    expect(evaluateOnFirstVisit({ type: 'onFirstVisit' }, createContext({ visitCount: 5 }))).toBe(false)
+  })
+
+  it('returns false when visitCount is 0', () => {
+    expect(evaluateOnFirstVisit({ type: 'onFirstVisit' }, createContext({ visitCount: 0 }))).toBe(false)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// evaluateOnRouteEnter
+// ---------------------------------------------------------------------------
+
+describe('evaluateOnRouteEnter', () => {
+  it('matches exact route', () => {
+    const result = evaluateOnRouteEnter(
+      { type: 'onRouteEnter', route: '/dashboard' },
+      createContext({ currentRoute: '/dashboard' }),
+    )
+    expect(result).toBe(true)
+  })
+
+  it('does not match different route', () => {
+    const result = evaluateOnRouteEnter(
+      { type: 'onRouteEnter', route: '/settings' },
+      createContext({ currentRoute: '/dashboard' }),
+    )
+    expect(result).toBe(false)
+  })
+
+  it('matches wildcard pattern /admin/*', () => {
+    const trigger = { type: 'onRouteEnter' as const, route: '/admin/*' }
+    expect(evaluateOnRouteEnter(trigger, createContext({ currentRoute: '/admin/users' }))).toBe(true)
+    expect(evaluateOnRouteEnter(trigger, createContext({ currentRoute: '/admin' }))).toBe(true)
+    expect(evaluateOnRouteEnter(trigger, createContext({ currentRoute: '/other' }))).toBe(false)
+  })
+
+  it('matches glob pattern /docs/**', () => {
+    const trigger = { type: 'onRouteEnter' as const, route: '/docs/**' }
+    expect(evaluateOnRouteEnter(trigger, createContext({ currentRoute: '/docs/a/b/c' }))).toBe(true)
+    expect(evaluateOnRouteEnter(trigger, createContext({ currentRoute: '/docs' }))).toBe(true)
+  })
+
+  it('returns false when no route in trigger', () => {
+    const result = evaluateOnRouteEnter({ type: 'onRouteEnter' }, createContext())
+    expect(result).toBe(false)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// evaluateOnEvent
+// ---------------------------------------------------------------------------
+
+describe('evaluateOnEvent', () => {
+  it('returns true when event is in customEvents set', () => {
+    const events = new Set(['my-event'])
+    const result = evaluateOnEvent(
+      { type: 'onEvent', event: 'my-event' },
+      createContext({ customEvents: events }),
+    )
+    expect(result).toBe(true)
+  })
+
+  it('returns false when event is not in set', () => {
+    const result = evaluateOnEvent(
+      { type: 'onEvent', event: 'my-event' },
+      createContext({ customEvents: new Set() }),
+    )
+    expect(result).toBe(false)
+  })
+
+  it('returns false when no event in trigger', () => {
+    const result = evaluateOnEvent({ type: 'onEvent' }, createContext())
+    expect(result).toBe(false)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// evaluateScheduled
+// ---------------------------------------------------------------------------
+
+describe('evaluateScheduled', () => {
+  it('triggers when visitCount meets afterVisits threshold', () => {
+    const result = evaluateScheduled(
+      { type: 'scheduled', afterVisits: 5 },
+      createContext({ visitCount: 5 }),
+    )
+    expect(result).toBe(true)
+  })
+
+  it('does not trigger when visitCount is below threshold', () => {
+    const result = evaluateScheduled(
+      { type: 'scheduled', afterVisits: 5 },
+      createContext({ visitCount: 3 }),
+    )
+    expect(result).toBe(false)
+  })
+
+  it('triggers when enough days have passed since first visit', () => {
+    const tenDaysAgo = new Date()
+    tenDaysAgo.setDate(tenDaysAgo.getDate() - 10)
+
+    const result = evaluateScheduled(
+      { type: 'scheduled', afterDays: 7 },
+      createContext({ firstVisitDate: tenDaysAgo.toISOString() }),
+    )
+    expect(result).toBe(true)
+  })
+
+  it('does not trigger when not enough days have passed', () => {
+    const twoDaysAgo = new Date()
+    twoDaysAgo.setDate(twoDaysAgo.getDate() - 2)
+
+    const result = evaluateScheduled(
+      { type: 'scheduled', afterDays: 7 },
+      createContext({ firstVisitDate: twoDaysAgo.toISOString() }),
+    )
+    expect(result).toBe(false)
+  })
+
+  it('returns false when no thresholds specified', () => {
+    const result = evaluateScheduled({ type: 'scheduled' }, createContext())
+    expect(result).toBe(false)
+  })
+
+  it('returns false when firstVisitDate is null for afterDays', () => {
+    const result = evaluateScheduled(
+      { type: 'scheduled', afterDays: 1 },
+      createContext({ firstVisitDate: null }),
+    )
+    expect(result).toBe(false)
+  })
+})

--- a/plugins/walkme/tests/lib/validation.test.ts
+++ b/plugins/walkme/tests/lib/validation.test.ts
@@ -1,0 +1,249 @@
+import {
+  TourTriggerSchema,
+  TourStepSchema,
+  TourSchema,
+  TourArraySchema,
+  validateTour,
+  validateTours,
+  validateStep,
+} from '../../lib/validation'
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const validStep = {
+  id: 'step-1',
+  type: 'modal',
+  title: 'Title',
+  content: 'Content',
+  actions: ['next'],
+}
+
+const validTooltipStep = {
+  id: 'tooltip-1',
+  type: 'tooltip',
+  target: '#my-element',
+  title: 'Tooltip',
+  content: 'Content',
+  position: 'bottom',
+  actions: ['next', 'prev'],
+}
+
+const validTour = {
+  id: 'tour-1',
+  name: 'My Tour',
+  trigger: { type: 'manual' },
+  steps: [validStep],
+}
+
+// ---------------------------------------------------------------------------
+// TourTriggerSchema
+// ---------------------------------------------------------------------------
+
+describe('TourTriggerSchema', () => {
+  it('accepts all valid trigger types', () => {
+    for (const type of ['onFirstVisit', 'onRouteEnter', 'onEvent', 'manual', 'scheduled']) {
+      expect(TourTriggerSchema.safeParse({ type }).success).toBe(true)
+    }
+  })
+
+  it('rejects invalid trigger type', () => {
+    expect(TourTriggerSchema.safeParse({ type: 'invalid' }).success).toBe(false)
+  })
+
+  it('accepts optional delay, route, event fields', () => {
+    const result = TourTriggerSchema.safeParse({
+      type: 'onRouteEnter',
+      delay: 500,
+      route: '/dashboard/*',
+    })
+    expect(result.success).toBe(true)
+  })
+
+  it('rejects negative delay', () => {
+    const result = TourTriggerSchema.safeParse({ type: 'manual', delay: -1 })
+    expect(result.success).toBe(false)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// TourStepSchema
+// ---------------------------------------------------------------------------
+
+describe('TourStepSchema', () => {
+  it('accepts a valid modal step (no target required)', () => {
+    const result = TourStepSchema.safeParse(validStep)
+    expect(result.success).toBe(true)
+  })
+
+  it('accepts a valid tooltip step with target', () => {
+    const result = TourStepSchema.safeParse(validTooltipStep)
+    expect(result.success).toBe(true)
+  })
+
+  it('rejects tooltip step without target', () => {
+    const result = TourStepSchema.safeParse({
+      id: 'tooltip-bad',
+      type: 'tooltip',
+      title: 'Bad',
+      content: 'No target',
+      actions: ['next'],
+    })
+    expect(result.success).toBe(false)
+  })
+
+  it('rejects spotlight step without target', () => {
+    const result = TourStepSchema.safeParse({
+      id: 'spotlight-bad',
+      type: 'spotlight',
+      title: 'Bad',
+      content: 'No target',
+      actions: ['next'],
+    })
+    expect(result.success).toBe(false)
+  })
+
+  it('rejects beacon step without target', () => {
+    const result = TourStepSchema.safeParse({
+      id: 'beacon-bad',
+      type: 'beacon',
+      title: 'Bad',
+      content: 'No target',
+      actions: ['next'],
+    })
+    expect(result.success).toBe(false)
+  })
+
+  it('rejects step with empty id', () => {
+    const result = TourStepSchema.safeParse({ ...validStep, id: '' })
+    expect(result.success).toBe(false)
+  })
+
+  it('rejects step with empty actions array', () => {
+    const result = TourStepSchema.safeParse({ ...validStep, actions: [] })
+    expect(result.success).toBe(false)
+  })
+
+  it('rejects step with invalid action', () => {
+    const result = TourStepSchema.safeParse({ ...validStep, actions: ['invalid'] })
+    expect(result.success).toBe(false)
+  })
+
+  it('accepts all valid step types', () => {
+    for (const type of ['tooltip', 'modal', 'spotlight', 'beacon', 'floating']) {
+      const step = type === 'modal' || type === 'floating'
+        ? { ...validStep, type }
+        : { ...validStep, type, target: '#el' }
+      expect(TourStepSchema.safeParse(step).success).toBe(true)
+    }
+  })
+})
+
+// ---------------------------------------------------------------------------
+// TourSchema
+// ---------------------------------------------------------------------------
+
+describe('TourSchema', () => {
+  it('accepts a valid tour', () => {
+    const result = TourSchema.safeParse(validTour)
+    expect(result.success).toBe(true)
+  })
+
+  it('rejects tour with empty id', () => {
+    const result = TourSchema.safeParse({ ...validTour, id: '' })
+    expect(result.success).toBe(false)
+  })
+
+  it('rejects tour with no steps', () => {
+    const result = TourSchema.safeParse({ ...validTour, steps: [] })
+    expect(result.success).toBe(false)
+  })
+
+  it('accepts tour with conditions', () => {
+    const result = TourSchema.safeParse({
+      ...validTour,
+      conditions: {
+        userRole: ['admin'],
+        completedTours: ['onboarding'],
+      },
+    })
+    expect(result.success).toBe(true)
+  })
+
+  it('accepts tour with priority', () => {
+    const result = TourSchema.safeParse({ ...validTour, priority: 10 })
+    expect(result.success).toBe(true)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// TourArraySchema
+// ---------------------------------------------------------------------------
+
+describe('TourArraySchema', () => {
+  it('validates an array of tours', () => {
+    const result = TourArraySchema.safeParse([validTour, { ...validTour, id: 'tour-2' }])
+    expect(result.success).toBe(true)
+  })
+
+  it('rejects if any tour is invalid', () => {
+    const result = TourArraySchema.safeParse([validTour, { id: '' }])
+    expect(result.success).toBe(false)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// validateTour
+// ---------------------------------------------------------------------------
+
+describe('validateTour', () => {
+  it('returns valid: true for a valid tour', () => {
+    const result = validateTour(validTour)
+    expect(result.valid).toBe(true)
+    expect(result.tour).toBeDefined()
+    expect(result.errors).toBeUndefined()
+  })
+
+  it('returns valid: false with errors for invalid tour', () => {
+    const result = validateTour({ id: '' })
+    expect(result.valid).toBe(false)
+    expect(result.errors).toBeDefined()
+    expect(result.tour).toBeUndefined()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// validateTours
+// ---------------------------------------------------------------------------
+
+describe('validateTours', () => {
+  it('filters valid tours from mixed input', () => {
+    const result = validateTours([validTour, { id: '' }, { ...validTour, id: 'tour-2' }])
+    expect(result.validTours).toHaveLength(2)
+    expect(result.errors).toHaveLength(1)
+    expect(result.valid).toBe(false)
+  })
+
+  it('returns valid: true when all tours are valid', () => {
+    const result = validateTours([validTour])
+    expect(result.valid).toBe(true)
+    expect(result.errors).toBeUndefined()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// validateStep
+// ---------------------------------------------------------------------------
+
+describe('validateStep', () => {
+  it('returns valid: true for a valid step', () => {
+    expect(validateStep(validStep).valid).toBe(true)
+  })
+
+  it('returns valid: false for invalid step', () => {
+    const result = validateStep({ id: '' })
+    expect(result.valid).toBe(false)
+    expect(result.errors).toBeDefined()
+  })
+})

--- a/plugins/walkme/tests/setup.ts
+++ b/plugins/walkme/tests/setup.ts
@@ -1,0 +1,52 @@
+/**
+ * Jest test setup for WalkMe plugin.
+ * Polyfills and mocks needed for jsdom environment.
+ */
+
+// Mock localStorage
+const localStorageMock = (() => {
+  let store: Record<string, string> = {}
+  return {
+    getItem: jest.fn((key: string) => store[key] ?? null),
+    setItem: jest.fn((key: string, value: string) => {
+      store[key] = value
+    }),
+    removeItem: jest.fn((key: string) => {
+      delete store[key]
+    }),
+    clear: jest.fn(() => {
+      store = {}
+    }),
+    get length() {
+      return Object.keys(store).length
+    },
+    key: jest.fn((index: number) => Object.keys(store)[index] ?? null),
+  }
+})()
+
+Object.defineProperty(window, 'localStorage', {
+  value: localStorageMock,
+})
+
+// Mock MutationObserver
+global.MutationObserver = jest.fn().mockImplementation(() => ({
+  observe: jest.fn(),
+  disconnect: jest.fn(),
+  takeRecords: jest.fn().mockReturnValue([]),
+}))
+
+// Mock ResizeObserver
+global.ResizeObserver = jest.fn().mockImplementation(() => ({
+  observe: jest.fn(),
+  unobserve: jest.fn(),
+  disconnect: jest.fn(),
+}))
+
+// Mock scrollIntoView
+Element.prototype.scrollIntoView = jest.fn()
+
+// Reset localStorage between tests
+beforeEach(() => {
+  localStorageMock.clear()
+  jest.clearAllMocks()
+})

--- a/plugins/walkme/tests/tsconfig.json
+++ b/plugins/walkme/tests/tsconfig.json
@@ -1,0 +1,32 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "commonjs",
+    "moduleResolution": "node",
+    "jsx": "react-jsx",
+    "esModuleInterop": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "types": ["jest"],
+    "typeRoots": [
+      "../../../packages/core/node_modules/@types"
+    ],
+    "resolveJsonModule": true,
+    "baseUrl": "..",
+    "paths": {
+      "~/*": ["./*"]
+    }
+  },
+  "include": [
+    "**/*.test.ts",
+    "**/*.test.tsx",
+    "setup.ts",
+    "../lib/**/*.ts",
+    "../types/**/*.ts",
+    "../hooks/**/*.ts",
+    "../hooks/**/*.tsx",
+    "../components/**/*.tsx",
+    "../providers/**/*.ts"
+  ],
+  "exclude": ["node_modules"]
+}

--- a/plugins/walkme/tsconfig.json
+++ b/plugins/walkme/tsconfig.json
@@ -1,0 +1,47 @@
+{
+  "extends": "../../../tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "baseUrl": ".",
+    "moduleResolution": "node",
+    "paths": {
+      "@/*": ["../../../*"],
+      "@/core/*": ["../../../core/*"],
+      "@/contents/*": ["../../../contents/*"],
+      "~/*": ["./*"]
+    }
+  },
+  "watchOptions": {
+    "watchFile": "useFsEvents",
+    "watchDirectory": "useFsEvents",
+    "fallbackPolling": "dynamicPriority",
+    "synchronousWatchDirectory": false,
+    "excludeDirectories": [
+      "**/node_modules",
+      "**/.next",
+      "**/dist",
+      "**/build",
+      "**/.turbo",
+      "**/coverage",
+      "**/.git"
+    ]
+  },
+  "include": [
+    "**/*.ts",
+    "**/*.tsx",
+    "plugin.config.ts"
+  ],
+  "exclude": [
+    "node_modules",
+    ".next",
+    "dist",
+    "build",
+    ".turbo",
+    "coverage",
+    ".git",
+    "**/*.test.ts",
+    "**/*.test.tsx",
+    "**/__tests__/**",
+    "**/tsconfig.tsbuildinfo"
+  ]
+}

--- a/plugins/walkme/types/walkme.types.ts
+++ b/plugins/walkme/types/walkme.types.ts
@@ -163,6 +163,7 @@ export interface WalkmeState {
 /** Discriminated union of all reducer actions */
 export type WalkmeAction =
   | { type: 'INITIALIZE'; tours: Tour[] }
+  | { type: 'UPDATE_TOURS'; tours: Tour[] }
   | { type: 'START_TOUR'; tourId: string }
   | { type: 'NEXT_STEP' }
   | { type: 'PREV_STEP' }
@@ -264,6 +265,8 @@ export interface WalkmeProviderProps {
   conditionContext?: Omit<ConditionContext, 'completedTourIds' | 'visitCount' | 'firstVisitDate'>
   /** Translated UI labels (defaults to English if not provided) */
   labels?: Partial<WalkmeLabels>
+  /** User ID for scoping localStorage persistence per user */
+  userId?: string
 }
 
 // ---------------------------------------------------------------------------

--- a/plugins/walkme/types/walkme.types.ts
+++ b/plugins/walkme/types/walkme.types.ts
@@ -1,0 +1,313 @@
+/**
+ * WalkMe Plugin - Type Definitions
+ *
+ * Complete type system for the guided tour and onboarding plugin.
+ * All types are exported from this single file as the source of truth.
+ */
+
+// ---------------------------------------------------------------------------
+// Enums / Literal Unions
+// ---------------------------------------------------------------------------
+
+/** Tour lifecycle states */
+export type TourStatus = 'idle' | 'active' | 'paused' | 'completed' | 'skipped'
+
+/** Visual step types */
+export type StepType = 'tooltip' | 'modal' | 'spotlight' | 'beacon' | 'floating'
+
+/** Tooltip positioning relative to target */
+export type StepPosition = 'top' | 'bottom' | 'left' | 'right' | 'auto'
+
+/** How a tour is activated */
+export type TriggerType = 'onFirstVisit' | 'onRouteEnter' | 'onEvent' | 'manual' | 'scheduled'
+
+/** User actions available within a step */
+export type StepAction = 'next' | 'prev' | 'skip' | 'complete' | 'close'
+
+// ---------------------------------------------------------------------------
+// Tour Configuration
+// ---------------------------------------------------------------------------
+
+/** Defines a complete guided tour */
+export interface Tour {
+  /** Unique identifier for the tour */
+  id: string
+  /** Human-readable name */
+  name: string
+  /** Optional description */
+  description?: string
+  /** How and when the tour should be triggered */
+  trigger: TourTrigger
+  /** Optional conditions that must be met to show the tour */
+  conditions?: TourConditions
+  /** Ordered list of steps in the tour */
+  steps: TourStep[]
+  /** Callback when the tour is completed */
+  onComplete?: () => void
+  /** Callback when the tour is skipped */
+  onSkip?: () => void
+  /** Priority for auto-trigger ordering (lower = higher priority) */
+  priority?: number
+}
+
+/** Defines a single step within a tour */
+export interface TourStep {
+  /** Unique identifier for the step */
+  id: string
+  /** Visual type of the step */
+  type: StepType
+  /** Step title */
+  title: string
+  /** Step content / description */
+  content: string
+  /** CSS selector or data-walkme-target value to anchor to */
+  target?: string
+  /** Route path for cross-page tours (triggers navigation if different from current) */
+  route?: string
+  /** Positioning for tooltip/spotlight types */
+  position?: StepPosition
+  /** Available user actions for this step */
+  actions: StepAction[]
+  /** Delay in ms before showing this step */
+  delay?: number
+  /** Auto-advance to next step after this many ms */
+  autoAdvance?: number
+  /** Callback before the step is shown */
+  beforeShow?: () => Promise<void> | void
+  /** Callback after the step is shown */
+  afterShow?: () => Promise<void> | void
+}
+
+/** Defines when a tour should be activated */
+export interface TourTrigger {
+  /** Trigger mechanism */
+  type: TriggerType
+  /** Delay in ms before activating after trigger condition is met */
+  delay?: number
+  /** Route pattern for onRouteEnter trigger */
+  route?: string
+  /** Event name for onEvent trigger */
+  event?: string
+  /** Activate after this many visits (for scheduled trigger) */
+  afterVisits?: number
+  /** Activate after this many days since first visit (for scheduled trigger) */
+  afterDays?: number
+}
+
+/** Conditions that must be met before a tour can start */
+export interface TourConditions {
+  /** User must have one of these roles */
+  userRole?: string[]
+  /** All of these feature flags must be active */
+  featureFlags?: string[]
+  /** All of these tours must be completed first */
+  completedTours?: string[]
+  /** None of these tours should be completed */
+  notCompletedTours?: string[]
+  /** Custom condition function */
+  custom?: (context: ConditionContext) => boolean
+}
+
+/** Context passed to condition evaluators */
+export interface ConditionContext {
+  /** Current user role */
+  userRole?: string
+  /** Active feature flags */
+  featureFlags?: string[]
+  /** IDs of completed tours */
+  completedTourIds: string[]
+  /** Total number of page visits */
+  visitCount: number
+  /** ISO date string of first visit */
+  firstVisitDate?: string
+}
+
+// ---------------------------------------------------------------------------
+// State Management
+// ---------------------------------------------------------------------------
+
+/** Runtime state for a single tour */
+export interface TourState {
+  /** Tour identifier */
+  tourId: string
+  /** Current status */
+  status: TourStatus
+  /** Index of the current step */
+  currentStepIndex: number
+  /** ISO timestamp when the tour was started */
+  startedAt: string
+  /** ISO timestamp when completed */
+  completedAt?: string
+  /** ISO timestamp when skipped */
+  skippedAt?: string
+}
+
+/** Global state for the WalkMe system */
+export interface WalkmeState {
+  /** Map of registered tours by ID */
+  tours: Record<string, Tour>
+  /** Currently active tour state (null if no tour is active) */
+  activeTour: TourState | null
+  /** IDs of completed tours */
+  completedTours: string[]
+  /** IDs of skipped tours */
+  skippedTours: string[]
+  /** Historical state of all tours */
+  tourHistory: Record<string, TourState>
+  /** Whether the system has been initialized */
+  initialized: boolean
+  /** Debug mode flag */
+  debug: boolean
+}
+
+/** Discriminated union of all reducer actions */
+export type WalkmeAction =
+  | { type: 'INITIALIZE'; tours: Tour[] }
+  | { type: 'START_TOUR'; tourId: string }
+  | { type: 'NEXT_STEP' }
+  | { type: 'PREV_STEP' }
+  | { type: 'SKIP_TOUR' }
+  | { type: 'COMPLETE_TOUR' }
+  | { type: 'PAUSE_TOUR' }
+  | { type: 'RESUME_TOUR' }
+  | { type: 'RESET_TOUR'; tourId: string }
+  | { type: 'RESET_ALL' }
+  | { type: 'NAVIGATE_TO_STEP'; stepIndex: number }
+  | { type: 'SET_DEBUG'; enabled: boolean }
+  | { type: 'RESTORE_STATE'; completedTours: string[]; skippedTours: string[]; tourHistory: Record<string, TourState>; activeTour: TourState | null }
+
+// ---------------------------------------------------------------------------
+// Labels / i18n
+// ---------------------------------------------------------------------------
+
+/** Translatable UI strings for walkme components */
+export interface WalkmeLabels {
+  /** "Next" button text */
+  next: string
+  /** "Previous" button text */
+  prev: string
+  /** "Skip tour" button text */
+  skip: string
+  /** "Complete" button text */
+  complete: string
+  /** "Close" button aria-label */
+  close: string
+  /** Progress text template, receives {current} and {total} */
+  progress: string
+  /** Beacon fallback aria-label */
+  tourAvailable: string
+}
+
+// ---------------------------------------------------------------------------
+// Context / Provider
+// ---------------------------------------------------------------------------
+
+/** Value exposed by WalkmeContext to consumers */
+export interface WalkmeContextValue {
+  /** Current global state */
+  state: WalkmeState
+  /** Start a specific tour by ID */
+  startTour: (tourId: string) => void
+  /** Pause the active tour */
+  pauseTour: () => void
+  /** Resume a paused tour */
+  resumeTour: () => void
+  /** Skip the active tour */
+  skipTour: () => void
+  /** Complete the active tour */
+  completeTour: () => void
+  /** Reset a specific tour (remove from completed/skipped) */
+  resetTour: (tourId: string) => void
+  /** Reset all tours to initial state */
+  resetAllTours: () => void
+  /** Advance to the next step */
+  nextStep: () => void
+  /** Go back to the previous step */
+  prevStep: () => void
+  /** Jump to a specific step index */
+  goToStep: (stepIndex: number) => void
+  /** Check if a tour has been completed */
+  isTourCompleted: (tourId: string) => boolean
+  /** Check if a tour is currently active */
+  isTourActive: (tourId: string) => boolean
+  /** Get the full Tour object for the active tour */
+  getActiveTour: () => Tour | null
+  /** Get the current TourStep for the active tour */
+  getActiveStep: () => TourStep | null
+  /** Emit a custom event (for onEvent triggers) */
+  emitEvent: (eventName: string) => void
+}
+
+/** Props for the WalkmeProvider component */
+export interface WalkmeProviderProps {
+  /** Array of tour definitions */
+  tours: Tour[]
+  /** React children */
+  children: React.ReactNode
+  /** Enable debug logging */
+  debug?: boolean
+  /** Auto-start eligible tours */
+  autoStart?: boolean
+  /** Delay before auto-starting tours (ms) */
+  autoStartDelay?: number
+  /** Persist tour state in localStorage */
+  persistState?: boolean
+  /** Callback when a tour starts */
+  onTourStart?: (event: TourEvent) => void
+  /** Callback when a tour is completed */
+  onTourComplete?: (event: TourEvent) => void
+  /** Callback when a tour is skipped */
+  onTourSkip?: (event: TourEvent) => void
+  /** Callback when a step changes */
+  onStepChange?: (event: TourEvent) => void
+  /** Context for evaluating tour conditions */
+  conditionContext?: Omit<ConditionContext, 'completedTourIds' | 'visitCount' | 'firstVisitDate'>
+  /** Translated UI labels (defaults to English if not provided) */
+  labels?: Partial<WalkmeLabels>
+}
+
+// ---------------------------------------------------------------------------
+// Storage
+// ---------------------------------------------------------------------------
+
+/** Schema for localStorage persistence */
+export interface StorageSchema {
+  /** Schema version for migrations */
+  version: number
+  /** IDs of completed tours */
+  completedTours: string[]
+  /** IDs of skipped tours */
+  skippedTours: string[]
+  /** Currently active tour state */
+  activeTour: TourState | null
+  /** Historical state of all tours */
+  tourHistory: Record<string, TourState>
+  /** Total page visit count */
+  visitCount: number
+  /** ISO date string of first visit */
+  firstVisitDate: string
+}
+
+// ---------------------------------------------------------------------------
+// Events / Analytics
+// ---------------------------------------------------------------------------
+
+/** Event emitted for analytics tracking */
+export interface TourEvent {
+  /** Event type */
+  type: 'tour_started' | 'tour_completed' | 'tour_skipped' | 'step_changed' | 'step_completed'
+  /** Tour identifier */
+  tourId: string
+  /** Tour human-readable name */
+  tourName: string
+  /** Current step identifier */
+  stepId?: string
+  /** Current step index */
+  stepIndex?: number
+  /** Total steps in the tour */
+  totalSteps?: number
+  /** Unix timestamp */
+  timestamp: number
+  /** Additional metadata */
+  metadata?: Record<string, unknown>
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -355,9 +355,6 @@ importers:
       gray-matter:
         specifier: ^4.0.3
         version: 4.0.3
-      jiti:
-        specifier: ^2.6.1
-        version: 2.6.1
       lucide-react:
         specifier: ^0.539.0
         version: 0.539.0(react@19.1.0)
@@ -685,7 +682,7 @@ importers:
         version: 1.0.30(zod@4.3.4)
       '@nextsparkjs/core':
         specifier: '*'
-        version: 0.1.0-beta.100(@babel/runtime@7.28.4)(@codemirror/autocomplete@6.20.0)(@codemirror/language@6.12.1)(@codemirror/lint@6.9.2)(@codemirror/search@6.5.11)(@codemirror/state@6.5.3)(@codemirror/theme-one-dark@6.1.3)(@codemirror/view@6.39.9)(@swc/helpers@0.5.15)(@types/node@22.19.3)(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(codemirror@6.0.2)(cypress@15.8.2)(next@15.5.10(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react-native-reanimated@4.2.1(react-native-worklets@0.7.2(@babel/core@7.28.5)(react-native@0.81.5(@babel/core@7.28.5)(@types/react@19.2.7)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.28.5)(@types/react@19.2.7)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.28.5)(@types/react@19.2.7)(react@19.1.0))(react@19.1.0)(tailwindcss@4.1.18)(typescript@5.9.3)
+        version: 0.1.0-beta.102(@babel/runtime@7.28.4)(@codemirror/autocomplete@6.20.0)(@codemirror/language@6.12.1)(@codemirror/lint@6.9.2)(@codemirror/search@6.5.11)(@codemirror/state@6.5.3)(@codemirror/theme-one-dark@6.1.3)(@codemirror/view@6.39.9)(@swc/helpers@0.5.15)(@types/node@22.19.3)(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(codemirror@6.0.2)(cypress@15.8.2)(next@15.5.10(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react-native-reanimated@4.2.1(react-native-worklets@0.7.2(@babel/core@7.28.5)(react-native@0.81.5(@babel/core@7.28.5)(@types/react@19.2.7)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.28.5)(@types/react@19.2.7)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.28.5)(@types/react@19.2.7)(react@19.1.0))(react@19.1.0)(tailwindcss@4.1.18)(typescript@5.9.3)
       '@tanstack/react-query':
         specifier: ^5.0.0
         version: 5.90.16(react@19.1.0)
@@ -715,7 +712,7 @@ importers:
     dependencies:
       '@nextsparkjs/core':
         specifier: '*'
-        version: 0.1.0-beta.100(@babel/runtime@7.28.4)(@codemirror/autocomplete@6.20.0)(@codemirror/language@6.12.1)(@codemirror/lint@6.9.2)(@codemirror/search@6.5.11)(@codemirror/state@6.5.3)(@codemirror/theme-one-dark@6.1.3)(@codemirror/view@6.39.9)(@swc/helpers@0.5.15)(@types/node@22.19.3)(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(codemirror@6.0.2)(cypress@15.8.2)(next@15.5.10(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react-native-reanimated@4.2.1(react-native-worklets@0.7.2(@babel/core@7.28.5)(react-native@0.81.5(@babel/core@7.28.5)(@types/react@19.2.7)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.28.5)(@types/react@19.2.7)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.28.5)(@types/react@19.2.7)(react@19.1.0))(react@19.1.0)(tailwindcss@4.1.18)(typescript@5.9.3)
+        version: 0.1.0-beta.102(@babel/runtime@7.28.4)(@codemirror/autocomplete@6.20.0)(@codemirror/language@6.12.1)(@codemirror/lint@6.9.2)(@codemirror/search@6.5.11)(@codemirror/state@6.5.3)(@codemirror/theme-one-dark@6.1.3)(@codemirror/view@6.39.9)(@swc/helpers@0.5.15)(@types/node@22.19.3)(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(codemirror@6.0.2)(cypress@15.8.2)(next@15.5.10(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react-native-reanimated@4.2.1(react-native-worklets@0.7.2(@babel/core@7.28.5)(react-native@0.81.5(@babel/core@7.28.5)(@types/react@19.2.7)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.28.5)(@types/react@19.2.7)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.28.5)(@types/react@19.2.7)(react@19.1.0))(react@19.1.0)(tailwindcss@4.1.18)(typescript@5.9.3)
       next:
         specifier: 15.5.10
         version: 15.5.10(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
@@ -754,7 +751,7 @@ importers:
         version: 0.3.17(@langchain/core@0.3.80(@opentelemetry/api@1.9.0)(openai@6.15.0(ws@8.18.3)(zod@4.3.4)))(ws@8.18.3)
       '@nextsparkjs/core':
         specifier: '*'
-        version: 0.1.0-beta.100(@babel/runtime@7.28.4)(@codemirror/autocomplete@6.20.0)(@codemirror/language@6.12.1)(@codemirror/lint@6.9.2)(@codemirror/search@6.5.11)(@codemirror/state@6.5.3)(@codemirror/theme-one-dark@6.1.3)(@codemirror/view@6.39.9)(@swc/helpers@0.5.15)(@types/node@22.19.3)(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(codemirror@6.0.2)(cypress@15.8.2)(next@15.5.10(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react-native-reanimated@4.2.1(react-native-worklets@0.7.2(@babel/core@7.28.5)(react-native@0.81.5(@babel/core@7.28.5)(@types/react@19.2.7)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.28.5)(@types/react@19.2.7)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.28.5)(@types/react@19.2.7)(react@19.1.0))(react@19.1.0)(tailwindcss@4.1.18)(typescript@5.9.3)
+        version: 0.1.0-beta.102(@babel/runtime@7.28.4)(@codemirror/autocomplete@6.20.0)(@codemirror/language@6.12.1)(@codemirror/lint@6.9.2)(@codemirror/search@6.5.11)(@codemirror/state@6.5.3)(@codemirror/theme-one-dark@6.1.3)(@codemirror/view@6.39.9)(@swc/helpers@0.5.15)(@types/node@22.19.3)(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(codemirror@6.0.2)(cypress@15.8.2)(next@15.5.10(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react-native-reanimated@4.2.1(react-native-worklets@0.7.2(@babel/core@7.28.5)(react-native@0.81.5(@babel/core@7.28.5)(@types/react@19.2.7)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.28.5)(@types/react@19.2.7)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.28.5)(@types/react@19.2.7)(react@19.1.0))(react@19.1.0)(tailwindcss@4.1.18)(typescript@5.9.3)
       '@tanstack/react-query':
         specifier: ^5.0.0
         version: 5.90.16(react@19.1.0)
@@ -787,7 +784,7 @@ importers:
     dependencies:
       '@nextsparkjs/core':
         specifier: '*'
-        version: 0.1.0-beta.100(@babel/runtime@7.28.4)(@codemirror/autocomplete@6.20.0)(@codemirror/language@6.12.1)(@codemirror/lint@6.9.2)(@codemirror/search@6.5.11)(@codemirror/state@6.5.3)(@codemirror/theme-one-dark@6.1.3)(@codemirror/view@6.39.9)(@swc/helpers@0.5.15)(@types/node@22.19.3)(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(codemirror@6.0.2)(cypress@15.8.2)(next@15.5.10(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react-native-reanimated@4.2.1(react-native-worklets@0.7.2(@babel/core@7.28.5)(react-native@0.81.5(@babel/core@7.28.5)(@types/react@19.2.7)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.28.5)(@types/react@19.2.7)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.28.5)(@types/react@19.2.7)(react@19.1.0))(react@19.1.0)(tailwindcss@4.1.18)(typescript@5.9.3)
+        version: 0.1.0-beta.102(@babel/runtime@7.28.4)(@codemirror/autocomplete@6.20.0)(@codemirror/language@6.12.1)(@codemirror/lint@6.9.2)(@codemirror/search@6.5.11)(@codemirror/state@6.5.3)(@codemirror/theme-one-dark@6.1.3)(@codemirror/view@6.39.9)(@swc/helpers@0.5.15)(@types/node@22.19.3)(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(codemirror@6.0.2)(cypress@15.8.2)(next@15.5.10(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react-native-reanimated@4.2.1(react-native-worklets@0.7.2(@babel/core@7.28.5)(react-native@0.81.5(@babel/core@7.28.5)(@types/react@19.2.7)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.28.5)(@types/react@19.2.7)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.28.5)(@types/react@19.2.7)(react@19.1.0))(react@19.1.0)(tailwindcss@4.1.18)(typescript@5.9.3)
       next:
         specifier: 15.5.10
         version: 15.5.10(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
@@ -801,14 +798,50 @@ importers:
         specifier: ^4.0.0
         version: 4.3.4
 
+  plugins/walkme:
+    dependencies:
+      '@floating-ui/react':
+        specifier: ^0.27.0
+        version: 0.27.18(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@nextsparkjs/core':
+        specifier: workspace:*
+        version: link:../../packages/core
+      class-variance-authority:
+        specifier: ^0.7.0
+        version: 0.7.1
+      clsx:
+        specifier: ^2.0.0
+        version: 2.1.1
+      lucide-react:
+        specifier: ^0.539.0
+        version: 0.539.0(react@19.1.0)
+      next:
+        specifier: 15.5.10
+        version: 15.5.10(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      next-intl:
+        specifier: ^4.0.0
+        version: 4.7.0(@swc/helpers@0.5.15)(next@15.5.10(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
+      react:
+        specifier: ^19.0.0
+        version: 19.1.0
+      react-dom:
+        specifier: ^19.0.0
+        version: 19.1.0(react@19.1.0)
+      tailwind-merge:
+        specifier: ^3.0.0
+        version: 3.4.0
+      zod:
+        specifier: ^4.0.0
+        version: 4.3.4
+
   themes/blog:
     dependencies:
       '@nextsparkjs/core':
         specifier: '*'
-        version: 0.1.0-beta.100(@babel/runtime@7.28.4)(@codemirror/autocomplete@6.20.0)(@codemirror/language@6.12.1)(@codemirror/lint@6.9.2)(@codemirror/search@6.5.11)(@codemirror/state@6.5.3)(@codemirror/theme-one-dark@6.1.3)(@codemirror/view@6.39.9)(@swc/helpers@0.5.15)(@types/node@22.19.3)(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(codemirror@6.0.2)(cypress@15.8.2)(next@15.5.10(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react-native-reanimated@4.2.1(react-native-worklets@0.7.2(@babel/core@7.28.5)(react-native@0.81.5(@babel/core@7.28.5)(@types/react@19.2.7)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.28.5)(@types/react@19.2.7)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.28.5)(@types/react@19.2.7)(react@19.1.0))(react@19.1.0)(tailwindcss@4.1.18)(typescript@5.9.3)
+        version: 0.1.0-beta.102(@babel/runtime@7.28.4)(@codemirror/autocomplete@6.20.0)(@codemirror/language@6.12.1)(@codemirror/lint@6.9.2)(@codemirror/search@6.5.11)(@codemirror/state@6.5.3)(@codemirror/theme-one-dark@6.1.3)(@codemirror/view@6.39.9)(@swc/helpers@0.5.15)(@types/node@22.19.3)(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(codemirror@6.0.2)(cypress@15.8.2)(next@15.5.10(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react-native-reanimated@4.2.1(react-native-worklets@0.7.2(@babel/core@7.28.5)(react-native@0.81.5(@babel/core@7.28.5)(@types/react@19.2.7)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.28.5)(@types/react@19.2.7)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.28.5)(@types/react@19.2.7)(react@19.1.0))(react@19.1.0)(tailwindcss@4.1.18)(typescript@5.9.3)
       '@nextsparkjs/testing':
         specifier: '*'
-        version: 0.1.0-beta.100(cypress@15.8.2)
+        version: 0.1.0-beta.102(cypress@15.8.2)
       lucide-react:
         specifier: ^0.539.0
         version: 0.539.0(react@19.1.0)
@@ -832,10 +865,10 @@ importers:
     dependencies:
       '@nextsparkjs/core':
         specifier: '*'
-        version: 0.1.0-beta.100(@babel/runtime@7.28.4)(@codemirror/autocomplete@6.20.0)(@codemirror/language@6.12.1)(@codemirror/lint@6.9.2)(@codemirror/search@6.5.11)(@codemirror/state@6.5.3)(@codemirror/theme-one-dark@6.1.3)(@codemirror/view@6.39.9)(@swc/helpers@0.5.15)(@types/node@22.19.3)(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(codemirror@6.0.2)(cypress@15.8.2)(next@15.5.10(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react-native-reanimated@4.2.1(react-native-worklets@0.7.2(@babel/core@7.28.5)(react-native@0.81.5(@babel/core@7.28.5)(@types/react@19.2.7)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.28.5)(@types/react@19.2.7)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.28.5)(@types/react@19.2.7)(react@19.1.0))(react@19.1.0)(tailwindcss@4.1.18)(typescript@5.9.3)
+        version: 0.1.0-beta.102(@babel/runtime@7.28.4)(@codemirror/autocomplete@6.20.0)(@codemirror/language@6.12.1)(@codemirror/lint@6.9.2)(@codemirror/search@6.5.11)(@codemirror/state@6.5.3)(@codemirror/theme-one-dark@6.1.3)(@codemirror/view@6.39.9)(@swc/helpers@0.5.15)(@types/node@22.19.3)(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(codemirror@6.0.2)(cypress@15.8.2)(next@15.5.10(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react-native-reanimated@4.2.1(react-native-worklets@0.7.2(@babel/core@7.28.5)(react-native@0.81.5(@babel/core@7.28.5)(@types/react@19.2.7)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.28.5)(@types/react@19.2.7)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.28.5)(@types/react@19.2.7)(react@19.1.0))(react@19.1.0)(tailwindcss@4.1.18)(typescript@5.9.3)
       '@nextsparkjs/testing':
         specifier: '*'
-        version: 0.1.0-beta.100(cypress@15.8.2)
+        version: 0.1.0-beta.102(cypress@15.8.2)
       lucide-react:
         specifier: ^0.539.0
         version: 0.539.0(react@19.1.0)
@@ -859,10 +892,10 @@ importers:
     dependencies:
       '@nextsparkjs/core':
         specifier: '*'
-        version: 0.1.0-beta.100(@babel/runtime@7.28.4)(@codemirror/autocomplete@6.20.0)(@codemirror/language@6.12.1)(@codemirror/lint@6.9.2)(@codemirror/search@6.5.11)(@codemirror/state@6.5.3)(@codemirror/theme-one-dark@6.1.3)(@codemirror/view@6.39.9)(@swc/helpers@0.5.15)(@types/node@22.19.3)(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(codemirror@6.0.2)(cypress@15.8.2)(next@15.5.10(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react-native-reanimated@4.2.1(react-native-worklets@0.7.2(@babel/core@7.28.5)(react-native@0.81.5(@babel/core@7.28.5)(@types/react@19.2.7)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.28.5)(@types/react@19.2.7)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.28.5)(@types/react@19.2.7)(react@19.1.0))(react@19.1.0)(tailwindcss@4.1.18)(typescript@5.9.3)
+        version: 0.1.0-beta.102(@babel/runtime@7.28.4)(@codemirror/autocomplete@6.20.0)(@codemirror/language@6.12.1)(@codemirror/lint@6.9.2)(@codemirror/search@6.5.11)(@codemirror/state@6.5.3)(@codemirror/theme-one-dark@6.1.3)(@codemirror/view@6.39.9)(@swc/helpers@0.5.15)(@types/node@22.19.3)(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(codemirror@6.0.2)(cypress@15.8.2)(next@15.5.10(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react-native-reanimated@4.2.1(react-native-worklets@0.7.2(@babel/core@7.28.5)(react-native@0.81.5(@babel/core@7.28.5)(@types/react@19.2.7)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.28.5)(@types/react@19.2.7)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.28.5)(@types/react@19.2.7)(react@19.1.0))(react@19.1.0)(tailwindcss@4.1.18)(typescript@5.9.3)
       '@nextsparkjs/testing':
         specifier: '*'
-        version: 0.1.0-beta.100(cypress@15.8.2)
+        version: 0.1.0-beta.102(cypress@15.8.2)
       '@tanstack/react-query':
         specifier: ^5.0.0
         version: 5.90.16(react@19.1.0)
@@ -892,10 +925,10 @@ importers:
     dependencies:
       '@nextsparkjs/core':
         specifier: '*'
-        version: 0.1.0-beta.100(@babel/runtime@7.28.4)(@codemirror/autocomplete@6.20.0)(@codemirror/language@6.12.1)(@codemirror/lint@6.9.2)(@codemirror/search@6.5.11)(@codemirror/state@6.5.3)(@codemirror/theme-one-dark@6.1.3)(@codemirror/view@6.39.9)(@swc/helpers@0.5.15)(@types/node@22.19.3)(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(codemirror@6.0.2)(cypress@15.8.2)(next@15.5.10(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react-native-reanimated@4.2.1(react-native-worklets@0.7.2(@babel/core@7.28.5)(react-native@0.81.5(@babel/core@7.28.5)(@types/react@19.2.7)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.28.5)(@types/react@19.2.7)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.28.5)(@types/react@19.2.7)(react@19.1.0))(react@19.1.0)(tailwindcss@4.1.18)(typescript@5.9.3)
+        version: 0.1.0-beta.102(@babel/runtime@7.28.4)(@codemirror/autocomplete@6.20.0)(@codemirror/language@6.12.1)(@codemirror/lint@6.9.2)(@codemirror/search@6.5.11)(@codemirror/state@6.5.3)(@codemirror/theme-one-dark@6.1.3)(@codemirror/view@6.39.9)(@swc/helpers@0.5.15)(@types/node@22.19.3)(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(codemirror@6.0.2)(cypress@15.8.2)(next@15.5.10(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react-native-reanimated@4.2.1(react-native-worklets@0.7.2(@babel/core@7.28.5)(react-native@0.81.5(@babel/core@7.28.5)(@types/react@19.2.7)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.28.5)(@types/react@19.2.7)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.28.5)(@types/react@19.2.7)(react@19.1.0))(react@19.1.0)(tailwindcss@4.1.18)(typescript@5.9.3)
       '@nextsparkjs/testing':
         specifier: '*'
-        version: 0.1.0-beta.100(cypress@15.8.2)
+        version: 0.1.0-beta.102(cypress@15.8.2)
       lucide-react:
         specifier: ^0.539.0
         version: 0.539.0(react@19.1.0)
@@ -2131,14 +2164,32 @@ packages:
   '@floating-ui/core@1.7.3':
     resolution: {integrity: sha512-sGnvb5dmrJaKEZ+LDIpguvdX3bDlEllmv4/ClQ9awcmCZrlx5jQyyMWFM5kBI+EyNOCDDiKk8il0zeuX3Zlg/w==}
 
+  '@floating-ui/core@1.7.4':
+    resolution: {integrity: sha512-C3HlIdsBxszvm5McXlB8PeOEWfBhcGBTZGkGlWc2U0KFY5IwG5OQEuQ8rq52DZmcHDlPLd+YFBK+cZcytwIFWg==}
+
   '@floating-ui/dom@1.7.4':
     resolution: {integrity: sha512-OOchDgh4F2CchOX94cRVqhvy7b3AFb+/rQXyswmzmGakRfkMgoWVjfnLWkRirfLEfuD4ysVW16eXzwt3jHIzKA==}
+
+  '@floating-ui/dom@1.7.5':
+    resolution: {integrity: sha512-N0bD2kIPInNHUHehXhMke1rBGs1dwqvC9O9KYMyyjK7iXt7GAhnro7UlcuYcGdS/yYOlq0MAVgrow8IbWJwyqg==}
 
   '@floating-ui/react-dom@2.1.6':
     resolution: {integrity: sha512-4JX6rEatQEvlmgU80wZyq9RT96HZJa88q8hp0pBd+LrczeDI4o6uA2M+uvxngVHo4Ihr8uibXxH6+70zhAFrVw==}
     peerDependencies:
       react: '>=16.8.0'
       react-dom: '>=16.8.0'
+
+  '@floating-ui/react-dom@2.1.7':
+    resolution: {integrity: sha512-0tLRojf/1Go2JgEVm+3Frg9A3IW8bJgKgdO0BN5RkF//ufuz2joZM63Npau2ff3J6lUVYgDSNzNkR+aH3IVfjg==}
+    peerDependencies:
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
+
+  '@floating-ui/react@0.27.18':
+    resolution: {integrity: sha512-xJWJxvmy3a05j643gQt+pRbht5XnTlGpsEsAPnMi5F5YTOEEJymA90uZKBD8OvIv5XvZ1qi4GcccSlqT3Bq44Q==}
+    peerDependencies:
+      react: '>=17.0.0'
+      react-dom: '>=17.0.0'
 
   '@floating-ui/utils@0.2.10':
     resolution: {integrity: sha512-aGTxbpbg8/b5JfU1HXSrbH3wXZuLPJcNEcZQFMxLs3oSzgtVu6nFPkbbGGUvBcUjKV2YyB9Wxxabo+HEH9tcRQ==}
@@ -3233,8 +3284,8 @@ packages:
   '@nextsparkjs/ai-workflow@0.1.0-beta.92':
     resolution: {integrity: sha512-9w4WCFx139rzU+uSgcX8YOCaSypk8k/AjAaz6Qefkt/XPS9cVhWNlQmlFOMTjaNzGWd0qpUg1aTOBP5mNO8xBQ==}
 
-  '@nextsparkjs/core@0.1.0-beta.100':
-    resolution: {integrity: sha512-3B0A3ML6Qp1l1AnVFP7Xg4WUJrLT9juJDV+o+Yyipjl4w4PSPZmsML1zySDJFseh8PxAMQ48psMd5kt8tockEg==}
+  '@nextsparkjs/core@0.1.0-beta.102':
+    resolution: {integrity: sha512-6YjxxLnTOmG2Si+3Pay/uGtzNdBeQ7GATW7WDI2MUSt396g/IzBEKmwULiAdVUQ4P7tjZGhqy7LWp9j2WaPDsw==}
     peerDependencies:
       next: 15.5.10
       react: '>=18.0.0'
@@ -3247,8 +3298,8 @@ packages:
       react: '>=18.0.0'
       react-dom: '>=18.0.0'
 
-  '@nextsparkjs/testing@0.1.0-beta.100':
-    resolution: {integrity: sha512-W/2xJVajNrFKdcoaSnAtKT2Q8R/pom304/iHW9K3W/GHKtGBM5jkEWPb/qlxMymyTnd0H9kDk/meL1j2NoLwUA==}
+  '@nextsparkjs/testing@0.1.0-beta.102':
+    resolution: {integrity: sha512-rJUWuOb8rd6j/uMF+HlaSTizkkp7WmCPG3TraUp1n1kI8+A+MHoeMP9qvC9ieJGAlhBDfovY53X+QJoz4IbhSQ==}
     peerDependencies:
       cypress: '>=13.0.0'
     peerDependenciesMeta:
@@ -9323,6 +9374,9 @@ packages:
     os: [darwin, linux, win32, freebsd, openbsd, netbsd, sunos, android]
     hasBin: true
 
+  tabbable@6.4.0:
+    resolution: {integrity: sha512-05PUHKSNE8ou2dwIxTngl4EzcnsCDZGJ/iCLtDflR/SHB/ny14rXc+qU5P4mG9JkusiV7EivzY9Mhm55AzAvCg==}
+
   tailwind-merge@3.4.0:
     resolution: {integrity: sha512-uSaO4gnW+b3Y2aWoWfFpX62vn2sR3skfhbjsEnaBI81WD1wBLlHZe5sWf0AqjksNdYTbGBEd0UasQMT3SNV15g==}
 
@@ -11561,9 +11615,18 @@ snapshots:
     dependencies:
       '@floating-ui/utils': 0.2.10
 
+  '@floating-ui/core@1.7.4':
+    dependencies:
+      '@floating-ui/utils': 0.2.10
+
   '@floating-ui/dom@1.7.4':
     dependencies:
       '@floating-ui/core': 1.7.3
+      '@floating-ui/utils': 0.2.10
+
+  '@floating-ui/dom@1.7.5':
+    dependencies:
+      '@floating-ui/core': 1.7.4
       '@floating-ui/utils': 0.2.10
 
   '@floating-ui/react-dom@2.1.6(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
@@ -11571,6 +11634,20 @@ snapshots:
       '@floating-ui/dom': 1.7.4
       react: 19.1.0
       react-dom: 19.1.0(react@19.1.0)
+
+  '@floating-ui/react-dom@2.1.7(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
+    dependencies:
+      '@floating-ui/dom': 1.7.5
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+
+  '@floating-ui/react@0.27.18(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
+    dependencies:
+      '@floating-ui/react-dom': 2.1.7(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@floating-ui/utils': 0.2.10
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+      tabbable: 6.4.0
 
   '@floating-ui/utils@0.2.10': {}
 
@@ -12496,7 +12573,7 @@ snapshots:
 
   '@nextsparkjs/ai-workflow@0.1.0-beta.92': {}
 
-  '@nextsparkjs/core@0.1.0-beta.100(@babel/runtime@7.28.4)(@codemirror/autocomplete@6.20.0)(@codemirror/language@6.12.1)(@codemirror/lint@6.9.2)(@codemirror/search@6.5.11)(@codemirror/state@6.5.3)(@codemirror/theme-one-dark@6.1.3)(@codemirror/view@6.39.9)(@swc/helpers@0.5.15)(@types/node@22.19.3)(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(codemirror@6.0.2)(cypress@15.8.2)(next@15.5.10(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react-native-reanimated@4.2.1(react-native-worklets@0.7.2(@babel/core@7.28.5)(react-native@0.81.5(@babel/core@7.28.5)(@types/react@19.2.7)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.28.5)(@types/react@19.2.7)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.28.5)(@types/react@19.2.7)(react@19.1.0))(react@19.1.0)(tailwindcss@4.1.18)(typescript@5.9.3)':
+  '@nextsparkjs/core@0.1.0-beta.102(@babel/runtime@7.28.4)(@codemirror/autocomplete@6.20.0)(@codemirror/language@6.12.1)(@codemirror/lint@6.9.2)(@codemirror/search@6.5.11)(@codemirror/state@6.5.3)(@codemirror/theme-one-dark@6.1.3)(@codemirror/view@6.39.9)(@swc/helpers@0.5.15)(@types/node@22.19.3)(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(codemirror@6.0.2)(cypress@15.8.2)(next@15.5.10(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react-native-reanimated@4.2.1(react-native-worklets@0.7.2(@babel/core@7.28.5)(react-native@0.81.5(@babel/core@7.28.5)(@types/react@19.2.7)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.28.5)(@types/react@19.2.7)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.28.5)(@types/react@19.2.7)(react@19.1.0))(react@19.1.0)(tailwindcss@4.1.18)(typescript@5.9.3)':
     dependencies:
       '@codemirror/lang-json': 6.0.2
       '@dnd-kit/core': 6.3.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
@@ -12504,8 +12581,9 @@ snapshots:
       '@dnd-kit/utilities': 3.2.2(react@19.1.0)
       '@hookform/resolvers': 5.2.2(react-hook-form@7.69.0(react@19.1.0))
       '@inquirer/prompts': 7.10.1(@types/node@22.19.3)
-      '@nextsparkjs/testing': 0.1.0-beta.100(cypress@15.8.2)
+      '@nextsparkjs/testing': 0.1.0-beta.102(cypress@15.8.2)
       '@nextsparkjs/ui': 0.1.0-beta.79(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.1.0(react@19.1.0))(react-native-reanimated@4.2.1(react-native-worklets@0.7.2(@babel/core@7.28.5)(react-native@0.81.5(@babel/core@7.28.5)(@types/react@19.2.7)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.28.5)(@types/react@19.2.7)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.28.5)(@types/react@19.2.7)(react@19.1.0))(react@19.1.0)
+      '@polar-sh/sdk': 0.43.1
       '@radix-ui/react-accordion': 1.2.12(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@radix-ui/react-alert-dialog': 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@radix-ui/react-avatar': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
@@ -12691,7 +12769,7 @@ snapshots:
       - tailwindcss
       - typescript
 
-  '@nextsparkjs/testing@0.1.0-beta.100(cypress@15.8.2)':
+  '@nextsparkjs/testing@0.1.0-beta.102(cypress@15.8.2)':
     optionalDependencies:
       cypress: 15.8.2
 
@@ -20184,6 +20262,8 @@ snapshots:
   symbol-tree@3.2.4: {}
 
   systeminformation@5.30.2: {}
+
+  tabbable@6.4.0: {}
 
   tailwind-merge@3.4.0: {}
 

--- a/themes/default/config/theme.config.ts
+++ b/themes/default/config/theme.config.ts
@@ -12,7 +12,7 @@ export const boilerplateThemeConfig: ThemeConfig = {
   description: 'Default neutral theme - black and white',
   author: 'NextSpark Team',
 
-  plugins: ['langchain', 'walkme'],
+  plugins: ['langchain'],
 
   // Styles configuration - colors come from globals.css only
   styles: {

--- a/themes/default/config/theme.config.ts
+++ b/themes/default/config/theme.config.ts
@@ -12,7 +12,7 @@ export const boilerplateThemeConfig: ThemeConfig = {
   description: 'Default neutral theme - black and white',
   author: 'NextSpark Team',
 
-  plugins: ['langchain'],
+  plugins: ['langchain', 'walkme'],
 
   // Styles configuration - colors come from globals.css only
   styles: {


### PR DESCRIPTION
## Summary

- New `plugins/walkme/` plugin providing declarative guided tours and onboarding flows
- Pure-function state machine with 5 step types (tooltip, modal, spotlight, beacon, floating)
- Cross-page and per-window tour support with smart positioning via @floating-ui/react
- Full i18n labels system, WCAG AA accessibility, localStorage persistence, Zod validation
- 165 unit tests with 91.25% statement coverage

## Architecture

```
plugins/walkme/
├── lib/           # Core engine: state machine, validation, storage, targeting, triggers, conditions, positioning
├── hooks/         # React hooks: useWalkme, useTour, useTourProgress, useTourState
├── components/    # UI: Provider, Tooltip, Modal, Spotlight, Beacon, Overlay, Progress, Controls
├── providers/     # WalkmeContext
├── types/         # Full TypeScript type system (WalkmeState, Tour, TourStep, WalkmeLabels, etc.)
├── messages/      # i18n: en.json, es.json
├── examples/      # Usage examples: basic, cross-window, conditional tours
└── tests/         # 7 test suites, 165 tests, 91%+ coverage
```

## Key Features

| Feature | Implementation |
|---------|---------------|
| Step types | tooltip, modal, spotlight, beacon, floating |
| Triggers | onFirstVisit, onRouteEnter, onEvent, manual, scheduled |
| Conditions | userRole, featureFlags, completedTours, notCompletedTours, custom |
| Cross-page | Next.js router.push() + waitForTarget after navigation |
| Positioning | @floating-ui/react with auto-flip, shift, offset |
| Persistence | localStorage with schema versioning + migration |
| Validation | Zod v4 schemas for all tour configurations |
| i18n | WalkmeLabels prop + en/es message files |
| Accessibility | ARIA roles, focus trap, keyboard nav, aria-live region |
| Analytics | onTourStart, onTourComplete, onTourSkip, onStepChange callbacks |

## Test plan

- [x] 165 unit tests passing (core, validation, storage, triggers, conditions, targeting, positioning)
- [x] 91.25% statement coverage, 94.32% line coverage
- [x] No duplicate dependencies (`pnpm ls @floating-ui/react` and `pnpm ls zod` clean)
- [x] 12 data-cy selectors on all interactive components
- [x] All 17 acceptance criteria verified
- [ ] Hook tests (useWalkme, useTour, useTourProgress) — deferred to follow-up
- [ ] E2E Cypress tests — deferred to theme integration

🤖 Generated with [Claude Code](https://claude.com/claude-code)