### PR TITLE
feat(marketplace): Stripe Connect + MercadoPago Split payment splitting

### DIFF
--- a/apps/dev/app/api/v1/marketplace/account/route.ts
+++ b/apps/dev/app/api/v1/marketplace/account/route.ts
@@ -1,0 +1,120 @@
+/**
+ * Marketplace Account Endpoint
+ *
+ * GET - Retrieve the connected account status for the current team
+ * Returns onboarding status, charges/payouts enabled, commission rate, and dashboard link.
+ */
+
+import { NextRequest, NextResponse } from 'next/server'
+import { authenticateRequest, createAuthError } from '@nextsparkjs/core/lib/api/auth/dual-auth'
+import { MembershipService } from '@nextsparkjs/core/lib/services'
+import { getMarketplaceGateway } from '@nextsparkjs/core/lib/marketplace'
+import { queryOne } from '@nextsparkjs/core/lib/db'
+import { withRateLimitTier } from '@nextsparkjs/core/lib/api/rate-limit'
+
+export const GET = withRateLimitTier(async (request: NextRequest) => {
+  // 1. Authentication
+  const authResult = await authenticateRequest(request)
+  if (!authResult.success || !authResult.user) {
+    return createAuthError('Unauthorized', 401)
+  }
+
+  // 2. Team context
+  const teamId = request.headers.get('x-team-id') || authResult.user.defaultTeamId
+  if (!teamId) {
+    return NextResponse.json(
+      { success: false, error: 'No team context. Provide x-team-id header.' },
+      { status: 400 }
+    )
+  }
+
+  // 3. Permission check
+  const membership = await MembershipService.get(authResult.user.id, teamId)
+  const actionResult = membership.canPerformAction('billing.checkout')
+  if (!actionResult.allowed) {
+    return NextResponse.json(
+      { success: false, error: actionResult.message },
+      { status: 403 }
+    )
+  }
+
+  // 4. Get connected account from DB
+  const account = await queryOne<{
+    id: string
+    provider: string
+    externalAccountId: string
+    email: string
+    businessName: string | null
+    country: string
+    currency: string
+    onboardingStatus: string
+    chargesEnabled: boolean
+    payoutsEnabled: boolean
+    commissionRate: number
+    fixedFee: number
+    payoutSchedule: string
+    createdAt: string
+  }>(
+    `SELECT id, provider, "externalAccountId", email, "businessName",
+            country, currency, "onboardingStatus", "chargesEnabled", "payoutsEnabled",
+            "commissionRate", "fixedFee", "payoutSchedule", "createdAt"
+     FROM "connectedAccounts"
+     WHERE "teamId" = $1
+     LIMIT 1`,
+    [teamId]
+  )
+
+  if (!account) {
+    return NextResponse.json({
+      success: true,
+      data: {
+        connected: false,
+        account: null,
+      },
+    })
+  }
+
+  // 5. Get fresh status from provider (if account is not fully active)
+  let dashboardUrl: string | null = null
+  let balance: { available: number; pending: number } | null = null
+
+  const gateway = getMarketplaceGateway()
+
+  try {
+    if (account.chargesEnabled) {
+      // Get dashboard link
+      const dashboardLink = await gateway.createDashboardLink(account.externalAccountId)
+      dashboardUrl = dashboardLink.url
+
+      // Get balance
+      const balanceResult = await gateway.getAccountBalance(account.externalAccountId)
+      balance = { available: balanceResult.available, pending: balanceResult.pending }
+    }
+  } catch (error) {
+    console.warn('[marketplace/account] Error fetching provider data:', error)
+  }
+
+  return NextResponse.json({
+    success: true,
+    data: {
+      connected: true,
+      account: {
+        id: account.id,
+        provider: account.provider,
+        email: account.email,
+        businessName: account.businessName,
+        country: account.country,
+        currency: account.currency,
+        onboardingStatus: account.onboardingStatus,
+        chargesEnabled: account.chargesEnabled,
+        payoutsEnabled: account.payoutsEnabled,
+        commissionRate: account.commissionRate,
+        fixedFee: account.fixedFee,
+        payoutSchedule: account.payoutSchedule,
+        createdAt: account.createdAt,
+        dashboardUrl,
+        balance,
+      },
+    },
+  })
+}, 'read')

--- a/apps/dev/app/api/v1/marketplace/checkout/route.ts
+++ b/apps/dev/app/api/v1/marketplace/checkout/route.ts
@@ -1,0 +1,157 @@
+/**
+ * Marketplace Checkout Endpoint
+ *
+ * Creates a checkout session for a marketplace payment (e.g., booking a service).
+ * The payment is split between the platform (commission) and the business.
+ *
+ * POST /api/v1/marketplace/checkout
+ * Body: { connectedAccountId, amount, currency, referenceId, referenceType, description, customerEmail? }
+ * Returns: { url, paymentId }
+ */
+
+import { NextRequest, NextResponse } from 'next/server'
+import { z } from 'zod'
+import { authenticateRequest, createAuthError } from '@nextsparkjs/core/lib/api/auth/dual-auth'
+import { getMarketplaceGateway, calculateFee } from '@nextsparkjs/core/lib/marketplace'
+import { query, queryOne } from '@nextsparkjs/core/lib/db'
+import { withRateLimitTier } from '@nextsparkjs/core/lib/api/rate-limit'
+import type { CommissionConfig } from '@nextsparkjs/core/lib/marketplace'
+
+const checkoutSchema = z.object({
+  connectedAccountId: z.string().min(1, 'Connected account ID is required'),
+  amount: z.number().int().positive('Amount must be positive'),
+  currency: z.string().length(3).default('usd'),
+  referenceId: z.string().min(1, 'Reference ID is required (e.g., booking ID)'),
+  referenceType: z.string().min(1).default('booking'),
+  description: z.string().min(1, 'Description is required'),
+  customerEmail: z.string().email().optional(),
+  metadata: z.record(z.string(), z.string()).optional(),
+})
+
+export const POST = withRateLimitTier(async (request: NextRequest) => {
+  // 1. Authentication (customer or API key)
+  const authResult = await authenticateRequest(request)
+  if (!authResult.success || !authResult.user) {
+    return createAuthError('Unauthorized', 401)
+  }
+
+  // 2. Validate body
+  let body: Record<string, unknown>
+  try {
+    body = await request.json()
+  } catch {
+    return NextResponse.json({ success: false, error: 'Invalid JSON body' }, { status: 400 })
+  }
+
+  const parseResult = checkoutSchema.safeParse(body)
+  if (!parseResult.success) {
+    return NextResponse.json(
+      { success: false, error: 'Validation failed', details: parseResult.error.issues },
+      { status: 400 }
+    )
+  }
+
+  const { connectedAccountId, amount, currency, referenceId, referenceType, description, customerEmail, metadata } = parseResult.data
+
+  // 3. Get connected account
+  const account = await queryOne<{
+    id: string
+    teamId: string
+    externalAccountId: string
+    commissionRate: number
+    fixedFee: number
+    chargesEnabled: boolean
+    onboardingStatus: string
+    provider: string
+  }>(
+    `SELECT id, "teamId", "externalAccountId", "commissionRate", "fixedFee",
+            "chargesEnabled", "onboardingStatus", provider
+     FROM "connectedAccounts"
+     WHERE id = $1`,
+    [connectedAccountId]
+  )
+
+  if (!account) {
+    return NextResponse.json(
+      { success: false, error: 'Connected account not found' },
+      { status: 404 }
+    )
+  }
+
+  if (!account.chargesEnabled) {
+    return NextResponse.json(
+      { success: false, error: 'Connected account cannot accept payments yet. Complete onboarding first.' },
+      { status: 400 }
+    )
+  }
+
+  // 4. Calculate commission
+  const commissionConfig: CommissionConfig = {
+    model: account.fixedFee > 0 ? 'hybrid' : 'percentage',
+    rate: account.commissionRate,
+    fixedFee: account.fixedFee || undefined,
+  }
+  const applicationFee = calculateFee(amount, commissionConfig)
+  const businessAmount = amount - applicationFee
+
+  // 5. Create checkout session
+  const gateway = getMarketplaceGateway()
+  const appUrl = process.env.NEXT_PUBLIC_APP_URL || 'http://localhost:5173'
+
+  try {
+    const result = await gateway.createMarketplaceCheckout({
+      connectedAccountId: account.id,
+      externalAccountId: account.externalAccountId,
+      amount,
+      currency,
+      applicationFee,
+      referenceId,
+      description,
+      customerEmail: customerEmail || authResult.user.email || undefined,
+      successUrl: `${appUrl}/booking/${referenceId}/success`,
+      cancelUrl: `${appUrl}/booking/${referenceId}/cancel`,
+      metadata,
+    })
+
+    // 6. Record the payment intent in our DB
+    await query(
+      `INSERT INTO "marketplacePayments" (
+        "connectedAccountId", "teamId", "referenceId", "referenceType",
+        "externalPaymentId", "totalAmount", "applicationFee", "businessAmount",
+        currency, "commissionRate", status, metadata
+      ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)`,
+      [
+        account.id,
+        account.teamId,
+        referenceId,
+        referenceType,
+        result.id,
+        amount,
+        applicationFee,
+        businessAmount,
+        currency,
+        account.commissionRate,
+        'pending',
+        JSON.stringify(metadata || {}),
+      ]
+    )
+
+    return NextResponse.json({
+      success: true,
+      data: {
+        url: result.url,
+        paymentId: result.id,
+        amount,
+        applicationFee,
+        businessAmount,
+        currency,
+      },
+    })
+  } catch (error) {
+    console.error('[marketplace/checkout] Error:', error)
+    return NextResponse.json(
+      { success: false, error: error instanceof Error ? error.message : 'Failed to create checkout' },
+      { status: 500 }
+    )
+  }
+}, 'write')

--- a/apps/dev/app/api/v1/marketplace/connect/route.ts
+++ b/apps/dev/app/api/v1/marketplace/connect/route.ts
@@ -11,6 +11,7 @@
  */
 
 import { NextRequest, NextResponse } from 'next/server'
+import { randomUUID } from 'crypto'
 import { z } from 'zod'
 import { authenticateRequest, createAuthError } from '@nextsparkjs/core/lib/api/auth/dual-auth'
 import { MembershipService } from '@nextsparkjs/core/lib/services'
@@ -80,10 +81,24 @@ export const POST = withRateLimitTier(async (request: NextRequest) => {
   // If account exists but onboarding is incomplete, generate a new link
   if (existing && existing.onboardingStatus !== 'active') {
     try {
+      // Generate a cryptographic state token for OAuth CSRF protection
+      const oauthState = randomUUID()
+      await query(
+        `UPDATE "connectedAccounts"
+         SET metadata = jsonb_set(
+           COALESCE(metadata, '{}'::jsonb),
+           '{oauthState}',
+           to_jsonb($1::text)
+         ),
+         "updatedAt" = NOW()
+         WHERE id = $2`,
+        [oauthState, existing.id]
+      )
+
       const link = await gateway.createOnboardingLink({
-        externalAccountId: existing.externalAccountId,
+        externalAccountId: oauthState,
         refreshUrl: `${appUrl}/dashboard/settings/marketplace?refresh=true`,
-        returnUrl: `${appUrl}/dashboard/settings/marketplace?onboarding=complete`,
+        returnUrl: `${appUrl}/api/v1/marketplace/oauth/callback`,
       })
 
       return NextResponse.json({
@@ -127,13 +142,16 @@ export const POST = withRateLimitTier(async (request: NextRequest) => {
     }
     const currency = currencyMap[country.toUpperCase()] || 'usd'
 
-    // 7. Save to database
+    // Generate a cryptographic state token for OAuth CSRF protection
+    const oauthState = randomUUID()
+
+    // 7. Save to database (with oauthState in metadata)
     const result = await queryOne<{ id: string }>(
       `INSERT INTO "connectedAccounts" (
         "teamId", provider, "externalAccountId", email, "businessName",
         country, currency, "onboardingStatus", "chargesEnabled", "payoutsEnabled",
-        "commissionRate"
-      ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
+        "commissionRate", metadata
+      ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)
       RETURNING id`,
       [
         teamId,
@@ -147,14 +165,15 @@ export const POST = withRateLimitTier(async (request: NextRequest) => {
         account.chargesEnabled,
         account.payoutsEnabled,
         0.15, // Default 15% commission
+        JSON.stringify({ oauthState }),
       ]
     )
 
-    // 8. Generate onboarding link
+    // 8. Generate onboarding link (pass state token, NOT teamId)
     const link = await gateway.createOnboardingLink({
-      externalAccountId: account.id,
+      externalAccountId: oauthState,
       refreshUrl: `${appUrl}/dashboard/settings/marketplace?refresh=true`,
-      returnUrl: `${appUrl}/dashboard/settings/marketplace?onboarding=complete`,
+      returnUrl: `${appUrl}/api/v1/marketplace/oauth/callback`,
     })
 
     return NextResponse.json({

--- a/apps/dev/app/api/v1/marketplace/connect/route.ts
+++ b/apps/dev/app/api/v1/marketplace/connect/route.ts
@@ -1,0 +1,176 @@
+/**
+ * Marketplace Connect Endpoint
+ *
+ * Creates a connected account and returns an onboarding link.
+ * The business owner is redirected to Stripe (Account Links) or MercadoPago (OAuth)
+ * to complete their onboarding.
+ *
+ * POST /api/v1/marketplace/connect
+ * Body: { country, businessName?, businessType? }
+ * Returns: { onboardingUrl, accountId }
+ */
+
+import { NextRequest, NextResponse } from 'next/server'
+import { z } from 'zod'
+import { authenticateRequest, createAuthError } from '@nextsparkjs/core/lib/api/auth/dual-auth'
+import { MembershipService } from '@nextsparkjs/core/lib/services'
+import { getMarketplaceGateway } from '@nextsparkjs/core/lib/marketplace'
+import { query, queryOne } from '@nextsparkjs/core/lib/db'
+import { withRateLimitTier } from '@nextsparkjs/core/lib/api/rate-limit'
+
+const connectSchema = z.object({
+  country: z.string().length(2, 'Country must be ISO 3166-1 alpha-2 (e.g., US, AR, BR)'),
+  businessName: z.string().min(1).max(200).optional(),
+  businessType: z.enum(['individual', 'company']).default('individual'),
+})
+
+export const POST = withRateLimitTier(async (request: NextRequest) => {
+  // 1. Authentication
+  const authResult = await authenticateRequest(request)
+  if (!authResult.success || !authResult.user) {
+    return createAuthError('Unauthorized', 401)
+  }
+
+  // 2. Team context
+  const teamId = request.headers.get('x-team-id') || authResult.user.defaultTeamId
+  if (!teamId) {
+    return NextResponse.json(
+      { success: false, error: 'No team context. Provide x-team-id header.' },
+      { status: 400 }
+    )
+  }
+
+  // 3. Permission check (team owner/admin)
+  const membership = await MembershipService.get(authResult.user.id, teamId)
+  const actionResult = membership.canPerformAction('billing.checkout')
+  if (!actionResult.allowed) {
+    return NextResponse.json(
+      { success: false, error: actionResult.message, reason: actionResult.reason },
+      { status: 403 }
+    )
+  }
+
+  // 4. Validate body
+  let body: Record<string, unknown>
+  try {
+    body = await request.json()
+  } catch {
+    return NextResponse.json({ success: false, error: 'Invalid JSON body' }, { status: 400 })
+  }
+
+  const parseResult = connectSchema.safeParse(body)
+  if (!parseResult.success) {
+    return NextResponse.json(
+      { success: false, error: 'Validation failed', details: parseResult.error.issues },
+      { status: 400 }
+    )
+  }
+
+  const { country, businessName, businessType } = parseResult.data
+
+  // 5. Check if team already has a connected account
+  const existing = await queryOne<{ id: string; onboardingStatus: string; externalAccountId: string }>(
+    `SELECT id, "onboardingStatus", "externalAccountId" FROM "connectedAccounts" WHERE "teamId" = $1 LIMIT 1`,
+    [teamId]
+  )
+
+  const gateway = getMarketplaceGateway()
+  const appUrl = process.env.NEXT_PUBLIC_APP_URL || 'http://localhost:5173'
+
+  // If account exists but onboarding is incomplete, generate a new link
+  if (existing && existing.onboardingStatus !== 'active') {
+    try {
+      const link = await gateway.createOnboardingLink({
+        externalAccountId: existing.externalAccountId,
+        refreshUrl: `${appUrl}/dashboard/settings/marketplace?refresh=true`,
+        returnUrl: `${appUrl}/dashboard/settings/marketplace?onboarding=complete`,
+      })
+
+      return NextResponse.json({
+        success: true,
+        data: {
+          onboardingUrl: link.url,
+          accountId: existing.id,
+          status: existing.onboardingStatus,
+          isResuming: true,
+        },
+      })
+    } catch (error) {
+      console.error('[marketplace/connect] Error creating onboarding link:', error)
+      return NextResponse.json(
+        { success: false, error: 'Failed to create onboarding link' },
+        { status: 500 }
+      )
+    }
+  }
+
+  if (existing && existing.onboardingStatus === 'active') {
+    return NextResponse.json(
+      { success: false, error: 'Team already has an active connected account' },
+      { status: 409 }
+    )
+  }
+
+  // 6. Create connected account
+  try {
+    const account = await gateway.createConnectedAccount({
+      teamId,
+      email: authResult.user.email || '',
+      businessName,
+      country,
+      businessType,
+    })
+
+    // Determine currency from country
+    const currencyMap: Record<string, string> = {
+      US: 'usd', GB: 'gbp', AR: 'ars', BR: 'brl', MX: 'mxn', CO: 'cop',
+    }
+    const currency = currencyMap[country.toUpperCase()] || 'usd'
+
+    // 7. Save to database
+    const result = await queryOne<{ id: string }>(
+      `INSERT INTO "connectedAccounts" (
+        "teamId", provider, "externalAccountId", email, "businessName",
+        country, currency, "onboardingStatus", "chargesEnabled", "payoutsEnabled",
+        "commissionRate"
+      ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
+      RETURNING id`,
+      [
+        teamId,
+        gateway.provider,
+        account.id,
+        account.email,
+        businessName || null,
+        country,
+        currency,
+        account.onboardingStatus,
+        account.chargesEnabled,
+        account.payoutsEnabled,
+        0.15, // Default 15% commission
+      ]
+    )
+
+    // 8. Generate onboarding link
+    const link = await gateway.createOnboardingLink({
+      externalAccountId: account.id,
+      refreshUrl: `${appUrl}/dashboard/settings/marketplace?refresh=true`,
+      returnUrl: `${appUrl}/dashboard/settings/marketplace?onboarding=complete`,
+    })
+
+    return NextResponse.json({
+      success: true,
+      data: {
+        onboardingUrl: link.url,
+        accountId: result?.id,
+        externalAccountId: account.id,
+        status: account.onboardingStatus,
+      },
+    })
+  } catch (error) {
+    console.error('[marketplace/connect] Error:', error)
+    return NextResponse.json(
+      { success: false, error: error instanceof Error ? error.message : 'Failed to create connected account' },
+      { status: 500 }
+    )
+  }
+}, 'write')

--- a/apps/dev/app/api/v1/marketplace/oauth/callback/route.ts
+++ b/apps/dev/app/api/v1/marketplace/oauth/callback/route.ts
@@ -4,18 +4,25 @@
  * Handles the OAuth callback from MercadoPago when a seller authorizes the platform.
  * Exchanges the authorization code for access/refresh tokens and saves the connected account.
  *
- * GET /api/v1/marketplace/oauth/callback?code=xxx&state=teamId
+ * GET /api/v1/marketplace/oauth/callback?code=xxx&state=<oauthStateToken>
+ *
+ * Security: The `state` parameter is a cryptographic token (UUID) that was generated
+ * by the /connect endpoint and stored in the connectedAccounts metadata. This prevents
+ * OAuth CSRF attacks where an attacker could link their MP account to a victim's team.
  *
  * This is only used for MercadoPago. Stripe Connect uses Account Links (no OAuth).
  */
 
 import { NextRequest, NextResponse } from 'next/server'
 import { exchangeMPAuthorizationCode } from '@nextsparkjs/core/lib/marketplace'
+import { encryptTokens } from '@nextsparkjs/core/lib/marketplace/token-encryption'
+import { authenticateRequest, createAuthError } from '@nextsparkjs/core/lib/api/auth/dual-auth'
+import { MembershipService } from '@nextsparkjs/core/lib/services'
 import { query, queryOne } from '@nextsparkjs/core/lib/db'
 
 export async function GET(request: NextRequest) {
   const code = request.nextUrl.searchParams.get('code')
-  const state = request.nextUrl.searchParams.get('state') // Contains teamId or account reference
+  const state = request.nextUrl.searchParams.get('state') // Cryptographic state token (NOT teamId)
 
   const appUrl = process.env.NEXT_PUBLIC_APP_URL || 'http://localhost:5173'
 
@@ -29,103 +36,73 @@ export async function GET(request: NextRequest) {
     return NextResponse.redirect(`${appUrl}/dashboard/settings/marketplace?error=no_state`)
   }
 
+  // 1. Authentication check - user must be logged in
+  const authResult = await authenticateRequest(request)
+  if (!authResult.success || !authResult.user) {
+    return createAuthError('Unauthorized - OAuth callback requires authentication', 401)
+  }
+
+  // 2. Look up the connected account by oauthState token (cryptographic lookup, not teamId)
+  const account = await queryOne<{ id: string; teamId: string }>(
+    `SELECT id, "teamId" FROM "connectedAccounts"
+     WHERE metadata->>'oauthState' = $1
+     LIMIT 1`,
+    [state]
+  )
+
+  if (!account) {
+    console.error('[marketplace/oauth] Invalid or expired state token')
+    return NextResponse.redirect(`${appUrl}/dashboard/settings/marketplace?error=invalid_state`)
+  }
+
+  // 3. Verify the authenticated user is a member of the team that owns this account
   try {
-    // 1. Exchange code for tokens
+    const membership = await MembershipService.get(authResult.user.id, account.teamId)
+    const actionResult = membership.canPerformAction('billing.checkout')
+    if (!actionResult.allowed) {
+      console.error(`[marketplace/oauth] User ${authResult.user.id} is not authorized for team ${account.teamId}`)
+      return NextResponse.redirect(`${appUrl}/dashboard/settings/marketplace?error=unauthorized`)
+    }
+  } catch {
+    console.error(`[marketplace/oauth] User ${authResult.user.id} is not a member of team ${account.teamId}`)
+    return NextResponse.redirect(`${appUrl}/dashboard/settings/marketplace?error=unauthorized`)
+  }
+
+  try {
+    // 4. Exchange code for tokens
     const redirectUri = `${appUrl}/api/v1/marketplace/oauth/callback`
     const tokens = await exchangeMPAuthorizationCode(code, redirectUri)
 
-    // 2. Check if this MP user is already connected
-    const existing = await queryOne<{ id: string }>(
-      `SELECT id FROM "connectedAccounts" WHERE "externalAccountId" = $1`,
-      [String(tokens.userId)]
+    // 5. Encrypt tokens before storing
+    const encryptedMPTokens = encryptTokens({
+      accessToken: tokens.accessToken,
+      refreshToken: tokens.refreshToken,
+      expiresAt: new Date(Date.now() + tokens.expiresIn * 1000).toISOString(),
+      publicKey: tokens.publicKey,
+    })
+
+    // 6. Update the account with MP data and clear the oauthState (one-time use / replay protection)
+    await query(
+      `UPDATE "connectedAccounts"
+       SET "externalAccountId" = $1,
+           "onboardingStatus" = 'active',
+           "chargesEnabled" = true,
+           "payoutsEnabled" = true,
+           metadata = jsonb_set(
+             COALESCE(metadata, '{}'::jsonb) - 'oauthState',
+             '{mpTokens}',
+             $2::jsonb
+           ),
+           "updatedAt" = NOW()
+       WHERE id = $3`,
+      [
+        String(tokens.userId),
+        JSON.stringify(encryptedMPTokens),
+        account.id,
+      ]
     )
 
-    if (existing) {
-      // Update existing account with new tokens
-      await query(
-        `UPDATE "connectedAccounts"
-         SET "onboardingStatus" = 'active',
-             "chargesEnabled" = true,
-             "payoutsEnabled" = true,
-             metadata = jsonb_set(
-               COALESCE(metadata, '{}'::jsonb),
-               '{mpTokens}',
-               $1::jsonb
-             ),
-             "updatedAt" = NOW()
-         WHERE id = $2`,
-        [
-          JSON.stringify({
-            accessToken: tokens.accessToken,
-            refreshToken: tokens.refreshToken,
-            expiresAt: new Date(Date.now() + tokens.expiresIn * 1000).toISOString(),
-            publicKey: tokens.publicKey,
-          }),
-          existing.id,
-        ]
-      )
-
-      return NextResponse.redirect(`${appUrl}/dashboard/settings/marketplace?onboarding=complete&reconnected=true`)
-    }
-
-    // 3. Check if we have a pending account for this state (teamId)
-    const pendingAccount = await queryOne<{ id: string; teamId: string }>(
-      `SELECT id, "teamId" FROM "connectedAccounts"
-       WHERE "teamId" = $1 AND "onboardingStatus" = 'pending'
-       LIMIT 1`,
-      [state]
-    )
-
-    if (pendingAccount) {
-      // Update pending account with MP data
-      await query(
-        `UPDATE "connectedAccounts"
-         SET "externalAccountId" = $1,
-             "onboardingStatus" = 'active',
-             "chargesEnabled" = true,
-             "payoutsEnabled" = true,
-             metadata = jsonb_set(
-               COALESCE(metadata, '{}'::jsonb),
-               '{mpTokens}',
-               $2::jsonb
-             ),
-             "updatedAt" = NOW()
-         WHERE id = $3`,
-        [
-          String(tokens.userId),
-          JSON.stringify({
-            accessToken: tokens.accessToken,
-            refreshToken: tokens.refreshToken,
-            expiresAt: new Date(Date.now() + tokens.expiresIn * 1000).toISOString(),
-            publicKey: tokens.publicKey,
-          }),
-          pendingAccount.id,
-        ]
-      )
-    } else {
-      // Create new connected account (OAuth-first flow)
-      await query(
-        `INSERT INTO "connectedAccounts" (
-          "teamId", provider, "externalAccountId", email,
-          country, currency, "onboardingStatus", "chargesEnabled", "payoutsEnabled",
-          "commissionRate", metadata
-        ) VALUES ($1, 'mercadopago_split', $2, '', 'AR', 'ars', 'active', true, true, 0.15, $3)`,
-        [
-          state,
-          String(tokens.userId),
-          JSON.stringify({
-            mpTokens: {
-              accessToken: tokens.accessToken,
-              refreshToken: tokens.refreshToken,
-              expiresAt: new Date(Date.now() + tokens.expiresIn * 1000).toISOString(),
-              publicKey: tokens.publicKey,
-            },
-          }),
-        ]
-      )
-    }
-
-    console.log(`[marketplace/oauth] Successfully connected MP user ${tokens.userId} for team ${state}`)
+    console.log(`[marketplace/oauth] Successfully connected MP user ${tokens.userId} for team ${account.teamId}`)
     return NextResponse.redirect(`${appUrl}/dashboard/settings/marketplace?onboarding=complete`)
   } catch (error) {
     console.error('[marketplace/oauth] Error exchanging code:', error)

--- a/apps/dev/app/api/v1/marketplace/oauth/callback/route.ts
+++ b/apps/dev/app/api/v1/marketplace/oauth/callback/route.ts
@@ -1,0 +1,134 @@
+/**
+ * MercadoPago OAuth Callback
+ *
+ * Handles the OAuth callback from MercadoPago when a seller authorizes the platform.
+ * Exchanges the authorization code for access/refresh tokens and saves the connected account.
+ *
+ * GET /api/v1/marketplace/oauth/callback?code=xxx&state=teamId
+ *
+ * This is only used for MercadoPago. Stripe Connect uses Account Links (no OAuth).
+ */
+
+import { NextRequest, NextResponse } from 'next/server'
+import { exchangeMPAuthorizationCode } from '@nextsparkjs/core/lib/marketplace'
+import { query, queryOne } from '@nextsparkjs/core/lib/db'
+
+export async function GET(request: NextRequest) {
+  const code = request.nextUrl.searchParams.get('code')
+  const state = request.nextUrl.searchParams.get('state') // Contains teamId or account reference
+
+  const appUrl = process.env.NEXT_PUBLIC_APP_URL || 'http://localhost:5173'
+
+  if (!code) {
+    console.error('[marketplace/oauth] No authorization code received')
+    return NextResponse.redirect(`${appUrl}/dashboard/settings/marketplace?error=no_code`)
+  }
+
+  if (!state) {
+    console.error('[marketplace/oauth] No state parameter received')
+    return NextResponse.redirect(`${appUrl}/dashboard/settings/marketplace?error=no_state`)
+  }
+
+  try {
+    // 1. Exchange code for tokens
+    const redirectUri = `${appUrl}/api/v1/marketplace/oauth/callback`
+    const tokens = await exchangeMPAuthorizationCode(code, redirectUri)
+
+    // 2. Check if this MP user is already connected
+    const existing = await queryOne<{ id: string }>(
+      `SELECT id FROM "connectedAccounts" WHERE "externalAccountId" = $1`,
+      [String(tokens.userId)]
+    )
+
+    if (existing) {
+      // Update existing account with new tokens
+      await query(
+        `UPDATE "connectedAccounts"
+         SET "onboardingStatus" = 'active',
+             "chargesEnabled" = true,
+             "payoutsEnabled" = true,
+             metadata = jsonb_set(
+               COALESCE(metadata, '{}'::jsonb),
+               '{mpTokens}',
+               $1::jsonb
+             ),
+             "updatedAt" = NOW()
+         WHERE id = $2`,
+        [
+          JSON.stringify({
+            accessToken: tokens.accessToken,
+            refreshToken: tokens.refreshToken,
+            expiresAt: new Date(Date.now() + tokens.expiresIn * 1000).toISOString(),
+            publicKey: tokens.publicKey,
+          }),
+          existing.id,
+        ]
+      )
+
+      return NextResponse.redirect(`${appUrl}/dashboard/settings/marketplace?onboarding=complete&reconnected=true`)
+    }
+
+    // 3. Check if we have a pending account for this state (teamId)
+    const pendingAccount = await queryOne<{ id: string; teamId: string }>(
+      `SELECT id, "teamId" FROM "connectedAccounts"
+       WHERE "teamId" = $1 AND "onboardingStatus" = 'pending'
+       LIMIT 1`,
+      [state]
+    )
+
+    if (pendingAccount) {
+      // Update pending account with MP data
+      await query(
+        `UPDATE "connectedAccounts"
+         SET "externalAccountId" = $1,
+             "onboardingStatus" = 'active',
+             "chargesEnabled" = true,
+             "payoutsEnabled" = true,
+             metadata = jsonb_set(
+               COALESCE(metadata, '{}'::jsonb),
+               '{mpTokens}',
+               $2::jsonb
+             ),
+             "updatedAt" = NOW()
+         WHERE id = $3`,
+        [
+          String(tokens.userId),
+          JSON.stringify({
+            accessToken: tokens.accessToken,
+            refreshToken: tokens.refreshToken,
+            expiresAt: new Date(Date.now() + tokens.expiresIn * 1000).toISOString(),
+            publicKey: tokens.publicKey,
+          }),
+          pendingAccount.id,
+        ]
+      )
+    } else {
+      // Create new connected account (OAuth-first flow)
+      await query(
+        `INSERT INTO "connectedAccounts" (
+          "teamId", provider, "externalAccountId", email,
+          country, currency, "onboardingStatus", "chargesEnabled", "payoutsEnabled",
+          "commissionRate", metadata
+        ) VALUES ($1, 'mercadopago_split', $2, '', 'AR', 'ars', 'active', true, true, 0.15, $3)`,
+        [
+          state,
+          String(tokens.userId),
+          JSON.stringify({
+            mpTokens: {
+              accessToken: tokens.accessToken,
+              refreshToken: tokens.refreshToken,
+              expiresAt: new Date(Date.now() + tokens.expiresIn * 1000).toISOString(),
+              publicKey: tokens.publicKey,
+            },
+          }),
+        ]
+      )
+    }
+
+    console.log(`[marketplace/oauth] Successfully connected MP user ${tokens.userId} for team ${state}`)
+    return NextResponse.redirect(`${appUrl}/dashboard/settings/marketplace?onboarding=complete`)
+  } catch (error) {
+    console.error('[marketplace/oauth] Error exchanging code:', error)
+    return NextResponse.redirect(`${appUrl}/dashboard/settings/marketplace?error=oauth_failed`)
+  }
+}

--- a/apps/dev/app/api/v1/marketplace/webhooks/mercadopago/route.ts
+++ b/apps/dev/app/api/v1/marketplace/webhooks/mercadopago/route.ts
@@ -1,0 +1,24 @@
+/**
+ * MercadoPago Marketplace Webhook Route
+ *
+ * Handles MercadoPago webhook notifications for marketplace split payments.
+ * Rate limiting: 500 requests/hour per IP (tier: webhook).
+ * Signature verification via x-signature HMAC-SHA256 is the primary security layer.
+ *
+ * Configure this URL in MercadoPago Dashboard > Webhooks:
+ *   https://yourdomain.com/api/v1/marketplace/webhooks/mercadopago
+ *
+ * Events to enable: payment
+ */
+
+import { NextRequest } from 'next/server'
+import { handleMPMarketplaceWebhook } from '@nextsparkjs/core/lib/marketplace/mercadopago-webhook'
+import { mpMarketplaceWebhookExtensions } from '@/lib/marketplace/mp-webhook-extensions'
+import { withRateLimitTier } from '@nextsparkjs/core/lib/api/rate-limit'
+
+export const POST = withRateLimitTier(
+  async (request: NextRequest) => {
+    return handleMPMarketplaceWebhook(request, mpMarketplaceWebhookExtensions)
+  },
+  'webhook'
+)

--- a/apps/dev/app/api/v1/marketplace/webhooks/stripe-connect/route.ts
+++ b/apps/dev/app/api/v1/marketplace/webhooks/stripe-connect/route.ts
@@ -1,0 +1,23 @@
+/**
+ * Stripe Connect Webhook Handler
+ *
+ * Handles Stripe Connect events for marketplace payment splitting.
+ * Uses a SEPARATE signing secret from regular billing webhooks (STRIPE_CONNECT_WEBHOOK_SECRET).
+ *
+ * Rate limiting: 500 requests/hour per IP (tier: webhook).
+ */
+
+import { NextRequest } from 'next/server'
+import { handleStripeConnectWebhook } from '@nextsparkjs/core/lib/marketplace/stripe-connect-webhook'
+import { withRateLimitTier } from '@nextsparkjs/core/lib/api/rate-limit'
+
+export const POST = withRateLimitTier(
+  async (request: NextRequest) => {
+    return handleStripeConnectWebhook(request, {
+      // Add custom handlers here:
+      // onPaymentSucceeded: async (pi, accountId) => { ... },
+      // onDisputeCreated: async (dispute, accountId) => { ... },
+    })
+  },
+  'webhook'
+)

--- a/apps/dev/lib/marketplace/mp-webhook-extensions.ts
+++ b/apps/dev/lib/marketplace/mp-webhook-extensions.ts
@@ -1,0 +1,25 @@
+/**
+ * MercadoPago Marketplace Webhook Extensions
+ *
+ * Override these callbacks to handle marketplace-specific payment events.
+ * This is the theme/project-level customization point.
+ *
+ * Example: fulfill an order when payment is approved, notify seller on chargeback, etc.
+ *
+ * import type { MPMarketplaceWebhookExtensions } from '@nextsparkjs/core/lib/marketplace/mercadopago-webhook'
+ *
+ * export const mpMarketplaceWebhookExtensions: MPMarketplaceWebhookExtensions = {
+ *   onPaymentApproved: async (payment, context) => {
+ *     // Fulfill the order
+ *     await fulfillOrder(context.referenceId)
+ *   },
+ *   onChargeBack: async (payment, context) => {
+ *     // Freeze seller payouts, notify admin
+ *     await handleChargeback(context.connectedAccountId, payment.id)
+ *   },
+ * }
+ */
+
+import type { MPMarketplaceWebhookExtensions } from '@nextsparkjs/core/lib/marketplace/mercadopago-webhook'
+
+export const mpMarketplaceWebhookExtensions: MPMarketplaceWebhookExtensions = {}

--- a/packages/core/jest.config.cjs
+++ b/packages/core/jest.config.cjs
@@ -48,6 +48,7 @@ module.exports = {
     // Mock ESM modules that cause import issues
     '^better-auth$': '<rootDir>/tests/jest/__mocks__/better-auth.js',
     '^better-auth/next-js$': '<rootDir>/tests/jest/__mocks__/better-auth-next.js',
+    '^better-auth/plugins$': '<rootDir>/tests/jest/__mocks__/better-auth-plugins.js',
   },
   setupFilesAfterEnv: ['<rootDir>/tests/jest/setup.ts'],
   transform: {

--- a/packages/core/migrations/022_marketplace.sql
+++ b/packages/core/migrations/022_marketplace.sql
@@ -1,0 +1,221 @@
+-- Migration: 022_marketplace.sql
+-- Description: Marketplace / Payment Splitting (connected accounts, payments, webhook events)
+-- Date: 2026-03-19
+-- NOTE: This module is PARALLEL to billing (subscriptions).
+--   billing = SaaS subscription (business pays platform)
+--   marketplace = payment splitting (customer pays, platform takes commission)
+
+-- ============================================
+-- TABLE: connectedAccounts
+-- Merchant accounts connected via Stripe Connect or MercadoPago OAuth
+-- ============================================
+DROP TABLE IF EXISTS public."connectedAccounts" CASCADE;
+
+CREATE TABLE IF NOT EXISTS public."connectedAccounts" (
+  -- Primary Key
+  id                         TEXT PRIMARY KEY DEFAULT gen_random_uuid()::text,
+
+  -- Foreign Keys
+  "teamId"                   TEXT NOT NULL REFERENCES public."teams"(id) ON DELETE CASCADE,
+
+  -- Provider
+  provider                   TEXT NOT NULL CHECK (provider IN ('stripe_connect', 'mercadopago_split')),
+  "externalAccountId"        TEXT NOT NULL,
+
+  -- Business Info
+  email                      TEXT NOT NULL DEFAULT '',
+  "businessName"             TEXT,
+  country                    TEXT NOT NULL DEFAULT 'US',
+  currency                   TEXT NOT NULL DEFAULT 'usd',
+
+  -- Onboarding Status
+  "onboardingStatus"         TEXT NOT NULL DEFAULT 'pending' CHECK (
+    "onboardingStatus" IN ('pending', 'in_progress', 'active', 'restricted', 'disabled', 'disconnected')
+  ),
+  "chargesEnabled"           BOOLEAN NOT NULL DEFAULT FALSE,
+  "payoutsEnabled"           BOOLEAN NOT NULL DEFAULT FALSE,
+
+  -- Commission
+  "commissionRate"           NUMERIC(5,4) NOT NULL DEFAULT 0.1500,
+  "fixedFee"                 INTEGER NOT NULL DEFAULT 0,
+
+  -- Payout Configuration
+  "payoutSchedule"           TEXT NOT NULL DEFAULT 'weekly' CHECK (
+    "payoutSchedule" IN ('daily', 'weekly', 'monthly', 'manual')
+  ),
+
+  -- Metadata (stores provider-specific data like MP tokens)
+  metadata                   JSONB DEFAULT '{}'::jsonb,
+
+  -- Timestamps
+  "createdAt"                TIMESTAMPTZ NOT NULL DEFAULT now(),
+  "updatedAt"                TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- One connected account per team
+CREATE UNIQUE INDEX "idx_connectedAccounts_teamId" ON public."connectedAccounts"("teamId");
+-- Lookup by external account ID
+CREATE UNIQUE INDEX "idx_connectedAccounts_externalAccountId" ON public."connectedAccounts"("externalAccountId");
+
+COMMENT ON TABLE  public."connectedAccounts"                            IS 'Merchant accounts connected via Stripe Connect or MercadoPago OAuth';
+COMMENT ON COLUMN public."connectedAccounts"."teamId"                   IS 'Team that owns this connected account';
+COMMENT ON COLUMN public."connectedAccounts".provider                   IS 'Payment provider: stripe_connect, mercadopago_split';
+COMMENT ON COLUMN public."connectedAccounts"."externalAccountId"        IS 'Provider account ID (acct_xxx for Stripe, user_id for MP)';
+COMMENT ON COLUMN public."connectedAccounts"."onboardingStatus"         IS 'Onboarding state: pending, in_progress, active, restricted, disabled, disconnected';
+COMMENT ON COLUMN public."connectedAccounts"."commissionRate"           IS 'Platform commission rate (0.1500 = 15%)';
+COMMENT ON COLUMN public."connectedAccounts"."fixedFee"                 IS 'Fixed fee per transaction in smallest currency unit';
+
+-- ============================================
+-- TABLE: marketplacePayments
+-- Split payments between platform and connected accounts
+-- ============================================
+DROP TABLE IF EXISTS public."marketplacePayments" CASCADE;
+
+CREATE TABLE IF NOT EXISTS public."marketplacePayments" (
+  -- Primary Key
+  id                         TEXT PRIMARY KEY DEFAULT gen_random_uuid()::text,
+
+  -- Foreign Keys
+  "connectedAccountId"       TEXT NOT NULL REFERENCES public."connectedAccounts"(id) ON DELETE RESTRICT,
+  "teamId"                   TEXT NOT NULL REFERENCES public."teams"(id) ON DELETE CASCADE,
+
+  -- Reference (booking, order, etc.)
+  "referenceId"              TEXT NOT NULL,
+  "referenceType"            TEXT NOT NULL DEFAULT 'booking',
+
+  -- Provider Data
+  "externalPaymentId"        TEXT NOT NULL,
+  "externalChargeId"         TEXT,
+  "externalTransferId"       TEXT,
+
+  -- Amounts (in smallest currency unit: cents for USD, full units for ARS/BRL/MXN)
+  "totalAmount"              INTEGER NOT NULL,
+  "applicationFee"           INTEGER NOT NULL,
+  "businessAmount"           INTEGER NOT NULL,
+  "providerFee"              INTEGER,
+  currency                   TEXT NOT NULL DEFAULT 'usd',
+  "commissionRate"           NUMERIC(5,4) NOT NULL,
+
+  -- Status
+  status                     TEXT NOT NULL DEFAULT 'pending' CHECK (
+    status IN ('pending', 'processing', 'succeeded', 'failed', 'refunded', 'partially_refunded', 'disputed', 'canceled')
+  ),
+  "statusDetail"             TEXT,
+  "paymentMethod"            TEXT,
+  "paymentType"              TEXT,
+
+  -- Refunds
+  "refundedAmount"           INTEGER NOT NULL DEFAULT 0,
+
+  -- Metadata
+  metadata                   JSONB DEFAULT '{}'::jsonb,
+
+  -- Timestamps
+  "paidAt"                   TIMESTAMPTZ,
+  "createdAt"                TIMESTAMPTZ NOT NULL DEFAULT now(),
+  "updatedAt"                TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX "idx_marketplacePayments_connectedAccountId" ON public."marketplacePayments"("connectedAccountId");
+CREATE INDEX "idx_marketplacePayments_teamId" ON public."marketplacePayments"("teamId");
+CREATE INDEX "idx_marketplacePayments_referenceId" ON public."marketplacePayments"("referenceId");
+CREATE INDEX "idx_marketplacePayments_externalPaymentId" ON public."marketplacePayments"("externalPaymentId");
+CREATE INDEX "idx_marketplacePayments_status" ON public."marketplacePayments"("status");
+
+COMMENT ON TABLE  public."marketplacePayments"                          IS 'Split payments between platform and connected merchant accounts';
+COMMENT ON COLUMN public."marketplacePayments"."connectedAccountId"     IS 'Connected account receiving the payment';
+COMMENT ON COLUMN public."marketplacePayments"."referenceId"            IS 'External reference (booking ID, order ID)';
+COMMENT ON COLUMN public."marketplacePayments"."totalAmount"            IS 'Total amount paid by customer';
+COMMENT ON COLUMN public."marketplacePayments"."applicationFee"         IS 'Platform commission amount';
+COMMENT ON COLUMN public."marketplacePayments"."businessAmount"         IS 'Amount received by business (before provider fees)';
+
+-- ============================================
+-- TABLE: marketplaceWebhookEvents
+-- Idempotency tracking for marketplace webhook events
+-- ============================================
+DROP TABLE IF EXISTS public."marketplaceWebhookEvents" CASCADE;
+
+CREATE TABLE IF NOT EXISTS public."marketplaceWebhookEvents" (
+  -- Primary Key
+  id                         TEXT PRIMARY KEY DEFAULT gen_random_uuid()::text,
+
+  -- Event Data
+  provider                   TEXT NOT NULL CHECK (provider IN ('stripe_connect', 'mercadopago_split')),
+  "externalEventId"          TEXT NOT NULL,
+  "eventType"                TEXT NOT NULL,
+  action                     TEXT NOT NULL DEFAULT '',
+  "resourceId"               TEXT NOT NULL DEFAULT '',
+
+  -- Processing
+  processed                  BOOLEAN NOT NULL DEFAULT FALSE,
+  "processedAt"              TIMESTAMPTZ,
+  error                      TEXT,
+  "rawPayload"               JSONB,
+
+  -- Timestamps
+  "createdAt"                TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- Idempotency: one event per provider+externalEventId
+CREATE UNIQUE INDEX "idx_marketplaceWebhookEvents_unique" ON public."marketplaceWebhookEvents"(provider, "externalEventId");
+CREATE INDEX "idx_marketplaceWebhookEvents_resourceId" ON public."marketplaceWebhookEvents"("resourceId");
+
+COMMENT ON TABLE  public."marketplaceWebhookEvents"                     IS 'Webhook event log for marketplace providers (idempotency)';
+
+-- ============================================
+-- RLS POLICIES
+-- ============================================
+
+-- connectedAccounts: team owner/admin can read, system can write
+ALTER TABLE public."connectedAccounts" ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "connectedAccounts_team_read" ON public."connectedAccounts"
+  FOR SELECT USING (
+    "teamId" IN (
+      SELECT "teamId" FROM public."team_members"
+      WHERE "userId" = (SELECT id FROM public."users" WHERE id = current_setting('app.current_user_id', true))
+    )
+  );
+
+CREATE POLICY "connectedAccounts_system_write" ON public."connectedAccounts"
+  FOR ALL USING (true) WITH CHECK (true);
+
+-- marketplacePayments: team members can read, system can write
+ALTER TABLE public."marketplacePayments" ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "marketplacePayments_team_read" ON public."marketplacePayments"
+  FOR SELECT USING (
+    "teamId" IN (
+      SELECT "teamId" FROM public."team_members"
+      WHERE "userId" = (SELECT id FROM public."users" WHERE id = current_setting('app.current_user_id', true))
+    )
+  );
+
+CREATE POLICY "marketplacePayments_system_write" ON public."marketplacePayments"
+  FOR ALL USING (true) WITH CHECK (true);
+
+-- marketplaceWebhookEvents: system only (no user reads needed)
+ALTER TABLE public."marketplaceWebhookEvents" ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "marketplaceWebhookEvents_system" ON public."marketplaceWebhookEvents"
+  FOR ALL USING (true) WITH CHECK (true);
+
+-- ============================================
+-- UPDATED_AT TRIGGER
+-- ============================================
+
+CREATE OR REPLACE FUNCTION update_marketplace_updated_at()
+RETURNS TRIGGER AS $$
+BEGIN
+  NEW."updatedAt" = now();
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER "connectedAccounts_updated_at"
+  BEFORE UPDATE ON public."connectedAccounts"
+  FOR EACH ROW EXECUTE FUNCTION update_marketplace_updated_at();
+
+CREATE TRIGGER "marketplacePayments_updated_at"
+  BEFORE UPDATE ON public."marketplacePayments"
+  FOR EACH ROW EXECUTE FUNCTION update_marketplace_updated_at();

--- a/packages/core/migrations/022_marketplace.sql
+++ b/packages/core/migrations/022_marketplace.sql
@@ -119,7 +119,7 @@ CREATE TABLE IF NOT EXISTS public."marketplacePayments" (
 CREATE INDEX "idx_marketplacePayments_connectedAccountId" ON public."marketplacePayments"("connectedAccountId");
 CREATE INDEX "idx_marketplacePayments_teamId" ON public."marketplacePayments"("teamId");
 CREATE INDEX "idx_marketplacePayments_referenceId" ON public."marketplacePayments"("referenceId");
-CREATE INDEX "idx_marketplacePayments_externalPaymentId" ON public."marketplacePayments"("externalPaymentId");
+CREATE UNIQUE INDEX "idx_marketplacePayments_externalPaymentId" ON public."marketplacePayments"("externalPaymentId");
 CREATE INDEX "idx_marketplacePayments_status" ON public."marketplacePayments"("status");
 
 COMMENT ON TABLE  public."marketplacePayments"                          IS 'Split payments between platform and connected merchant accounts';

--- a/packages/core/src/lib/marketplace/commission.ts
+++ b/packages/core/src/lib/marketplace/commission.ts
@@ -1,0 +1,129 @@
+/**
+ * Commission Calculator
+ *
+ * Calculates platform fees for marketplace payments.
+ * Supports percentage, fixed, hybrid, and tiered commission models.
+ */
+
+import type { CommissionConfig } from './types'
+
+/**
+ * Calculate the application fee (platform commission) for a payment.
+ *
+ * @param amount - Total payment amount in smallest currency unit
+ * @param config - Commission configuration
+ * @param monthlyVolume - Monthly volume for tiered pricing (optional)
+ * @returns Application fee in smallest currency unit
+ *
+ * @example
+ * // 15% commission on $100.00 (10000 cents)
+ * calculateFee(10000, { model: 'percentage', rate: 0.15 })
+ * // Returns: 1500
+ *
+ * @example
+ * // $2.00 fixed fee
+ * calculateFee(10000, { model: 'fixed', fixedAmount: 200 })
+ * // Returns: 200
+ *
+ * @example
+ * // 10% + $1.00 fixed
+ * calculateFee(10000, { model: 'hybrid', rate: 0.10, fixedAmount: 100 })
+ * // Returns: 1100
+ */
+export function calculateFee(
+  amount: number,
+  config: CommissionConfig,
+  monthlyVolume?: number
+): number {
+  let fee: number
+
+  switch (config.model) {
+    case 'percentage':
+      fee = Math.round(amount * (config.rate ?? 0))
+      break
+
+    case 'fixed':
+      fee = config.fixedAmount ?? 0
+      break
+
+    case 'hybrid':
+      fee = Math.round(amount * (config.rate ?? 0)) + (config.fixedAmount ?? 0)
+      break
+
+    case 'tiered': {
+      const tiers = config.tiers ?? []
+      const volume = monthlyVolume ?? 0
+      // Find the highest tier the merchant qualifies for
+      const applicableTier = tiers
+        .filter(t => volume >= t.minVolume)
+        .sort((a, b) => b.minVolume - a.minVolume)[0]
+
+      const rate = applicableTier?.rate ?? config.rate ?? 0
+      fee = Math.round(amount * rate)
+      break
+    }
+
+    default:
+      fee = Math.round(amount * (config.rate ?? 0))
+  }
+
+  // Apply min/max constraints
+  if (config.minFee !== undefined && fee < config.minFee) {
+    fee = config.minFee
+  }
+  if (config.maxFee !== undefined && fee > config.maxFee) {
+    fee = config.maxFee
+  }
+
+  // Fee cannot exceed the payment amount
+  if (fee > amount) {
+    fee = amount
+  }
+
+  // Fee cannot be negative
+  if (fee < 0) {
+    fee = 0
+  }
+
+  return fee
+}
+
+/**
+ * Get a human-readable description of the commission model.
+ *
+ * @example
+ * describeCommission({ model: 'percentage', rate: 0.15 })
+ * // Returns: "15%"
+ *
+ * describeCommission({ model: 'hybrid', rate: 0.10, fixedAmount: 100 })
+ * // Returns: "10% + $1.00"
+ */
+export function describeCommission(config: CommissionConfig, currency = 'USD'): string {
+  const formatAmount = (cents: number) => {
+    return new Intl.NumberFormat('en-US', {
+      style: 'currency',
+      currency,
+    }).format(cents / 100)
+  }
+
+  switch (config.model) {
+    case 'percentage':
+      return `${((config.rate ?? 0) * 100).toFixed(0)}%`
+
+    case 'fixed':
+      return formatAmount(config.fixedAmount ?? 0)
+
+    case 'hybrid':
+      return `${((config.rate ?? 0) * 100).toFixed(0)}% + ${formatAmount(config.fixedAmount ?? 0)}`
+
+    case 'tiered': {
+      const tiers = config.tiers ?? []
+      return tiers
+        .map(t => `${(t.rate * 100).toFixed(0)}% (>${formatAmount(t.minVolume)}/mo)`)
+        .join(', ')
+    }
+
+    default:
+      return `${((config.rate ?? 0) * 100).toFixed(0)}%`
+  }
+}

--- a/packages/core/src/lib/marketplace/gateways/factory.ts
+++ b/packages/core/src/lib/marketplace/gateways/factory.ts
@@ -1,0 +1,68 @@
+/**
+ * Marketplace Gateway Factory
+ *
+ * Returns the configured MarketplaceGateway implementation.
+ * Similar pattern to the billing gateway factory but for marketplace/connect payments.
+ *
+ * Usage:
+ *   import { getMarketplaceGateway } from '@nextsparkjs/core/lib/marketplace/gateways/factory'
+ *   const result = await getMarketplaceGateway().createMarketplaceCheckout(params)
+ */
+
+import type { MarketplaceGateway } from '../interface'
+import type { MarketplaceProvider } from '../types'
+import { StripeConnectGateway } from './stripe-connect'
+import { MercadoPagoSplitGateway } from './mercadopago-split'
+
+let gatewayInstance: MarketplaceGateway | null = null
+let configuredProvider: MarketplaceProvider | null = null
+
+/**
+ * Get the marketplace gateway for the configured provider.
+ * Singleton - the same instance is returned on subsequent calls.
+ *
+ * Provider is determined by MARKETPLACE_PROVIDER env var or explicit configuration.
+ */
+export function getMarketplaceGateway(provider?: MarketplaceProvider): MarketplaceGateway {
+  const resolvedProvider = provider
+    || configuredProvider
+    || (process.env.MARKETPLACE_PROVIDER as MarketplaceProvider)
+    || 'stripe_connect'
+
+  if (!gatewayInstance || (provider && provider !== configuredProvider)) {
+    switch (resolvedProvider) {
+      case 'stripe_connect':
+        gatewayInstance = new StripeConnectGateway()
+        break
+      case 'mercadopago_split':
+        gatewayInstance = new MercadoPagoSplitGateway()
+        break
+      default:
+        throw new Error(
+          `Unsupported marketplace provider: "${resolvedProvider}". ` +
+          `Supported providers: stripe_connect, mercadopago_split.`
+        )
+    }
+    configuredProvider = resolvedProvider
+  }
+
+  return gatewayInstance
+}
+
+/**
+ * Configure the marketplace provider explicitly.
+ * Call this during app initialization if not using env var.
+ */
+export function setMarketplaceProvider(provider: MarketplaceProvider): void {
+  configuredProvider = provider
+  gatewayInstance = null // Reset so next call creates the right instance
+}
+
+/**
+ * Reset the cached gateway instance.
+ * Useful for testing or when config changes at runtime.
+ */
+export function resetMarketplaceGateway(): void {
+  gatewayInstance = null
+  configuredProvider = null
+}

--- a/packages/core/src/lib/marketplace/gateways/mercadopago-split.ts
+++ b/packages/core/src/lib/marketplace/gateways/mercadopago-split.ts
@@ -151,13 +151,23 @@ function mapMPPaymentStatus(status: string): MarketplacePaymentStatus {
 
 /**
  * Interface for retrieving seller OAuth tokens.
- * Implementations should handle encryption and refresh logic.
+ *
+ * IMPORTANT: Tokens in the database are encrypted at rest using AES-256-GCM.
+ * Implementations that read from the connectedAccounts.metadata JSONB column
+ * MUST decrypt tokens before returning them. Use `decryptToken` from
+ * '@nextsparkjs/core/lib/marketplace/token-encryption' for this purpose.
+ *
+ * Example:
+ *   import { decryptToken } from '@nextsparkjs/core/lib/marketplace/token-encryption'
+ *   const plainToken = decryptToken(row.metadata.mpTokens.accessToken)
  */
 export interface MPTokenProvider {
   getAccessToken(externalAccountId: string): Promise<string>
 }
 
-// Default: reads from environment (for platform-level operations)
+// Default: reads from environment (for platform-level operations).
+// When tokens are loaded from the database, callers must use decryptToken()
+// before passing them to gateway methods.
 let tokenProvider: MPTokenProvider = {
   async getAccessToken(): Promise<string> {
     const token = process.env.MP_ACCESS_TOKEN

--- a/packages/core/src/lib/marketplace/gateways/mercadopago-split.ts
+++ b/packages/core/src/lib/marketplace/gateways/mercadopago-split.ts
@@ -1,0 +1,544 @@
+/**
+ * MercadoPago Split Gateway Implementation
+ *
+ * Implements MarketplaceGateway for MercadoPago Marketplace split payments.
+ *
+ * Model: OAuth-connected sellers + marketplace_fee
+ * - Payment is processed in the SELLER's account (they are the collector)
+ * - marketplace_fee is extracted and sent to the platform's account
+ * - OAuth flow connects sellers to the platform
+ *
+ * Key differences from Stripe Connect:
+ * - Amounts are in FULL currency units (not cents): 10000 ARS = 10000, not 100.00
+ * - OAuth is used for onboarding (not Account Links)
+ * - Tokens expire in ~180 days and must be refreshed
+ * - The seller is the collector (inverse of Stripe's destination charges)
+ *
+ * Country support: Argentina (MLA), Brazil (MLB), Mexico (MLM), Colombia (MCO)
+ */
+
+import type { MarketplaceGateway } from '../interface'
+import type {
+  CreateConnectedAccountParams,
+  CreateOnboardingLinkParams,
+  CreateMarketplacePaymentParams,
+  CreateMarketplaceCheckoutParams,
+  RefundMarketplacePaymentParams,
+  CreatePayoutParams,
+  ConnectedAccountResult,
+  OnboardingLinkResult,
+  DashboardLinkResult,
+  MarketplacePaymentResult,
+  RefundResult,
+  PayoutResult,
+  AccountBalanceResult,
+} from '../interface'
+import type { MarketplacePaymentStatus } from '../types'
+
+// ===========================================
+// MercadoPago SDK setup
+// ===========================================
+
+// MercadoPago SDK v2 types
+interface MPPaymentCreateBody {
+  transaction_amount: number
+  description: string
+  payment_method_id?: string
+  token?: string
+  installments?: number
+  payer: { email: string; identification?: { type: string; number: string } }
+  marketplace_fee?: number
+  notification_url?: string
+  external_reference?: string
+  metadata?: Record<string, string>
+}
+
+interface MPPreferenceCreateBody {
+  items: Array<{
+    id: string
+    title: string
+    quantity: number
+    unit_price: number
+    currency_id: string
+  }>
+  marketplace_fee?: number
+  payer?: { email: string }
+  back_urls?: { success: string; failure: string; pending: string }
+  auto_return?: string
+  notification_url?: string
+  external_reference?: string
+  expires?: boolean
+  expiration_date_to?: string
+  metadata?: Record<string, string>
+}
+
+interface MPPaymentResponse {
+  id: number
+  status: string
+  status_detail: string
+  transaction_amount: number
+  currency_id: string
+  fee_details?: Array<{ type: string; amount: number }>
+  transaction_details?: { net_received_amount: number }
+  payment_method_id: string
+  payment_type_id: string
+  date_approved: string | null
+  external_reference: string | null
+  metadata?: Record<string, string>
+}
+
+interface MPPreferenceResponse {
+  id: string
+  init_point: string
+  sandbox_init_point: string
+}
+
+// ===========================================
+// Helpers
+// ===========================================
+
+function getMPBaseUrl(): string {
+  return 'https://api.mercadopago.com'
+}
+
+function getAuthBaseUrl(): string {
+  return 'https://auth.mercadopago.com'
+}
+
+async function mpFetch<T>(
+  accessToken: string,
+  path: string,
+  options: RequestInit = {}
+): Promise<T> {
+  const response = await fetch(`${getMPBaseUrl()}${path}`, {
+    ...options,
+    headers: {
+      'Authorization': `Bearer ${accessToken}`,
+      'Content-Type': 'application/json',
+      ...options.headers,
+    },
+  })
+
+  if (!response.ok) {
+    const error = await response.text()
+    throw new Error(`MercadoPago API error (${response.status}): ${error}`)
+  }
+
+  return response.json() as Promise<T>
+}
+
+/**
+ * Map MercadoPago payment status to our MarketplacePaymentStatus
+ */
+function mapMPPaymentStatus(status: string): MarketplacePaymentStatus {
+  const statusMap: Record<string, MarketplacePaymentStatus> = {
+    pending: 'pending',
+    approved: 'succeeded',
+    authorized: 'processing',
+    in_process: 'processing',
+    in_mediation: 'disputed',
+    rejected: 'failed',
+    cancelled: 'canceled',
+    refunded: 'refunded',
+    charged_back: 'disputed',
+  }
+  return statusMap[status] || 'failed'
+}
+
+// ===========================================
+// Token storage interface
+// ===========================================
+
+/**
+ * Interface for retrieving seller OAuth tokens.
+ * Implementations should handle encryption and refresh logic.
+ */
+export interface MPTokenProvider {
+  getAccessToken(externalAccountId: string): Promise<string>
+}
+
+// Default: reads from environment (for platform-level operations)
+let tokenProvider: MPTokenProvider = {
+  async getAccessToken(): Promise<string> {
+    const token = process.env.MP_ACCESS_TOKEN
+    if (!token) throw new Error('MP_ACCESS_TOKEN is not configured')
+    return token
+  },
+}
+
+/**
+ * Set a custom token provider for retrieving seller access tokens.
+ * Call this during app initialization.
+ */
+export function setMPTokenProvider(provider: MPTokenProvider): void {
+  tokenProvider = provider
+}
+
+// ===========================================
+// Gateway Implementation
+// ===========================================
+
+export class MercadoPagoSplitGateway implements MarketplaceGateway {
+  readonly provider = 'mercadopago_split'
+
+  // --- Account Management ---
+
+  async createConnectedAccount(params: CreateConnectedAccountParams): Promise<ConnectedAccountResult> {
+    // In MercadoPago, "creating" a connected account means generating
+    // an OAuth authorization URL. The account already exists in MP.
+    // We return a pending result; actual connection happens via OAuth callback.
+    return {
+      id: `pending_${params.teamId}`,
+      email: params.email,
+      chargesEnabled: false,
+      payoutsEnabled: false,
+      detailsSubmitted: false,
+      onboardingStatus: 'pending',
+    }
+  }
+
+  async createOnboardingLink(params: CreateOnboardingLinkParams): Promise<OnboardingLinkResult> {
+    const appId = process.env.MP_APP_ID
+    if (!appId) throw new Error('MP_APP_ID is not configured')
+
+    const redirectUri = encodeURIComponent(params.returnUrl)
+    const state = encodeURIComponent(params.externalAccountId) // Pass account reference as state
+
+    const url = `${getAuthBaseUrl()}/authorization?client_id=${appId}&response_type=code&platform_id=mp&state=${state}&redirect_uri=${redirectUri}`
+
+    return { url }
+  }
+
+  async getAccountStatus(externalAccountId: string): Promise<ConnectedAccountResult> {
+    const accessToken = await tokenProvider.getAccessToken(externalAccountId)
+
+    const user = await mpFetch<{
+      id: number
+      email: string
+      nickname: string
+      status: { site_status: string }
+    }>(accessToken, '/users/me')
+
+    const isActive = user.status.site_status === 'active'
+
+    return {
+      id: String(user.id),
+      email: user.email,
+      chargesEnabled: isActive,
+      payoutsEnabled: isActive,
+      detailsSubmitted: true,
+      onboardingStatus: isActive ? 'active' : 'restricted',
+    }
+  }
+
+  async createDashboardLink(_externalAccountId: string): Promise<DashboardLinkResult> {
+    // MercadoPago doesn't have embedded dashboards like Stripe Express.
+    // Redirect to the seller's MP account.
+    return { url: 'https://www.mercadopago.com/activities' }
+  }
+
+  // --- Payments ---
+
+  async createMarketplaceCheckout(params: CreateMarketplaceCheckoutParams): Promise<MarketplacePaymentResult> {
+    const sellerToken = await tokenProvider.getAccessToken(params.externalAccountId)
+
+    const preferenceBody: MPPreferenceCreateBody = {
+      items: [
+        {
+          id: params.referenceId,
+          title: params.description,
+          quantity: 1,
+          unit_price: params.amount,
+          currency_id: params.currency.toUpperCase(),
+        },
+      ],
+      marketplace_fee: params.applicationFee,
+      payer: params.customerEmail ? { email: params.customerEmail } : undefined,
+      back_urls: {
+        success: params.successUrl,
+        failure: params.cancelUrl,
+        pending: params.successUrl,
+      },
+      auto_return: 'approved',
+      notification_url: process.env.MP_WEBHOOK_URL || undefined,
+      external_reference: params.referenceId,
+      metadata: {
+        connectedAccountId: params.connectedAccountId,
+        ...params.metadata,
+      },
+    }
+
+    const preference = await mpFetch<MPPreferenceResponse>(
+      sellerToken,
+      '/checkout/preferences',
+      { method: 'POST', body: JSON.stringify(preferenceBody) }
+    )
+
+    const isProduction = process.env.NODE_ENV === 'production'
+
+    return {
+      id: preference.id,
+      status: 'pending',
+      url: isProduction ? preference.init_point : preference.sandbox_init_point,
+    }
+  }
+
+  async createMarketplacePayment(params: CreateMarketplacePaymentParams): Promise<MarketplacePaymentResult> {
+    const sellerToken = await tokenProvider.getAccessToken(params.externalAccountId)
+
+    const paymentBody: MPPaymentCreateBody = {
+      transaction_amount: params.amount,
+      description: params.description || `Payment for ${params.referenceId}`,
+      payer: {
+        email: params.customerEmail || '',
+      },
+      marketplace_fee: params.applicationFee,
+      notification_url: process.env.MP_WEBHOOK_URL || undefined,
+      external_reference: params.referenceId,
+      metadata: {
+        connectedAccountId: params.connectedAccountId,
+        ...params.metadata,
+      },
+    }
+
+    const payment = await mpFetch<MPPaymentResponse>(
+      sellerToken,
+      '/v1/payments',
+      { method: 'POST', body: JSON.stringify(paymentBody) }
+    )
+
+    return {
+      id: String(payment.id),
+      status: mapMPPaymentStatus(payment.status),
+      statusDetail: payment.status_detail,
+    }
+  }
+
+  async getPaymentStatus(externalPaymentId: string): Promise<MarketplacePaymentResult> {
+    // For payment status, we need the platform token (not seller token)
+    const platformToken = process.env.MP_ACCESS_TOKEN
+    if (!platformToken) throw new Error('MP_ACCESS_TOKEN is not configured')
+
+    const payment = await mpFetch<MPPaymentResponse>(
+      platformToken,
+      `/v1/payments/${externalPaymentId}`
+    )
+
+    return {
+      id: String(payment.id),
+      status: mapMPPaymentStatus(payment.status),
+      statusDetail: payment.status_detail,
+    }
+  }
+
+  // --- Refunds ---
+
+  async refundPayment(params: RefundMarketplacePaymentParams): Promise<RefundResult> {
+    const platformToken = process.env.MP_ACCESS_TOKEN
+    if (!platformToken) throw new Error('MP_ACCESS_TOKEN is not configured')
+
+    const body = params.amount ? { amount: params.amount } : {}
+
+    const refund = await mpFetch<{
+      id: number
+      amount: number
+      status: string
+    }>(
+      platformToken,
+      `/v1/payments/${params.externalPaymentId}/refunds`,
+      { method: 'POST', body: JSON.stringify(body) }
+    )
+
+    return {
+      id: String(refund.id),
+      amount: refund.amount,
+      status: refund.status,
+      feeRefunded: 0, // MP handles fee refund proportionally by default
+    }
+  }
+
+  // --- Payouts ---
+
+  async createPayout(_params: CreatePayoutParams): Promise<PayoutResult> {
+    // MercadoPago handles payouts automatically based on the seller's account settings.
+    // Manual payouts are not supported via the marketplace API.
+    throw new Error('MercadoPago handles payouts automatically. Manual payouts are not supported via the marketplace API.')
+  }
+
+  async getAccountBalance(externalAccountId: string): Promise<AccountBalanceResult> {
+    const sellerToken = await tokenProvider.getAccessToken(externalAccountId)
+
+    const balance = await mpFetch<{
+      available_balance: number
+      unavailable_balance: number
+      currency_id: string
+    }>(sellerToken, '/users/me/mercadopago_account/balance')
+
+    return {
+      available: balance.available_balance,
+      pending: balance.unavailable_balance,
+      currency: balance.currency_id.toLowerCase(),
+    }
+  }
+
+  // --- Webhooks ---
+
+  verifyWebhookSignature(
+    _payload: string | Buffer,
+    signatureOrHeaders: string | Record<string, string>
+  ): { id: string; type: string; account?: string; data: Record<string, unknown> } {
+    // MercadoPago webhook verification uses x-signature header with HMAC-SHA256
+    const headers = typeof signatureOrHeaders === 'string'
+      ? {} as Record<string, string>
+      : signatureOrHeaders
+
+    const xSignature = headers['x-signature']
+    const xRequestId = headers['x-request-id']
+    const webhookSecret = process.env.MP_WEBHOOK_SECRET
+
+    if (!webhookSecret) {
+      throw new Error('MP_WEBHOOK_SECRET is not configured')
+    }
+
+    if (!xSignature) {
+      throw new Error('Missing x-signature header in MercadoPago webhook')
+    }
+
+    // Parse the body to get data.id for signature verification
+    const body = typeof _payload === 'string' ? JSON.parse(_payload) : JSON.parse(_payload.toString('utf-8'))
+    const dataId = body.data?.id
+
+    if (dataId && xRequestId) {
+      // Verify HMAC signature
+      // x-signature format: "ts=1234567890,v1=hash_value"
+      const parts: Record<string, string> = {}
+      xSignature.split(',').forEach((part: string) => {
+        const [key, value] = part.split('=')
+        if (key && value) parts[key.trim()] = value.trim()
+      })
+
+      const ts = parts['ts']
+      const expectedHash = parts['v1']
+
+      if (ts && expectedHash) {
+        const { createHmac } = require('crypto') as typeof import('crypto')
+        const manifest = `id:${dataId};request-id:${xRequestId};ts:${ts};`
+        const hmac = createHmac('sha256', webhookSecret)
+          .update(manifest)
+          .digest('hex')
+
+        if (hmac !== expectedHash) {
+          throw new Error('MercadoPago webhook signature verification failed')
+        }
+      }
+    }
+
+    return {
+      id: String(body.id || ''),
+      type: body.type || '',
+      account: body.user_id ? String(body.user_id) : undefined,
+      data: body.data || {},
+    }
+  }
+}
+
+// ===========================================
+// OAuth Token Exchange Helper
+// ===========================================
+
+/**
+ * Exchange an OAuth authorization code for access/refresh tokens.
+ * Call this from your OAuth callback route.
+ */
+export async function exchangeMPAuthorizationCode(code: string, redirectUri: string): Promise<{
+  accessToken: string
+  refreshToken: string
+  expiresIn: number
+  userId: number
+  publicKey: string
+}> {
+  const appId = process.env.MP_APP_ID
+  const clientSecret = process.env.MP_CLIENT_SECRET
+
+  if (!appId || !clientSecret) {
+    throw new Error('MP_APP_ID and MP_CLIENT_SECRET are required for OAuth')
+  }
+
+  const response = await fetch(`${getMPBaseUrl()}/oauth/token`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      client_id: appId,
+      client_secret: clientSecret,
+      grant_type: 'authorization_code',
+      code,
+      redirect_uri: redirectUri,
+    }),
+  })
+
+  if (!response.ok) {
+    const error = await response.text()
+    throw new Error(`MercadoPago OAuth token exchange failed: ${error}`)
+  }
+
+  const data = await response.json() as {
+    access_token: string
+    refresh_token: string
+    expires_in: number
+    user_id: number
+    public_key: string
+  }
+
+  return {
+    accessToken: data.access_token,
+    refreshToken: data.refresh_token,
+    expiresIn: data.expires_in,
+    userId: data.user_id,
+    publicKey: data.public_key,
+  }
+}
+
+/**
+ * Refresh an expiring MP OAuth token.
+ * Call this proactively before tokens expire (~180 days).
+ */
+export async function refreshMPToken(refreshToken: string): Promise<{
+  accessToken: string
+  refreshToken: string
+  expiresIn: number
+}> {
+  const appId = process.env.MP_APP_ID
+  const clientSecret = process.env.MP_CLIENT_SECRET
+
+  if (!appId || !clientSecret) {
+    throw new Error('MP_APP_ID and MP_CLIENT_SECRET are required for OAuth')
+  }
+
+  const response = await fetch(`${getMPBaseUrl()}/oauth/token`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      client_id: appId,
+      client_secret: clientSecret,
+      grant_type: 'refresh_token',
+      refresh_token: refreshToken,
+    }),
+  })
+
+  if (!response.ok) {
+    const error = await response.text()
+    throw new Error(`MercadoPago token refresh failed: ${error}`)
+  }
+
+  const data = await response.json() as {
+    access_token: string
+    refresh_token: string
+    expires_in: number
+  }
+
+  return {
+    accessToken: data.access_token,
+    refreshToken: data.refresh_token,
+    expiresIn: data.expires_in,
+  }
+}

--- a/packages/core/src/lib/marketplace/gateways/stripe-connect.ts
+++ b/packages/core/src/lib/marketplace/gateways/stripe-connect.ts
@@ -1,0 +1,316 @@
+/**
+ * Stripe Connect Gateway Implementation
+ *
+ * Implements MarketplaceGateway for Stripe Connect Express accounts
+ * with Destination Charges for payment splitting.
+ *
+ * Model: Express accounts + Destination charges
+ * - Platform is merchant of record (customer's card statement shows platform name)
+ * - application_fee_amount extracts platform commission
+ * - Stripe handles KYC/onboarding for connected accounts
+ */
+
+import Stripe from 'stripe'
+import type { MarketplaceGateway } from '../interface'
+import type {
+  CreateConnectedAccountParams,
+  CreateOnboardingLinkParams,
+  CreateMarketplacePaymentParams,
+  CreateMarketplaceCheckoutParams,
+  RefundMarketplacePaymentParams,
+  CreatePayoutParams,
+  ConnectedAccountResult,
+  OnboardingLinkResult,
+  DashboardLinkResult,
+  MarketplacePaymentResult,
+  RefundResult,
+  PayoutResult,
+  AccountBalanceResult,
+} from '../interface'
+import type { OnboardingStatus, MarketplacePaymentStatus } from '../types'
+
+// Lazy-load Stripe client
+let stripeInstance: Stripe | null = null
+
+function getStripe(): Stripe {
+  if (!stripeInstance) {
+    if (!process.env.STRIPE_SECRET_KEY) {
+      throw new Error('STRIPE_SECRET_KEY is not configured')
+    }
+    stripeInstance = new Stripe(process.env.STRIPE_SECRET_KEY, {
+      apiVersion: '2025-08-27.basil',
+      typescript: true,
+    })
+  }
+  return stripeInstance
+}
+
+/**
+ * Map Stripe account status to our OnboardingStatus
+ */
+function mapAccountStatus(account: Stripe.Account): OnboardingStatus {
+  if (account.requirements?.disabled_reason) return 'disabled'
+  if (account.charges_enabled && account.payouts_enabled) return 'active'
+  if (account.requirements?.past_due?.length) return 'restricted'
+  if (account.details_submitted) return 'in_progress'
+  return 'pending'
+}
+
+/**
+ * Map Stripe payment intent status to our MarketplacePaymentStatus
+ */
+function mapPaymentStatus(status: string): MarketplacePaymentStatus {
+  const statusMap: Record<string, MarketplacePaymentStatus> = {
+    requires_payment_method: 'pending',
+    requires_confirmation: 'pending',
+    requires_action: 'pending',
+    processing: 'processing',
+    succeeded: 'succeeded',
+    canceled: 'canceled',
+    requires_capture: 'processing',
+  }
+  return statusMap[status] || 'failed'
+}
+
+export class StripeConnectGateway implements MarketplaceGateway {
+  readonly provider = 'stripe_connect'
+
+  // --- Account Management ---
+
+  async createConnectedAccount(params: CreateConnectedAccountParams): Promise<ConnectedAccountResult> {
+    const account = await getStripe().accounts.create({
+      type: 'express',
+      country: params.country,
+      email: params.email,
+      business_type: params.businessType || 'individual',
+      capabilities: {
+        card_payments: { requested: true },
+        transfers: { requested: true },
+      },
+      business_profile: {
+        name: params.businessName || undefined,
+        mcc: '7230', // Barber and Beauty Shops
+      },
+      metadata: {
+        teamId: params.teamId,
+        ...params.metadata,
+      },
+    })
+
+    return this.mapAccountResult(account)
+  }
+
+  async createOnboardingLink(params: CreateOnboardingLinkParams): Promise<OnboardingLinkResult> {
+    const accountLink = await getStripe().accountLinks.create({
+      account: params.externalAccountId,
+      refresh_url: params.refreshUrl,
+      return_url: params.returnUrl,
+      type: 'account_onboarding',
+    })
+
+    return {
+      url: accountLink.url,
+      // Account links expire quickly (minutes, not hours)
+      expiresAt: new Date(accountLink.expires_at * 1000),
+    }
+  }
+
+  async getAccountStatus(externalAccountId: string): Promise<ConnectedAccountResult> {
+    const account = await getStripe().accounts.retrieve(externalAccountId)
+    return this.mapAccountResult(account)
+  }
+
+  async createDashboardLink(externalAccountId: string): Promise<DashboardLinkResult> {
+    const loginLink = await getStripe().accounts.createLoginLink(externalAccountId)
+    return { url: loginLink.url }
+  }
+
+  // --- Payments ---
+
+  async createMarketplaceCheckout(params: CreateMarketplaceCheckoutParams): Promise<MarketplacePaymentResult> {
+    const session = await getStripe().checkout.sessions.create({
+      mode: 'payment',
+      line_items: [
+        {
+          price_data: {
+            currency: params.currency,
+            product_data: {
+              name: params.description,
+            },
+            unit_amount: params.amount,
+          },
+          quantity: 1,
+        },
+      ],
+      payment_intent_data: {
+        application_fee_amount: params.applicationFee,
+        transfer_data: {
+          destination: params.externalAccountId,
+        },
+        metadata: {
+          referenceId: params.referenceId,
+          connectedAccountId: params.connectedAccountId,
+          ...params.metadata,
+        },
+      },
+      customer_email: params.customerEmail || undefined,
+      success_url: params.successUrl,
+      cancel_url: params.cancelUrl,
+      metadata: {
+        referenceId: params.referenceId,
+        connectedAccountId: params.connectedAccountId,
+      },
+    })
+
+    return {
+      id: session.id,
+      status: 'pending',
+      url: session.url,
+    }
+  }
+
+  async createMarketplacePayment(params: CreateMarketplacePaymentParams): Promise<MarketplacePaymentResult> {
+    const paymentIntent = await getStripe().paymentIntents.create({
+      amount: params.amount,
+      currency: params.currency,
+      application_fee_amount: params.applicationFee,
+      transfer_data: {
+        destination: params.externalAccountId,
+      },
+      customer: params.customerId || undefined,
+      automatic_payment_methods: {
+        enabled: true,
+        allow_redirects: 'never',
+      },
+      metadata: {
+        referenceId: params.referenceId,
+        connectedAccountId: params.connectedAccountId,
+        ...params.metadata,
+      },
+      description: params.description,
+    })
+
+    return {
+      id: paymentIntent.id,
+      status: mapPaymentStatus(paymentIntent.status),
+      chargeId: typeof paymentIntent.latest_charge === 'string'
+        ? paymentIntent.latest_charge
+        : paymentIntent.latest_charge?.id,
+    }
+  }
+
+  async getPaymentStatus(externalPaymentId: string): Promise<MarketplacePaymentResult> {
+    const pi = await getStripe().paymentIntents.retrieve(externalPaymentId)
+
+    return {
+      id: pi.id,
+      status: mapPaymentStatus(pi.status),
+      chargeId: typeof pi.latest_charge === 'string'
+        ? pi.latest_charge
+        : pi.latest_charge?.id,
+    }
+  }
+
+  // --- Refunds ---
+
+  async refundPayment(params: RefundMarketplacePaymentParams): Promise<RefundResult> {
+    const refundParams: Stripe.RefundCreateParams = {
+      payment_intent: params.externalPaymentId,
+      refund_application_fee: params.refundApplicationFee ?? true,
+      reason: (params.reason as Stripe.RefundCreateParams['reason']) || 'requested_by_customer',
+    }
+
+    if (params.amount) {
+      refundParams.amount = params.amount
+    }
+
+    const refund = await getStripe().refunds.create(refundParams)
+
+    return {
+      id: refund.id,
+      amount: refund.amount,
+      status: refund.status || 'pending',
+      feeRefunded: 0, // Stripe handles fee refund automatically if refund_application_fee is true
+    }
+  }
+
+  // --- Payouts ---
+
+  async createPayout(params: CreatePayoutParams): Promise<PayoutResult> {
+    const payout = await getStripe().payouts.create(
+      {
+        amount: params.amount,
+        currency: params.currency,
+        description: params.description,
+      },
+      { stripeAccount: params.externalAccountId }
+    )
+
+    return {
+      id: payout.id,
+      amount: payout.amount,
+      currency: payout.currency,
+      status: payout.status as PayoutResult['status'],
+      arrivalDate: new Date(payout.arrival_date * 1000),
+    }
+  }
+
+  async getAccountBalance(externalAccountId: string): Promise<AccountBalanceResult> {
+    const balance = await getStripe().balance.retrieve({
+      stripeAccount: externalAccountId,
+    })
+
+    const available = balance.available[0]
+    const pending = balance.pending[0]
+
+    return {
+      available: available?.amount ?? 0,
+      pending: pending?.amount ?? 0,
+      currency: available?.currency ?? pending?.currency ?? 'usd',
+    }
+  }
+
+  // --- Webhooks ---
+
+  verifyWebhookSignature(
+    payload: string | Buffer,
+    signatureOrHeaders: string | Record<string, string>
+  ): { id: string; type: string; account?: string; data: Record<string, unknown> } {
+    const webhookSecret = process.env.STRIPE_CONNECT_WEBHOOK_SECRET
+    if (!webhookSecret) {
+      throw new Error('STRIPE_CONNECT_WEBHOOK_SECRET is not configured')
+    }
+
+    const signature = typeof signatureOrHeaders === 'string'
+      ? signatureOrHeaders
+      : signatureOrHeaders['stripe-signature'] || ''
+
+    const event = getStripe().webhooks.constructEvent(payload, signature, webhookSecret)
+
+    return {
+      id: event.id,
+      type: event.type,
+      account: event.account,
+      data: event.data as unknown as Record<string, unknown>,
+    }
+  }
+
+  // --- Private helpers ---
+
+  private mapAccountResult(account: Stripe.Account): ConnectedAccountResult {
+    return {
+      id: account.id,
+      email: account.email ?? '',
+      chargesEnabled: account.charges_enabled ?? false,
+      payoutsEnabled: account.payouts_enabled ?? false,
+      detailsSubmitted: account.details_submitted ?? false,
+      onboardingStatus: mapAccountStatus(account),
+      requirements: account.requirements ? {
+        currentlyDue: account.requirements.currently_due ?? [],
+        eventuallyDue: account.requirements.eventually_due ?? [],
+        pastDue: account.requirements.past_due ?? [],
+        disabledReason: account.requirements.disabled_reason ?? null,
+      } : undefined,
+    }
+  }
+}

--- a/packages/core/src/lib/marketplace/handlers/refresh-mp-tokens.ts
+++ b/packages/core/src/lib/marketplace/handlers/refresh-mp-tokens.ts
@@ -1,0 +1,215 @@
+/**
+ * Scheduled Action: Refresh MercadoPago OAuth Tokens
+ *
+ * Runs daily via the scheduled actions system. Finds all MercadoPago
+ * connected accounts with OAuth tokens expiring within 30 days and
+ * proactively refreshes them.
+ *
+ * MercadoPago tokens expire after ~180 days. By refreshing 30 days
+ * before expiry, we ensure sellers never experience authentication
+ * failures during payment processing.
+ *
+ * @module core/lib/marketplace/handlers/refresh-mp-tokens
+ */
+
+import { queryWithRLS, mutateWithRLS } from '../../db'
+import { refreshMPToken } from '../gateways/mercadopago-split'
+import { encryptTokens, decryptToken } from '../token-encryption'
+import { registerScheduledAction } from '../../scheduled-actions/registry'
+import type { ScheduledAction } from '../../scheduled-actions/types'
+
+/**
+ * Result returned by the refresh handler for logging/monitoring
+ */
+export interface RefreshMPTokensResult {
+  refreshed: number
+  failed: number
+  skipped: number
+  errors: string[]
+}
+
+/**
+ * Database row shape for connected accounts with MP tokens
+ */
+interface ConnectedAccountRow {
+  id: string
+  teamId: string
+  externalAccountId: string
+  metadata: {
+    mpTokens: {
+      accessToken: string
+      refreshToken: string
+      expiresAt: string
+      publicKey: string
+    }
+  }
+}
+
+/**
+ * Number of days before token expiry to trigger a refresh.
+ * 30 days gives ample buffer for retries if something goes wrong.
+ */
+const REFRESH_BEFORE_DAYS = 30
+
+/**
+ * Core handler logic: find expiring tokens and refresh them.
+ *
+ * Separated from the registration function for testability.
+ * The handler queries all MercadoPago connected accounts whose tokens
+ * expire within REFRESH_BEFORE_DAYS, decrypts the refresh token,
+ * calls the MercadoPago OAuth refresh endpoint, and stores the
+ * newly encrypted tokens back in the database.
+ */
+export async function refreshMPTokensHandler(): Promise<RefreshMPTokensResult> {
+  const result: RefreshMPTokensResult = {
+    refreshed: 0,
+    failed: 0,
+    skipped: 0,
+    errors: [],
+  }
+
+  // Find accounts with tokens expiring within 30 days
+  // The expiresAt field is stored as an ISO string inside the JSONB metadata
+  const thresholdDate = new Date()
+  thresholdDate.setDate(thresholdDate.getDate() + REFRESH_BEFORE_DAYS)
+
+  const accounts = await queryWithRLS<ConnectedAccountRow>(
+    `SELECT id, "teamId", "externalAccountId", metadata
+     FROM "connectedAccounts"
+     WHERE provider = 'mercadopago_split'
+       AND status = 'active'
+       AND metadata->'mpTokens'->>'expiresAt' IS NOT NULL
+       AND (metadata->'mpTokens'->>'expiresAt')::timestamptz < $1::timestamptz
+     ORDER BY (metadata->'mpTokens'->>'expiresAt')::timestamptz ASC`,
+    [thresholdDate.toISOString()],
+    null // System operation, no user context
+  )
+
+  if (accounts.length === 0) {
+    console.info('[ScheduledAction:marketplace:refresh-mp-tokens] No tokens expiring soon, nothing to refresh')
+    return result
+  }
+
+  console.info(
+    `[ScheduledAction:marketplace:refresh-mp-tokens] Found ${accounts.length} account(s) with tokens expiring before ${thresholdDate.toISOString()}`
+  )
+
+  // Process each account individually so one failure doesn't block others
+  for (const account of accounts) {
+    try {
+      const mpTokens = account.metadata?.mpTokens
+      if (!mpTokens?.refreshToken) {
+        console.warn(
+          `[ScheduledAction:marketplace:refresh-mp-tokens] Account ${account.id} has no refresh token, skipping`
+        )
+        result.skipped++
+        continue
+      }
+
+      // Decrypt the stored refresh token
+      const decryptedRefreshToken = decryptToken(mpTokens.refreshToken)
+
+      // Call MercadoPago OAuth refresh endpoint
+      const newTokens = await refreshMPToken(decryptedRefreshToken)
+
+      // Calculate new expiry date
+      const newExpiresAt = new Date(Date.now() + newTokens.expiresIn * 1000).toISOString()
+
+      // Encrypt the new tokens before storing
+      const encryptedTokens = encryptTokens({
+        accessToken: newTokens.accessToken,
+        refreshToken: newTokens.refreshToken,
+        expiresAt: newExpiresAt,
+        publicKey: mpTokens.publicKey, // publicKey doesn't change on refresh
+      })
+
+      // Update the database with new encrypted tokens
+      await mutateWithRLS(
+        `UPDATE "connectedAccounts"
+         SET metadata = jsonb_set(
+           metadata,
+           '{mpTokens}',
+           $2::jsonb
+         ),
+         "updatedAt" = NOW()
+         WHERE id = $1`,
+        [
+          account.id,
+          JSON.stringify(encryptedTokens),
+        ],
+        null // System operation
+      )
+
+      result.refreshed++
+      console.info(
+        `[ScheduledAction:marketplace:refresh-mp-tokens] Refreshed tokens for account ${account.id} (team: ${account.teamId}), new expiry: ${newExpiresAt}`
+      )
+    } catch (error) {
+      result.failed++
+      const errorMessage = error instanceof Error ? error.message : 'Unknown error'
+      result.errors.push(`Account ${account.id}: ${errorMessage}`)
+      console.error(
+        `[ScheduledAction:marketplace:refresh-mp-tokens] Failed to refresh tokens for account ${account.id}:`,
+        errorMessage
+      )
+    }
+  }
+
+  console.info(
+    `[ScheduledAction:marketplace:refresh-mp-tokens] Complete: ` +
+    `${result.refreshed} refreshed, ${result.failed} failed, ${result.skipped} skipped`
+  )
+
+  return result
+}
+
+/**
+ * Register the MercadoPago token refresh handler with the scheduled actions system.
+ *
+ * Call this during app initialization. The handler should be scheduled
+ * as a daily recurring action:
+ *
+ * @example
+ * ```typescript
+ * // During app init:
+ * registerRefreshMPTokensHandler()
+ *
+ * // Schedule the recurring action (once):
+ * await scheduleAction('marketplace:refresh-mp-tokens', {}, {
+ *   recurringInterval: 'daily',
+ *   recurrenceType: 'fixed',
+ *   maxRetries: 3,
+ * })
+ * ```
+ */
+export function registerRefreshMPTokensHandler(): void {
+  registerScheduledAction(
+    'marketplace:refresh-mp-tokens',
+    async (_payload: unknown, _action: ScheduledAction): Promise<void> => {
+      const result = await refreshMPTokensHandler()
+
+      // If all accounts failed, throw to trigger the retry mechanism
+      if (result.failed > 0 && result.refreshed === 0) {
+        throw new Error(
+          `All ${result.failed} token refresh(es) failed. Errors: ${result.errors.join('; ')}`
+        )
+      }
+
+      // Partial failures are logged but don't trigger a full retry,
+      // since successfully refreshed tokens shouldn't be re-processed
+      if (result.failed > 0) {
+        console.warn(
+          `[ScheduledAction:marketplace:refresh-mp-tokens] Partial failure: ` +
+          `${result.failed} of ${result.refreshed + result.failed} failed. ` +
+          `Errors: ${result.errors.join('; ')}`
+        )
+      }
+    },
+    {
+      description: 'Refresh MercadoPago OAuth tokens expiring within 30 days',
+      timeout: 120000, // 2 minutes: may process many accounts
+    }
+  )
+
+  console.log('[ScheduledActions] Registered handler: marketplace:refresh-mp-tokens')
+}

--- a/packages/core/src/lib/marketplace/index.ts
+++ b/packages/core/src/lib/marketplace/index.ts
@@ -61,3 +61,16 @@ export {
   setMPTokenProvider,
 } from './gateways/mercadopago-split'
 export type { MPTokenProvider } from './gateways/mercadopago-split'
+
+// MercadoPago Marketplace Webhook
+export { handleMPMarketplaceWebhook } from './mercadopago-webhook'
+export type {
+  MPWebhookNotification,
+  MPFullPayment,
+  MPPaymentContext,
+  MPMarketplaceWebhookExtensions,
+} from './mercadopago-webhook'
+
+// Stripe Connect Webhook
+export { handleStripeConnectWebhook } from './stripe-connect-webhook'
+export type { StripeConnectWebhookExtensions } from './stripe-connect-webhook'

--- a/packages/core/src/lib/marketplace/index.ts
+++ b/packages/core/src/lib/marketplace/index.ts
@@ -75,6 +75,13 @@ export type {
 export { handleStripeConnectWebhook } from './stripe-connect-webhook'
 export type { StripeConnectWebhookExtensions } from './stripe-connect-webhook'
 
+// Scheduled Action: MP Token Refresh
+export {
+  refreshMPTokensHandler,
+  registerRefreshMPTokensHandler,
+} from './handlers/refresh-mp-tokens'
+export type { RefreshMPTokensResult } from './handlers/refresh-mp-tokens'
+
 // Token Encryption (for marketplace OAuth tokens at rest)
 export {
   encryptToken,

--- a/packages/core/src/lib/marketplace/index.ts
+++ b/packages/core/src/lib/marketplace/index.ts
@@ -74,3 +74,11 @@ export type {
 // Stripe Connect Webhook
 export { handleStripeConnectWebhook } from './stripe-connect-webhook'
 export type { StripeConnectWebhookExtensions } from './stripe-connect-webhook'
+
+// Token Encryption (for marketplace OAuth tokens at rest)
+export {
+  encryptToken,
+  decryptToken,
+  encryptTokens,
+  decryptTokens,
+} from './token-encryption'

--- a/packages/core/src/lib/marketplace/index.ts
+++ b/packages/core/src/lib/marketplace/index.ts
@@ -1,0 +1,63 @@
+/**
+ * Marketplace Module
+ *
+ * Payment splitting system for marketplace/platform businesses.
+ * Supports Stripe Connect and MercadoPago Split.
+ *
+ * Usage:
+ *   import { getMarketplaceGateway, calculateFee } from '@nextsparkjs/core/lib/marketplace'
+ *
+ *   const gateway = getMarketplaceGateway()
+ *   const fee = calculateFee(10000, { model: 'percentage', rate: 0.15 })
+ *   const checkout = await gateway.createMarketplaceCheckout({ ... })
+ */
+
+// Types
+export type {
+  MarketplaceProvider,
+  ConnectedAccount,
+  OnboardingStatus,
+  MarketplacePayment,
+  MarketplacePaymentStatus,
+  Payout,
+  PayoutStatus,
+  CommissionModel,
+  CommissionConfig,
+  MarketplaceWebhookEvent,
+} from './types'
+
+// Interface
+export type {
+  MarketplaceGateway,
+  CreateConnectedAccountParams,
+  CreateOnboardingLinkParams,
+  CreateMarketplacePaymentParams,
+  CreateMarketplaceCheckoutParams,
+  RefundMarketplacePaymentParams,
+  CreatePayoutParams,
+  ConnectedAccountResult,
+  OnboardingLinkResult,
+  DashboardLinkResult,
+  MarketplacePaymentResult,
+  RefundResult,
+  PayoutResult,
+  AccountBalanceResult,
+} from './interface'
+
+// Factory
+export {
+  getMarketplaceGateway,
+  setMarketplaceProvider,
+  resetMarketplaceGateway,
+} from './gateways/factory'
+
+// Commission
+export { calculateFee, describeCommission } from './commission'
+
+// MercadoPago OAuth helpers
+export {
+  exchangeMPAuthorizationCode,
+  refreshMPToken,
+  setMPTokenProvider,
+} from './gateways/mercadopago-split'
+export type { MPTokenProvider } from './gateways/mercadopago-split'

--- a/packages/core/src/lib/marketplace/interface.ts
+++ b/packages/core/src/lib/marketplace/interface.ts
@@ -1,0 +1,195 @@
+/**
+ * Marketplace Gateway Interface
+ *
+ * Defines the contract for marketplace payment providers.
+ * This is SEPARATE from BillingGateway (which handles SaaS subscriptions).
+ *
+ * MarketplaceGateway handles:
+ * - Connecting merchant accounts (onboarding)
+ * - Creating split payments (customer pays, platform takes commission)
+ * - Managing payouts to merchants
+ * - Handling refunds with fee allocation
+ * - Webhook signature verification
+ */
+
+import type {
+  ConnectedAccount,
+  OnboardingStatus,
+  MarketplacePaymentStatus,
+  PayoutStatus,
+} from './types'
+
+// ===========================================
+// PARAMETER TYPES
+// ===========================================
+
+export interface CreateConnectedAccountParams {
+  teamId: string
+  email: string
+  businessName?: string
+  country: string               // ISO 3166-1 alpha-2
+  businessType?: 'individual' | 'company'
+  metadata?: Record<string, string>
+}
+
+export interface CreateOnboardingLinkParams {
+  externalAccountId: string     // acct_xxx or MP user_id
+  refreshUrl: string            // URL if link expires
+  returnUrl: string             // URL after completing onboarding
+}
+
+export interface CreateMarketplacePaymentParams {
+  connectedAccountId: string    // Our internal connected account ID
+  externalAccountId: string     // Provider's account ID (acct_xxx, MP user_id)
+  amount: number                // Total amount in smallest currency unit
+  currency: string
+  applicationFee: number        // Platform commission in smallest currency unit
+  referenceId: string           // Booking/order ID
+  description?: string
+  customerEmail?: string
+  customerId?: string           // Provider's customer ID if known
+  successUrl?: string           // For redirect-based flows
+  cancelUrl?: string
+  metadata?: Record<string, string>
+}
+
+export interface CreateMarketplaceCheckoutParams {
+  connectedAccountId: string
+  externalAccountId: string
+  amount: number
+  currency: string
+  applicationFee: number
+  referenceId: string
+  description: string
+  customerEmail?: string
+  successUrl: string
+  cancelUrl: string
+  metadata?: Record<string, string>
+}
+
+export interface RefundMarketplacePaymentParams {
+  externalPaymentId: string
+  amount?: number               // Partial refund amount (omit for full)
+  refundApplicationFee?: boolean // Whether to refund the platform fee too
+  reason?: string
+}
+
+export interface CreatePayoutParams {
+  externalAccountId: string
+  amount: number
+  currency: string
+  description?: string
+}
+
+// ===========================================
+// RESULT TYPES
+// ===========================================
+
+export interface ConnectedAccountResult {
+  id: string                    // Provider's account ID
+  email: string
+  chargesEnabled: boolean
+  payoutsEnabled: boolean
+  detailsSubmitted: boolean
+  onboardingStatus: OnboardingStatus
+  requirements?: {
+    currentlyDue: string[]
+    eventuallyDue: string[]
+    pastDue: string[]
+    disabledReason: string | null
+  }
+}
+
+export interface OnboardingLinkResult {
+  url: string
+  expiresAt?: Date
+}
+
+export interface DashboardLinkResult {
+  url: string
+}
+
+export interface MarketplacePaymentResult {
+  id: string                    // Provider's payment ID
+  status: MarketplacePaymentStatus
+  statusDetail?: string
+  chargeId?: string
+  transferId?: string
+  url?: string | null           // Checkout URL (for redirect flows)
+}
+
+export interface RefundResult {
+  id: string
+  amount: number
+  status: string
+  feeRefunded: number           // How much of the application fee was refunded
+}
+
+export interface PayoutResult {
+  id: string
+  amount: number
+  currency: string
+  status: PayoutStatus
+  arrivalDate?: Date
+}
+
+export interface AccountBalanceResult {
+  available: number
+  pending: number
+  currency: string
+}
+
+// ===========================================
+// GATEWAY INTERFACE
+// ===========================================
+
+export interface MarketplaceGateway {
+  /** Provider identifier */
+  readonly provider: string
+
+  // --- Account Management ---
+
+  /** Create a connected merchant account */
+  createConnectedAccount(params: CreateConnectedAccountParams): Promise<ConnectedAccountResult>
+
+  /** Generate an onboarding link for the merchant */
+  createOnboardingLink(params: CreateOnboardingLinkParams): Promise<OnboardingLinkResult>
+
+  /** Get the current status of a connected account */
+  getAccountStatus(externalAccountId: string): Promise<ConnectedAccountResult>
+
+  /** Generate a dashboard link for the merchant (Express dashboard for Stripe) */
+  createDashboardLink(externalAccountId: string): Promise<DashboardLinkResult>
+
+  // --- Payments ---
+
+  /** Create a checkout session with payment splitting */
+  createMarketplaceCheckout(params: CreateMarketplaceCheckoutParams): Promise<MarketplacePaymentResult>
+
+  /** Create a direct payment with splitting (for API/server-side payments) */
+  createMarketplacePayment(params: CreateMarketplacePaymentParams): Promise<MarketplacePaymentResult>
+
+  /** Get payment status */
+  getPaymentStatus(externalPaymentId: string): Promise<MarketplacePaymentResult>
+
+  // --- Refunds ---
+
+  /** Refund a marketplace payment (full or partial) */
+  refundPayment(params: RefundMarketplacePaymentParams): Promise<RefundResult>
+
+  // --- Payouts ---
+
+  /** Trigger a manual payout to a connected account */
+  createPayout(params: CreatePayoutParams): Promise<PayoutResult>
+
+  /** Get the available balance for a connected account */
+  getAccountBalance(externalAccountId: string): Promise<AccountBalanceResult>
+
+  // --- Webhooks ---
+
+  /** Verify webhook signature and return parsed event */
+  verifyWebhookSignature(
+    payload: string | Buffer,
+    signatureOrHeaders: string | Record<string, string>
+  ): { id: string; type: string; account?: string; data: Record<string, unknown> }
+}

--- a/packages/core/src/lib/marketplace/mercadopago-webhook.ts
+++ b/packages/core/src/lib/marketplace/mercadopago-webhook.ts
@@ -1,0 +1,532 @@
+/**
+ * MercadoPago Marketplace Webhook Handler
+ *
+ * Handles MercadoPago webhook notifications for marketplace (split) payments.
+ * Follows the "fetch full resource" pattern: MP webhooks only send the resource ID,
+ * so the handler fetches the complete payment object from the API.
+ *
+ * Key behaviors:
+ * - Signature verification via x-signature HMAC-SHA256
+ * - Idempotency via marketplaceWebhookEvents table
+ * - Full payment fetch from MP API (webhook body only has resource ID)
+ * - Status mapping to MarketplacePaymentStatus
+ * - Extension point for theme-specific logic
+ *
+ * Webhook vs IPN:
+ * - This uses Webhooks (v2), the current recommended system as of 2025
+ * - IPN is legacy/deprecated. Do not use for new integrations.
+ *
+ * Retry behavior (MercadoPago):
+ * - Retries on any non-2xx response (~10 attempts over ~4 days, exponential backoff)
+ * - First retry ~5 minutes after failure
+ * - Return 200 for events you want to skip (not 400, which triggers retries)
+ *
+ * Usage in route.ts:
+ *   import { handleMPMarketplaceWebhook } from '@nextsparkjs/core/lib/marketplace/mercadopago-webhook'
+ *   export async function POST(request: NextRequest) {
+ *     return handleMPMarketplaceWebhook(request)
+ *   }
+ *
+ * With extensions:
+ *   export async function POST(request: NextRequest) {
+ *     return handleMPMarketplaceWebhook(request, {
+ *       onPaymentApproved: async (payment, context) => { ... },
+ *       onPaymentRejected: async (payment, context) => { ... },
+ *       onChargeBack: async (payment, context) => { ... },
+ *     })
+ *   }
+ */
+
+import { createHmac } from 'crypto'
+import { NextRequest } from 'next/server'
+import { query, queryOne } from '../db'
+import type { MarketplacePaymentStatus } from './types'
+
+// ===========================================
+// Types
+// ===========================================
+
+/**
+ * MercadoPago webhook notification body.
+ * This is the minimal payload MP sends — NOT the full payment.
+ */
+export interface MPWebhookNotification {
+  /** Notification ID (not the payment ID) */
+  id: number
+  /** Whether this is a production notification */
+  live_mode: boolean
+  /** Resource type: "payment", "plan", "subscription", "invoice" */
+  type: string
+  /** ISO 8601 datetime */
+  date_created: string
+  /** MercadoPago user_id of the application owner (your marketplace account) */
+  user_id: number
+  /** API version */
+  api_version: string
+  /** Event action: "payment.created", "payment.updated", etc. */
+  action: string
+  /** Contains only the resource ID — you MUST fetch the full resource */
+  data: {
+    id: string
+  }
+}
+
+/**
+ * Full payment object fetched from MP API after receiving webhook.
+ * This is a subset of the fields — only those relevant to marketplace processing.
+ */
+export interface MPFullPayment {
+  id: number
+  status: string
+  status_detail: string
+  transaction_amount: number
+  currency_id: string
+  description: string | null
+  payment_method_id: string
+  payment_type_id: string
+  date_approved: string | null
+  date_created: string
+  external_reference: string | null
+  /** Seller's MP user ID (the one who collected the payment) */
+  collector_id: number
+  /** Payer info */
+  payer: {
+    id: number | null
+    email: string | null
+    type: string | null
+  }
+  /** Fee breakdown — key for detecting marketplace payments */
+  fee_details: Array<{
+    /** "mercadopago_fee" (MP processing fee) or "application_fee" (your marketplace_fee) */
+    type: string
+    amount: number
+    fee_payer: string
+  }>
+  /** Net amount details */
+  transaction_details: {
+    net_received_amount: number
+    total_paid_amount: number
+    overpaid_amount: number
+    installment_amount: number
+  } | null
+  /** Metadata set when creating the payment/preference */
+  metadata: Record<string, string> | null
+  /** Marketplace owner's collector ID — present ONLY for marketplace payments */
+  marketplace_owner: number | null
+  /** Number of installments (common in LATAM) */
+  installments: number
+  /** Refund details if any */
+  refunds: Array<{
+    id: number
+    amount: number
+    status: string
+    date_created: string
+  }> | null
+}
+
+/**
+ * Parsed payment context passed to extension callbacks.
+ */
+export interface MPPaymentContext {
+  /** Our internal reference ID (from external_reference or metadata) */
+  referenceId: string | null
+  /** Connected account ID from metadata */
+  connectedAccountId: string | null
+  /** Seller's MP user ID */
+  sellerUserId: number
+  /** Whether this is a marketplace payment (has marketplace_owner or application_fee) */
+  isMarketplacePayment: boolean
+  /** The application fee (marketplace_fee) amount, if present */
+  applicationFee: number
+  /** MercadoPago's own processing fee */
+  providerFee: number
+  /** Net amount the seller receives */
+  netAmount: number
+  /** Our mapped status */
+  mappedStatus: MarketplacePaymentStatus
+}
+
+/**
+ * Extension hooks for theme-specific marketplace webhook logic.
+ */
+export interface MPMarketplaceWebhookExtensions {
+  /** Called when a marketplace payment is approved (status = approved) */
+  onPaymentApproved?: (payment: MPFullPayment, context: MPPaymentContext) => Promise<void>
+  /** Called when a marketplace payment is rejected */
+  onPaymentRejected?: (payment: MPFullPayment, context: MPPaymentContext) => Promise<void>
+  /** Called when a payment goes into pending state (cash payments like rapipago/boleto/oxxo) */
+  onPaymentPending?: (payment: MPFullPayment, context: MPPaymentContext) => Promise<void>
+  /** Called when a chargeback is initiated */
+  onChargeBack?: (payment: MPFullPayment, context: MPPaymentContext) => Promise<void>
+  /** Called when a payment is refunded */
+  onPaymentRefunded?: (payment: MPFullPayment, context: MPPaymentContext) => Promise<void>
+  /** Called when a payment is cancelled */
+  onPaymentCancelled?: (payment: MPFullPayment, context: MPPaymentContext) => Promise<void>
+  /** Called when a dispute/mediation is opened */
+  onPaymentInMediation?: (payment: MPFullPayment, context: MPPaymentContext) => Promise<void>
+  /** Called for any payment status update (after the specific handler above) */
+  onPaymentUpdated?: (payment: MPFullPayment, context: MPPaymentContext) => Promise<void>
+}
+
+// ===========================================
+// Signature Verification
+// ===========================================
+
+/**
+ * Verify MercadoPago webhook x-signature header.
+ *
+ * Algorithm:
+ * 1. Parse ts (timestamp) and v1 (hash) from x-signature: "ts=123,v1=abc"
+ * 2. Build manifest: "id:{data.id};request-id:{x-request-id};ts:{ts};"
+ * 3. HMAC-SHA256(manifest, webhook_secret)
+ * 4. Compare hex digest with v1
+ *
+ * Only parts that are present are included in the manifest.
+ * In practice, all three (id, request-id, ts) are always present for v2 webhooks.
+ */
+function verifyMPWebhookSignature(params: {
+  xSignature: string
+  xRequestId: string
+  dataId: string
+  webhookSecret: string
+}): void {
+  const { xSignature, xRequestId, dataId, webhookSecret } = params
+
+  // Parse "ts=1234567890,v1=abc123def456..."
+  const parts: Record<string, string> = {}
+  xSignature.split(',').forEach((segment) => {
+    const eqIndex = segment.indexOf('=')
+    if (eqIndex > 0) {
+      const key = segment.substring(0, eqIndex).trim()
+      const value = segment.substring(eqIndex + 1).trim()
+      parts[key] = value
+    }
+  })
+
+  const ts = parts['ts']
+  const expectedHash = parts['v1']
+
+  if (!expectedHash) {
+    throw new Error('Missing v1 hash in x-signature header')
+  }
+
+  // Build manifest string — only include parts that are present
+  let manifest = ''
+  if (dataId) manifest += `id:${dataId};`
+  if (xRequestId) manifest += `request-id:${xRequestId};`
+  if (ts) manifest += `ts:${ts};`
+
+  const computedHash = createHmac('sha256', webhookSecret)
+    .update(manifest)
+    .digest('hex')
+
+  if (computedHash !== expectedHash) {
+    throw new Error('MercadoPago webhook signature verification failed')
+  }
+}
+
+// ===========================================
+// Status Mapping
+// ===========================================
+
+function mapMPStatus(status: string): MarketplacePaymentStatus {
+  const statusMap: Record<string, MarketplacePaymentStatus> = {
+    pending: 'pending',
+    approved: 'succeeded',
+    authorized: 'processing',
+    in_process: 'processing',
+    in_mediation: 'disputed',
+    rejected: 'failed',
+    cancelled: 'canceled',
+    refunded: 'refunded',
+    charged_back: 'disputed',
+  }
+  return statusMap[status] || 'failed'
+}
+
+// ===========================================
+// Full Resource Fetch
+// ===========================================
+
+/**
+ * Fetch the full payment resource from MercadoPago API.
+ *
+ * CRITICAL: MP webhooks only send the resource ID in data.id.
+ * You MUST fetch the full payment to get status, amounts, fees, etc.
+ * Use the platform access token (not seller token) to read any payment.
+ */
+async function fetchFullPayment(paymentId: string): Promise<MPFullPayment> {
+  const accessToken = process.env.MP_ACCESS_TOKEN
+  if (!accessToken) {
+    throw new Error('MP_ACCESS_TOKEN is not configured')
+  }
+
+  const response = await fetch(`https://api.mercadopago.com/v1/payments/${paymentId}`, {
+    headers: {
+      'Authorization': `Bearer ${accessToken}`,
+      'Content-Type': 'application/json',
+    },
+  })
+
+  if (!response.ok) {
+    const errorText = await response.text()
+    throw new Error(`Failed to fetch payment ${paymentId}: ${response.status} ${errorText}`)
+  }
+
+  return response.json() as Promise<MPFullPayment>
+}
+
+// ===========================================
+// Payment Context Builder
+// ===========================================
+
+function buildPaymentContext(payment: MPFullPayment): MPPaymentContext {
+  const applicationFeeEntry = payment.fee_details?.find(f => f.type === 'application_fee')
+  const providerFeeEntry = payment.fee_details?.find(f => f.type === 'mercadopago_fee')
+
+  const applicationFee = applicationFeeEntry?.amount ?? 0
+  const providerFee = providerFeeEntry?.amount ?? 0
+  const netAmount = payment.transaction_details?.net_received_amount ?? (payment.transaction_amount - applicationFee - providerFee)
+
+  // Detect marketplace payment:
+  // - marketplace_owner is present (set by MP when payment is created with marketplace_fee)
+  // - OR there is an application_fee in fee_details
+  const isMarketplacePayment = payment.marketplace_owner !== null || applicationFee > 0
+
+  return {
+    referenceId: payment.external_reference ?? payment.metadata?.referenceId ?? null,
+    connectedAccountId: payment.metadata?.connectedAccountId ?? null,
+    sellerUserId: payment.collector_id,
+    isMarketplacePayment,
+    applicationFee,
+    providerFee,
+    netAmount,
+    mappedStatus: mapMPStatus(payment.status),
+  }
+}
+
+// ===========================================
+// Main Handler
+// ===========================================
+
+export async function handleMPMarketplaceWebhook(
+  request: NextRequest,
+  extensions?: MPMarketplaceWebhookExtensions
+): Promise<Response> {
+  // 1. Read raw body and headers
+  const rawBody = await request.text()
+  const xSignature = request.headers.get('x-signature')
+  const xRequestId = request.headers.get('x-request-id')
+
+  // 2. Parse body
+  let notification: MPWebhookNotification
+  try {
+    notification = JSON.parse(rawBody) as MPWebhookNotification
+  } catch {
+    // Return 200 even for unparseable bodies — returning 400 triggers MP retries
+    console.error('[mp-marketplace-webhook] Failed to parse request body')
+    return Response.json({ received: true, status: 'parse_error' })
+  }
+
+  // 3. Only process payment notifications
+  if (notification.type !== 'payment') {
+    console.log(`[mp-marketplace-webhook] Ignoring non-payment notification: ${notification.type}/${notification.action}`)
+    return Response.json({ received: true, status: 'ignored' })
+  }
+
+  const dataId = notification.data?.id
+  if (!dataId) {
+    console.error('[mp-marketplace-webhook] Missing data.id in notification')
+    return Response.json({ received: true, status: 'missing_data_id' })
+  }
+
+  // 4. Verify webhook signature (MANDATORY for security)
+  const webhookSecret = process.env.MP_WEBHOOK_SECRET
+  if (!webhookSecret) {
+    console.error('[mp-marketplace-webhook] MP_WEBHOOK_SECRET is not configured')
+    return Response.json({ error: 'Server misconfigured' }, { status: 500 })
+  }
+
+  if (xSignature && xRequestId) {
+    try {
+      verifyMPWebhookSignature({
+        xSignature,
+        xRequestId,
+        dataId,
+        webhookSecret,
+      })
+    } catch (error) {
+      console.error('[mp-marketplace-webhook] Signature verification failed:', error)
+      return Response.json({ error: 'Invalid signature' }, { status: 401 })
+    }
+  } else {
+    // In production, reject requests without signature headers.
+    // MP v2 webhooks always include these headers.
+    if (process.env.NODE_ENV === 'production') {
+      console.error('[mp-marketplace-webhook] Missing x-signature or x-request-id headers')
+      return Response.json({ error: 'Missing signature headers' }, { status: 401 })
+    }
+    console.warn('[mp-marketplace-webhook] Missing signature headers (allowed in non-production)')
+  }
+
+  // 5. Idempotency — check if we already processed this notification
+  const notificationId = String(notification.id)
+  const existing = await queryOne(
+    `SELECT id FROM "marketplaceWebhookEvents" WHERE "externalEventId" = $1`,
+    [notificationId]
+  )
+
+  if (existing) {
+    console.log(`[mp-marketplace-webhook] Notification ${notificationId} already processed, skipping`)
+    return Response.json({ received: true, status: 'duplicate' })
+  }
+
+  // 6. Fetch the full payment from MercadoPago API
+  //    This is the critical "fetch full resource" pattern.
+  //    The webhook body only has the payment ID — we must call the API to get everything.
+  let payment: MPFullPayment
+  try {
+    payment = await fetchFullPayment(dataId)
+  } catch (error) {
+    console.error(`[mp-marketplace-webhook] Failed to fetch payment ${dataId}:`, error)
+    // Return 500 so MP retries this notification
+    return Response.json({ error: 'Failed to fetch payment' }, { status: 500 })
+  }
+
+  const context = buildPaymentContext(payment)
+
+  console.log(
+    `[mp-marketplace-webhook] Processing payment ${payment.id}: ` +
+    `status=${payment.status}, marketplace=${context.isMarketplacePayment}, ` +
+    `amount=${payment.transaction_amount} ${payment.currency_id}, ` +
+    `fee=${context.applicationFee}, ref=${context.referenceId}`
+  )
+
+  // 7. Record the webhook event (for idempotency and audit trail)
+  try {
+    await query(
+      `INSERT INTO "marketplaceWebhookEvents" (
+        "externalEventId", provider, "eventType", action, "resourceId",
+        processed, "processedAt", "rawPayload"
+      ) VALUES ($1, $2, $3, $4, $5, $6, NOW(), $7)`,
+      [
+        notificationId,
+        'mercadopago_split',
+        notification.type,
+        notification.action,
+        dataId,
+        true,
+        JSON.stringify(notification),
+      ]
+    )
+  } catch (error) {
+    console.error('[mp-marketplace-webhook] Failed to record webhook event:', error)
+    // Continue processing — the payment update is more important than the audit record
+  }
+
+  // 8. Update the marketplace payment record in our database
+  try {
+    await upsertMarketplacePayment(payment, context)
+  } catch (error) {
+    console.error(`[mp-marketplace-webhook] Failed to update payment record:`, error)
+    // Continue to extension callbacks — partial processing is better than none
+  }
+
+  // 9. Call extension callbacks based on payment status
+  try {
+    switch (payment.status) {
+      case 'approved':
+        await extensions?.onPaymentApproved?.(payment, context)
+        break
+      case 'rejected':
+        await extensions?.onPaymentRejected?.(payment, context)
+        break
+      case 'pending':
+        await extensions?.onPaymentPending?.(payment, context)
+        break
+      case 'charged_back':
+        await extensions?.onChargeBack?.(payment, context)
+        break
+      case 'refunded':
+        await extensions?.onPaymentRefunded?.(payment, context)
+        break
+      case 'cancelled':
+        await extensions?.onPaymentCancelled?.(payment, context)
+        break
+      case 'in_mediation':
+        await extensions?.onPaymentInMediation?.(payment, context)
+        break
+    }
+
+    // Always call the generic onPaymentUpdated if provided
+    await extensions?.onPaymentUpdated?.(payment, context)
+  } catch (error) {
+    console.error('[mp-marketplace-webhook] Extension handler error:', error)
+    // Return 500 so MP retries — the extension logic may be critical
+    return Response.json({ error: 'Handler failed' }, { status: 500 })
+  }
+
+  return Response.json({ received: true })
+}
+
+// ===========================================
+// Database Helpers
+// ===========================================
+
+/**
+ * Upsert a marketplace payment record.
+ * Uses the MP payment ID as the unique key.
+ * Creates the record on payment.created, updates on payment.updated.
+ */
+async function upsertMarketplacePayment(
+  payment: MPFullPayment,
+  context: MPPaymentContext
+): Promise<void> {
+  const refundedAmount = payment.refunds?.reduce((sum, r) => {
+    return r.status === 'approved' ? sum + r.amount : sum
+  }, 0) ?? 0
+
+  await query(
+    `INSERT INTO "marketplacePayments" (
+      "externalPaymentId",
+      "connectedAccountId",
+      "referenceId",
+      "totalAmount",
+      "applicationFee",
+      "providerFee",
+      "businessAmount",
+      currency,
+      status,
+      "statusDetail",
+      "paymentMethod",
+      "paymentType",
+      "refundedAmount",
+      metadata,
+      "paidAt",
+      "updatedAt"
+    ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, NOW())
+    ON CONFLICT ("externalPaymentId") DO UPDATE SET
+      status = EXCLUDED.status,
+      "statusDetail" = EXCLUDED."statusDetail",
+      "refundedAmount" = EXCLUDED."refundedAmount",
+      "paidAt" = COALESCE(EXCLUDED."paidAt", "marketplacePayments"."paidAt"),
+      "updatedAt" = NOW()`,
+    [
+      String(payment.id),
+      context.connectedAccountId,
+      context.referenceId,
+      payment.transaction_amount,
+      context.applicationFee,
+      context.providerFee,
+      context.netAmount,
+      payment.currency_id.toLowerCase(),
+      context.mappedStatus,
+      payment.status_detail,
+      payment.payment_method_id,
+      payment.payment_type_id,
+      refundedAmount,
+      JSON.stringify(payment.metadata ?? {}),
+      payment.date_approved ? new Date(payment.date_approved) : null,
+    ]
+  )
+}

--- a/packages/core/src/lib/marketplace/stripe-connect-webhook.ts
+++ b/packages/core/src/lib/marketplace/stripe-connect-webhook.ts
@@ -1,0 +1,250 @@
+/**
+ * Stripe Connect Webhook Handler
+ *
+ * Handles Connect-specific events for marketplace payment splitting.
+ * Uses a SEPARATE webhook endpoint and signing secret from regular billing webhooks.
+ *
+ * Events handled:
+ * - account.updated: KYC/onboarding status changes
+ * - payment_intent.succeeded/failed: Payment lifecycle
+ * - charge.refunded: Refund processing
+ * - charge.dispute.created/closed: Dispute handling
+ * - payout.paid/failed: Payout lifecycle
+ * - transfer.created/reversed: Transfer tracking
+ */
+
+import { NextRequest } from 'next/server'
+import Stripe from 'stripe'
+import { query, queryOne } from '../db'
+
+// Lazy Stripe instance
+let stripeInstance: Stripe | null = null
+function getStripe(): Stripe {
+  if (!stripeInstance) {
+    stripeInstance = new Stripe(process.env.STRIPE_SECRET_KEY!, {
+      apiVersion: '2025-08-27.basil',
+      typescript: true,
+    })
+  }
+  return stripeInstance
+}
+
+export interface StripeConnectWebhookExtensions {
+  /** Called when a payment succeeds for custom business logic */
+  onPaymentSucceeded?: (paymentIntent: Stripe.PaymentIntent, connectedAccountId: string) => Promise<void>
+  /** Called when a dispute is created */
+  onDisputeCreated?: (dispute: Stripe.Dispute, connectedAccountId: string) => Promise<void>
+}
+
+export async function handleStripeConnectWebhook(
+  request: NextRequest,
+  extensions?: StripeConnectWebhookExtensions
+): Promise<Response> {
+  const payload = await request.text()
+  const signature = request.headers.get('stripe-signature')
+
+  if (!signature) {
+    return Response.json({ error: 'No signature provided' }, { status: 400 })
+  }
+
+  // Verify using CONNECT webhook secret (separate from billing webhook secret)
+  const webhookSecret = process.env.STRIPE_CONNECT_WEBHOOK_SECRET
+  if (!webhookSecret) {
+    console.error('[stripe-connect-webhook] STRIPE_CONNECT_WEBHOOK_SECRET not configured')
+    return Response.json({ error: 'Webhook not configured' }, { status: 500 })
+  }
+
+  let event: Stripe.Event
+  try {
+    event = getStripe().webhooks.constructEvent(payload, signature, webhookSecret)
+  } catch (error) {
+    console.error('[stripe-connect-webhook] Signature verification failed:', error)
+    return Response.json({ error: 'Invalid signature' }, { status: 400 })
+  }
+
+  // Connect events include event.account (the connected account ID)
+  const connectedAccountId = event.account || ''
+
+  // Idempotency check
+  const existing = await queryOne(
+    `SELECT id FROM "marketplaceWebhookEvents" WHERE provider = 'stripe_connect' AND "externalEventId" = $1`,
+    [event.id]
+  )
+  if (existing) {
+    return Response.json({ received: true, status: 'duplicate' })
+  }
+
+  // Log event
+  await query(
+    `INSERT INTO "marketplaceWebhookEvents" (provider, "externalEventId", "eventType", action, "resourceId", "rawPayload")
+     VALUES ('stripe_connect', $1, $2, $3, $4, $5)`,
+    [event.id, event.type, event.type, connectedAccountId, JSON.stringify(event.data)]
+  )
+
+  try {
+    switch (event.type) {
+      case 'account.updated':
+        await handleAccountUpdated(event.data.object as Stripe.Account)
+        break
+
+      case 'payment_intent.succeeded':
+        await handlePaymentSucceeded(event.data.object as Stripe.PaymentIntent, connectedAccountId, extensions)
+        break
+
+      case 'payment_intent.payment_failed':
+        await handlePaymentFailed(event.data.object as Stripe.PaymentIntent)
+        break
+
+      case 'charge.refunded':
+        await handleChargeRefunded(event.data.object as Stripe.Charge)
+        break
+
+      case 'charge.dispute.created':
+        await handleDisputeCreated(event.data.object as Stripe.Dispute, connectedAccountId, extensions)
+        break
+
+      case 'payout.paid':
+      case 'payout.failed':
+        await handlePayoutEvent(event.data.object as Stripe.Payout, event.type)
+        break
+
+      default:
+        console.log(`[stripe-connect-webhook] Unhandled event: ${event.type}`)
+    }
+
+    // Mark as processed
+    await query(
+      `UPDATE "marketplaceWebhookEvents" SET processed = true, "processedAt" = NOW()
+       WHERE provider = 'stripe_connect' AND "externalEventId" = $1`,
+      [event.id]
+    )
+
+    return Response.json({ received: true })
+  } catch (error) {
+    console.error(`[stripe-connect-webhook] Error handling ${event.type}:`, error)
+
+    await query(
+      `UPDATE "marketplaceWebhookEvents" SET error = $1
+       WHERE provider = 'stripe_connect' AND "externalEventId" = $2`,
+      [error instanceof Error ? error.message : 'Unknown error', event.id]
+    )
+
+    return Response.json({ error: 'Handler failed' }, { status: 500 })
+  }
+}
+
+// ===========================================
+// EVENT HANDLERS
+// ===========================================
+
+async function handleAccountUpdated(account: Stripe.Account) {
+  const statusMap: Record<string, string> = {
+    active: 'active',
+    pending: 'in_progress',
+    restricted: 'restricted',
+    disabled: 'disabled',
+  }
+
+  let onboardingStatus = 'pending'
+  if (account.requirements?.disabled_reason) onboardingStatus = 'disabled'
+  else if (account.charges_enabled && account.payouts_enabled) onboardingStatus = 'active'
+  else if (account.requirements?.past_due?.length) onboardingStatus = 'restricted'
+  else if (account.details_submitted) onboardingStatus = 'in_progress'
+
+  await query(
+    `UPDATE "connectedAccounts"
+     SET "onboardingStatus" = $1,
+         "chargesEnabled" = $2,
+         "payoutsEnabled" = $3,
+         "updatedAt" = NOW()
+     WHERE "externalAccountId" = $4`,
+    [onboardingStatus, account.charges_enabled, account.payouts_enabled, account.id]
+  )
+
+  console.log(`[stripe-connect-webhook] Account ${account.id} updated: status=${onboardingStatus}, charges=${account.charges_enabled}`)
+}
+
+async function handlePaymentSucceeded(
+  pi: Stripe.PaymentIntent,
+  connectedAccountId: string,
+  extensions?: StripeConnectWebhookExtensions
+) {
+  const chargeId = typeof pi.latest_charge === 'string' ? pi.latest_charge : pi.latest_charge?.id
+
+  await query(
+    `UPDATE "marketplacePayments"
+     SET status = 'succeeded',
+         "externalChargeId" = $1,
+         "paidAt" = NOW(),
+         "updatedAt" = NOW()
+     WHERE "externalPaymentId" = $2`,
+    [chargeId || null, pi.id]
+  )
+
+  console.log(`[stripe-connect-webhook] Payment ${pi.id} succeeded for account ${connectedAccountId}`)
+
+  if (extensions?.onPaymentSucceeded) {
+    await extensions.onPaymentSucceeded(pi, connectedAccountId)
+  }
+}
+
+async function handlePaymentFailed(pi: Stripe.PaymentIntent) {
+  await query(
+    `UPDATE "marketplacePayments"
+     SET status = 'failed',
+         "statusDetail" = $1,
+         "updatedAt" = NOW()
+     WHERE "externalPaymentId" = $2`,
+    [pi.last_payment_error?.message || 'Payment failed', pi.id]
+  )
+
+  console.log(`[stripe-connect-webhook] Payment ${pi.id} failed`)
+}
+
+async function handleChargeRefunded(charge: Stripe.Charge) {
+  const refundedAmount = charge.amount_refunded
+  const isFullRefund = charge.refunded
+
+  await query(
+    `UPDATE "marketplacePayments"
+     SET status = $1,
+         "refundedAmount" = $2,
+         "updatedAt" = NOW()
+     WHERE "externalChargeId" = $3`,
+    [isFullRefund ? 'refunded' : 'partially_refunded', refundedAmount, charge.id]
+  )
+
+  console.log(`[stripe-connect-webhook] Charge ${charge.id} refunded: ${refundedAmount} (full=${isFullRefund})`)
+}
+
+async function handleDisputeCreated(
+  dispute: Stripe.Dispute,
+  connectedAccountId: string,
+  extensions?: StripeConnectWebhookExtensions
+) {
+  const chargeId = typeof dispute.charge === 'string' ? dispute.charge : dispute.charge?.id
+
+  if (chargeId) {
+    await query(
+      `UPDATE "marketplacePayments"
+       SET status = 'disputed',
+           "statusDetail" = $1,
+           "updatedAt" = NOW()
+       WHERE "externalChargeId" = $2`,
+      [`Dispute: ${dispute.reason}`, chargeId]
+    )
+  }
+
+  console.error(`[stripe-connect-webhook] DISPUTE created for charge ${chargeId}, account ${connectedAccountId}, reason: ${dispute.reason}`)
+
+  if (extensions?.onDisputeCreated) {
+    await extensions.onDisputeCreated(dispute, connectedAccountId)
+  }
+}
+
+async function handlePayoutEvent(payout: Stripe.Payout, eventType: string) {
+  const status = eventType === 'payout.paid' ? 'paid' : 'failed'
+
+  console.log(`[stripe-connect-webhook] Payout ${payout.id}: ${status}`)
+  // Payout tracking can be extended with a dedicated payouts table if needed
+}

--- a/packages/core/src/lib/marketplace/token-encryption.ts
+++ b/packages/core/src/lib/marketplace/token-encryption.ts
@@ -1,0 +1,103 @@
+/**
+ * Marketplace Token Encryption
+ *
+ * AES-256-GCM encryption for MercadoPago OAuth tokens stored in the database.
+ * Prevents plaintext credential exposure if the database is compromised.
+ *
+ * Encrypted format: "iv:authTag:ciphertext" (hex-encoded)
+ *
+ * Setup:
+ *   Generate a key with: node -e "console.log(require('crypto').randomBytes(32).toString('hex'))"
+ *   Set MARKETPLACE_TOKEN_ENCRYPTION_KEY in .env
+ */
+
+import { createCipheriv, createDecipheriv, randomBytes } from 'crypto'
+
+const ALGORITHM = 'aes-256-gcm'
+const IV_LENGTH = 12 // 96 bits, recommended for GCM
+const AUTH_TAG_LENGTH = 16 // 128 bits
+
+function getEncryptionKey(): Buffer {
+  const key = process.env.MARKETPLACE_TOKEN_ENCRYPTION_KEY
+  if (!key) {
+    throw new Error(
+      'MARKETPLACE_TOKEN_ENCRYPTION_KEY is not configured. ' +
+      "Generate one with: node -e \"console.log(require('crypto').randomBytes(32).toString('hex'))\""
+    )
+  }
+  return Buffer.from(key, 'hex')
+}
+
+/**
+ * Encrypt a single token string.
+ * Returns "iv:authTag:ciphertext" in hex encoding.
+ */
+export function encryptToken(plaintext: string): string {
+  const key = getEncryptionKey()
+  const iv = randomBytes(IV_LENGTH)
+  const cipher = createCipheriv(ALGORITHM, key, iv, { authTagLength: AUTH_TAG_LENGTH })
+
+  const encrypted = Buffer.concat([cipher.update(plaintext, 'utf8'), cipher.final()])
+  const authTag = cipher.getAuthTag()
+
+  return `${iv.toString('hex')}:${authTag.toString('hex')}:${encrypted.toString('hex')}`
+}
+
+/**
+ * Decrypt a token encrypted by encryptToken.
+ * Expects "iv:authTag:ciphertext" in hex encoding.
+ */
+export function decryptToken(encrypted: string): string {
+  const parts = encrypted.split(':')
+  if (parts.length !== 3) {
+    throw new Error('Invalid encrypted token format. Expected "iv:authTag:ciphertext".')
+  }
+
+  const [ivHex, authTagHex, ciphertextHex] = parts
+  const key = getEncryptionKey()
+  const iv = Buffer.from(ivHex, 'hex')
+  const authTag = Buffer.from(authTagHex, 'hex')
+  const ciphertext = Buffer.from(ciphertextHex, 'hex')
+
+  const decipher = createDecipheriv(ALGORITHM, key, iv, { authTagLength: AUTH_TAG_LENGTH })
+  decipher.setAuthTag(authTag)
+
+  const decrypted = Buffer.concat([decipher.update(ciphertext), decipher.final()])
+  return decrypted.toString('utf8')
+}
+
+/**
+ * Token fields that contain sensitive credentials and must be encrypted.
+ */
+interface MPTokenFields {
+  accessToken: string
+  refreshToken: string
+  expiresAt: string
+  publicKey: string
+}
+
+/**
+ * Encrypt the sensitive fields (accessToken, refreshToken) in a token object.
+ * Non-sensitive fields (expiresAt, publicKey) are left as-is.
+ */
+export function encryptTokens(tokens: MPTokenFields): MPTokenFields {
+  return {
+    accessToken: encryptToken(tokens.accessToken),
+    refreshToken: encryptToken(tokens.refreshToken),
+    expiresAt: tokens.expiresAt,
+    publicKey: tokens.publicKey,
+  }
+}
+
+/**
+ * Decrypt the sensitive fields (accessToken, refreshToken) in a token object.
+ * Non-sensitive fields (expiresAt, publicKey) are returned as-is.
+ */
+export function decryptTokens(tokens: MPTokenFields): MPTokenFields {
+  return {
+    accessToken: decryptToken(tokens.accessToken),
+    refreshToken: decryptToken(tokens.refreshToken),
+    expiresAt: tokens.expiresAt,
+    publicKey: tokens.publicKey,
+  }
+}

--- a/packages/core/src/lib/marketplace/types.ts
+++ b/packages/core/src/lib/marketplace/types.ts
@@ -1,0 +1,154 @@
+/**
+ * Marketplace Types
+ *
+ * Core types for the marketplace/connect payment splitting system.
+ * Supports Stripe Connect (Express) and MercadoPago Split.
+ *
+ * This module is PARALLEL to the billing system:
+ * - billing/ = SaaS subscription (the business pays for the platform)
+ * - marketplace/ = Payment splitting (customer pays, platform takes commission)
+ */
+
+// ===========================================
+// PROVIDER TYPES
+// ===========================================
+
+export type MarketplaceProvider = 'stripe_connect' | 'mercadopago_split'
+
+// ===========================================
+// CONNECTED ACCOUNT TYPES
+// ===========================================
+
+export type OnboardingStatus =
+  | 'pending'      // Account created, onboarding not started
+  | 'in_progress'  // Onboarding started but not complete
+  | 'active'       // Fully onboarded, can accept payments
+  | 'restricted'   // Some capabilities disabled (e.g., pending KYC docs)
+  | 'disabled'     // Account disabled by provider
+  | 'disconnected' // Manually disconnected by team
+
+export interface ConnectedAccount {
+  id: string
+  teamId: string
+  provider: MarketplaceProvider
+  externalAccountId: string        // acct_xxx (Stripe) or MP user_id
+  email: string
+  businessName: string | null
+  country: string                  // ISO 3166-1 alpha-2 (US, AR, BR, MX)
+  currency: string                 // ISO 4217 (usd, ars, brl, mxn)
+  onboardingStatus: OnboardingStatus
+  chargesEnabled: boolean
+  payoutsEnabled: boolean
+  commissionRate: number           // 0.15 = 15%
+  fixedFee: number                 // Fixed fee per transaction (in smallest currency unit)
+  payoutSchedule: 'daily' | 'weekly' | 'monthly' | 'manual'
+  metadata: Record<string, unknown>
+  createdAt: Date
+  updatedAt: Date
+}
+
+// ===========================================
+// PAYMENT TYPES
+// ===========================================
+
+export type MarketplacePaymentStatus =
+  | 'pending'
+  | 'processing'
+  | 'succeeded'
+  | 'failed'
+  | 'refunded'
+  | 'partially_refunded'
+  | 'disputed'
+  | 'canceled'
+
+export interface MarketplacePayment {
+  id: string
+  connectedAccountId: string
+  teamId: string
+  referenceId: string              // External reference (booking ID, order ID, etc.)
+  referenceType: string            // 'booking', 'order', etc.
+  externalPaymentId: string        // pi_xxx (Stripe) or MP payment_id
+  externalChargeId: string | null
+  externalTransferId: string | null
+  totalAmount: number              // What the customer paid
+  applicationFee: number           // Platform commission
+  businessAmount: number           // What the business receives (before provider fees)
+  providerFee: number | null       // Provider processing fee
+  currency: string
+  commissionRate: number           // Rate applied for this payment
+  status: MarketplacePaymentStatus
+  statusDetail: string | null      // Provider-specific status detail
+  paymentMethod: string | null     // visa, master, pix, rapipago, etc.
+  paymentType: string | null       // credit_card, debit_card, bank_transfer, cash
+  refundedAmount: number
+  metadata: Record<string, unknown>
+  paidAt: Date | null
+  createdAt: Date
+  updatedAt: Date
+}
+
+// ===========================================
+// PAYOUT TYPES
+// ===========================================
+
+export type PayoutStatus =
+  | 'pending'
+  | 'in_transit'
+  | 'paid'
+  | 'failed'
+  | 'canceled'
+
+export interface Payout {
+  id: string
+  connectedAccountId: string
+  externalPayoutId: string
+  amount: number
+  currency: string
+  status: PayoutStatus
+  arrivalDate: Date | null
+  failureCode: string | null
+  failureMessage: string | null
+  createdAt: Date
+  updatedAt: Date
+}
+
+// ===========================================
+// COMMISSION TYPES
+// ===========================================
+
+export type CommissionModel = 'percentage' | 'fixed' | 'hybrid' | 'tiered'
+
+export interface CommissionConfig {
+  model: CommissionModel
+  /** Percentage rate (e.g., 0.15 for 15%). Used in percentage and hybrid models. */
+  rate?: number
+  /** Fixed fee per transaction in smallest currency unit. Used in fixed and hybrid models. */
+  fixedAmount?: number
+  /** Minimum fee per transaction. */
+  minFee?: number
+  /** Maximum fee per transaction. */
+  maxFee?: number
+  /** Volume-based tiers. Used in tiered model. */
+  tiers?: Array<{
+    minVolume: number  // Monthly volume threshold
+    rate: number       // Rate for this tier
+  }>
+}
+
+// ===========================================
+// WEBHOOK EVENT TYPES
+// ===========================================
+
+export interface MarketplaceWebhookEvent {
+  id: string
+  provider: MarketplaceProvider
+  externalEventId: string
+  eventType: string
+  action: string
+  resourceId: string
+  processed: boolean
+  processedAt: Date | null
+  error: string | null
+  rawPayload: Record<string, unknown>
+  createdAt: Date
+}

--- a/packages/core/src/lib/scheduled-actions/handlers/index.ts
+++ b/packages/core/src/lib/scheduled-actions/handlers/index.ts
@@ -8,3 +8,4 @@
  */
 
 export { registerPatternCacheInvalidationHandler } from './invalidate-pattern-cache'
+export { registerRefreshMPTokensHandler } from '../../marketplace/handlers/refresh-mp-tokens'

--- a/packages/core/templates/lib/marketplace/mp-webhook-extensions.ts
+++ b/packages/core/templates/lib/marketplace/mp-webhook-extensions.ts
@@ -1,0 +1,25 @@
+/**
+ * MercadoPago Marketplace Webhook Extensions
+ *
+ * Override these callbacks to handle marketplace-specific payment events.
+ * This is the theme/project-level customization point.
+ *
+ * Example: fulfill an order when payment is approved, notify seller on chargeback, etc.
+ *
+ * import type { MPMarketplaceWebhookExtensions } from '@nextsparkjs/core/lib/marketplace/mercadopago-webhook'
+ *
+ * export const mpMarketplaceWebhookExtensions: MPMarketplaceWebhookExtensions = {
+ *   onPaymentApproved: async (payment, context) => {
+ *     // Fulfill the order
+ *     await fulfillOrder(context.referenceId)
+ *   },
+ *   onChargeBack: async (payment, context) => {
+ *     // Freeze seller payouts, notify admin
+ *     await handleChargeback(context.connectedAccountId, payment.id)
+ *   },
+ * }
+ */
+
+import type { MPMarketplaceWebhookExtensions } from '@nextsparkjs/core/lib/marketplace/mercadopago-webhook'
+
+export const mpMarketplaceWebhookExtensions: MPMarketplaceWebhookExtensions = {}

--- a/packages/core/tests/jest/__mocks__/better-auth-plugins.js
+++ b/packages/core/tests/jest/__mocks__/better-auth-plugins.js
@@ -1,0 +1,17 @@
+/**
+ * Mock for better-auth/plugins package
+ * Resolves ES module import issues in Jest tests (rou3 ESM-only dependency)
+ */
+
+module.exports = {
+  emailOTP: jest.fn(() => ({})),
+  twoFactor: jest.fn(() => ({})),
+  magicLink: jest.fn(() => ({})),
+  passkey: jest.fn(() => ({})),
+  anonymous: jest.fn(() => ({})),
+  username: jest.fn(() => ({})),
+  phoneNumber: jest.fn(() => ({})),
+  admin: jest.fn(() => ({})),
+  organization: jest.fn(() => ({})),
+  multiSession: jest.fn(() => ({})),
+}

--- a/packages/core/tests/jest/api/billing/cancel.test.ts
+++ b/packages/core/tests/jest/api/billing/cancel.test.ts
@@ -1,0 +1,280 @@
+/**
+ * Billing Cancel API Route Tests
+ *
+ * POST /api/v1/billing/cancel
+ * Cancel or reactivate team subscription.
+ */
+
+import { describe, test, expect, beforeEach, jest } from '@jest/globals'
+import { NextRequest, NextResponse } from 'next/server'
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+const mockAuthenticateRequest = jest.fn()
+const mockCreateAuthError = jest.fn(
+  (msg: string, status: number) => NextResponse.json({ success: false, error: msg }, { status })
+)
+jest.mock('@nextsparkjs/core/lib/api/auth/dual-auth', () => ({
+  authenticateRequest: (...args: any[]) => mockAuthenticateRequest(...args),
+  createAuthError: (...args: any[]) => mockCreateAuthError(...args),
+}))
+
+const mockMembershipGet = jest.fn()
+const mockSubscriptionGetActive = jest.fn()
+jest.mock('@nextsparkjs/core/lib/services', () => ({
+  MembershipService: { get: (...args: any[]) => mockMembershipGet(...args) },
+  SubscriptionService: { getActive: (...args: any[]) => mockSubscriptionGetActive(...args) },
+}))
+
+const mockBillingGateway = {
+  cancelSubscriptionAtPeriodEnd: jest.fn(),
+  cancelSubscriptionImmediately: jest.fn(),
+  reactivateSubscription: jest.fn(),
+}
+jest.mock('@nextsparkjs/core/lib/billing/gateways/factory', () => ({
+  getBillingGateway: () => mockBillingGateway,
+}))
+
+const mockQueryWithRLS = jest.fn()
+jest.mock('@nextsparkjs/core/lib/db', () => ({
+  queryWithRLS: (...args: any[]) => mockQueryWithRLS(...args),
+}))
+
+jest.mock('@nextsparkjs/core/lib/api/rate-limit', () => ({
+  withRateLimitTier: (handler: any) => handler,
+}))
+
+import { POST } from '../../../../../../apps/dev/app/api/v1/billing/cancel/route'
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function createRequest(body?: any, headers: Record<string, string> = {}) {
+  return new NextRequest('http://localhost:3000/api/v1/billing/cancel', {
+    method: 'POST',
+    body: body !== undefined ? JSON.stringify(body) : undefined,
+    headers: { 'Content-Type': 'application/json', ...headers },
+  }) as any
+}
+
+const fakeUser = { id: 'user-1', email: 'admin@test.com', defaultTeamId: 'team-1' }
+
+function authSuccess() {
+  mockAuthenticateRequest.mockResolvedValue({ success: true, user: fakeUser })
+}
+
+function membershipAllowed() {
+  mockMembershipGet.mockResolvedValue({
+    canPerformAction: () => ({ allowed: true }),
+  })
+}
+
+function membershipDenied(msg = 'Not allowed', reason = 'role') {
+  mockMembershipGet.mockResolvedValue({
+    canPerformAction: () => ({ allowed: false, message: msg, reason, meta: {} }),
+  })
+}
+
+const activeSubscription = {
+  id: 'sub-1',
+  externalSubscriptionId: 'sub_stripe_abc',
+  externalCustomerId: 'cus_stripe_xyz',
+  cancelAtPeriodEnd: false,
+  currentPeriodEnd: new Date('2025-12-31T23:59:59Z'),
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('POST /api/v1/billing/cancel', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  // --- Auth ---
+  test('returns 401 if not authenticated', async () => {
+    mockAuthenticateRequest.mockResolvedValue({ success: false })
+    const res = await POST(createRequest({}))
+    expect(res.status).toBe(401)
+  })
+
+  // --- Team context ---
+  test('returns 400 if no team context', async () => {
+    mockAuthenticateRequest.mockResolvedValue({
+      success: true,
+      user: { ...fakeUser, defaultTeamId: null },
+    })
+    const res = await POST(createRequest({}))
+    expect(res.status).toBe(400)
+  })
+
+  // --- Permission ---
+  test('returns 403 if permission denied', async () => {
+    authSuccess()
+    membershipDenied()
+    const res = await POST(createRequest({}))
+    const json = await res.json()
+    expect(res.status).toBe(403)
+    expect(json.reason).toBe('role')
+  })
+
+  // --- Invalid JSON ---
+  test('returns 400 for invalid JSON body', async () => {
+    authSuccess()
+    membershipAllowed()
+    const req = new NextRequest('http://localhost:3000/api/v1/billing/cancel', {
+      method: 'POST',
+      body: 'not-json{{',
+      headers: { 'Content-Type': 'application/json' },
+    }) as any
+    const res = await POST(req)
+    expect(res.status).toBe(400)
+  })
+
+  // --- No active subscription ---
+  test('returns 404 if no active subscription', async () => {
+    authSuccess()
+    membershipAllowed()
+    mockSubscriptionGetActive.mockResolvedValue(null)
+
+    const res = await POST(createRequest({ immediate: false }))
+    const json = await res.json()
+    expect(res.status).toBe(404)
+    expect(json.error).toMatch(/no active subscription/i)
+  })
+
+  test('returns 404 if subscription has no external ID', async () => {
+    authSuccess()
+    membershipAllowed()
+    mockSubscriptionGetActive.mockResolvedValue({ id: 'sub-1', externalSubscriptionId: null })
+
+    const res = await POST(createRequest({ immediate: false }))
+    expect(res.status).toBe(404)
+  })
+
+  // --- Soft cancel (cancelAtPeriodEnd) ---
+  test('soft cancels subscription (cancel at period end)', async () => {
+    authSuccess()
+    membershipAllowed()
+    mockSubscriptionGetActive.mockResolvedValue(activeSubscription)
+    mockBillingGateway.cancelSubscriptionAtPeriodEnd.mockResolvedValue(undefined)
+    mockQueryWithRLS.mockResolvedValue(undefined)
+
+    const res = await POST(createRequest({ immediate: false, reason: 'Too expensive' }))
+    const json = await res.json()
+    expect(res.status).toBe(200)
+    expect(json.success).toBe(true)
+    expect(json.data.cancelAtPeriodEnd).toBe(true)
+    expect(json.data.canceledAt).toBeNull()
+    expect(json.data.periodEnd).toBe('2025-12-31T23:59:59.000Z')
+
+    expect(mockBillingGateway.cancelSubscriptionAtPeriodEnd).toHaveBeenCalledWith('sub_stripe_abc')
+    expect(mockBillingGateway.cancelSubscriptionImmediately).not.toHaveBeenCalled()
+  })
+
+  // --- Hard cancel (immediate) ---
+  test('hard cancels subscription immediately', async () => {
+    authSuccess()
+    membershipAllowed()
+    mockSubscriptionGetActive.mockResolvedValue(activeSubscription)
+    mockBillingGateway.cancelSubscriptionImmediately.mockResolvedValue(undefined)
+    mockQueryWithRLS.mockResolvedValue(undefined)
+
+    const res = await POST(createRequest({ immediate: true }))
+    const json = await res.json()
+    expect(res.status).toBe(200)
+    expect(json.success).toBe(true)
+    expect(json.data.cancelAtPeriodEnd).toBe(false)
+    expect(json.data.canceledAt).toBeDefined()
+    expect(json.data.message).toMatch(/immediately/i)
+
+    expect(mockBillingGateway.cancelSubscriptionImmediately).toHaveBeenCalledWith('sub_stripe_abc')
+  })
+
+  // --- Reactivation ---
+  test('reactivates subscription scheduled for cancellation', async () => {
+    authSuccess()
+    membershipAllowed()
+    mockSubscriptionGetActive.mockResolvedValue({
+      ...activeSubscription,
+      cancelAtPeriodEnd: true,
+    })
+    mockBillingGateway.reactivateSubscription.mockResolvedValue(undefined)
+    mockQueryWithRLS.mockResolvedValue(undefined)
+
+    const res = await POST(createRequest({ action: 'reactivate' }))
+    const json = await res.json()
+    expect(res.status).toBe(200)
+    expect(json.success).toBe(true)
+    expect(json.data.reactivated).toBe(true)
+  })
+
+  test('returns 404 on reactivation if no active subscription', async () => {
+    authSuccess()
+    membershipAllowed()
+    mockSubscriptionGetActive.mockResolvedValue(null)
+
+    const res = await POST(createRequest({ action: 'reactivate' }))
+    expect(res.status).toBe(404)
+  })
+
+  test('returns 400 on reactivation if not scheduled for cancellation', async () => {
+    authSuccess()
+    membershipAllowed()
+    mockSubscriptionGetActive.mockResolvedValue({
+      ...activeSubscription,
+      cancelAtPeriodEnd: false,
+    })
+
+    const res = await POST(createRequest({ action: 'reactivate' }))
+    const json = await res.json()
+    expect(res.status).toBe(400)
+    expect(json.error).toMatch(/not scheduled for cancellation/i)
+  })
+
+  // --- Gateway error ---
+  test('returns 500 on gateway cancel error', async () => {
+    authSuccess()
+    membershipAllowed()
+    mockSubscriptionGetActive.mockResolvedValue(activeSubscription)
+    mockBillingGateway.cancelSubscriptionAtPeriodEnd.mockRejectedValue(new Error('Gateway timeout'))
+
+    const res = await POST(createRequest({ immediate: false }))
+    const json = await res.json()
+    expect(res.status).toBe(500)
+    expect(json.error).toMatch(/gateway timeout/i)
+  })
+
+  test('returns 500 on gateway reactivation error', async () => {
+    authSuccess()
+    membershipAllowed()
+    mockSubscriptionGetActive.mockResolvedValue({
+      ...activeSubscription,
+      cancelAtPeriodEnd: true,
+    })
+    mockBillingGateway.reactivateSubscription.mockRejectedValue(new Error('Stripe error'))
+
+    const res = await POST(createRequest({ action: 'reactivate' }))
+    const json = await res.json()
+    expect(res.status).toBe(500)
+    expect(json.error).toMatch(/stripe error/i)
+  })
+
+  // --- Default behavior (no immediate flag) ---
+  test('defaults to soft cancel when immediate is not specified', async () => {
+    authSuccess()
+    membershipAllowed()
+    mockSubscriptionGetActive.mockResolvedValue(activeSubscription)
+    mockBillingGateway.cancelSubscriptionAtPeriodEnd.mockResolvedValue(undefined)
+    mockQueryWithRLS.mockResolvedValue(undefined)
+
+    const res = await POST(createRequest({}))
+    const json = await res.json()
+    expect(res.status).toBe(200)
+    expect(json.data.cancelAtPeriodEnd).toBe(true)
+  })
+})

--- a/packages/core/tests/jest/api/billing/portal.test.ts
+++ b/packages/core/tests/jest/api/billing/portal.test.ts
@@ -1,0 +1,203 @@
+/**
+ * Billing Portal API Route Tests
+ *
+ * POST /api/v1/billing/portal
+ * Creates a billing portal session for self-service billing management.
+ */
+
+import { describe, test, expect, beforeEach, jest } from '@jest/globals'
+import { NextRequest, NextResponse } from 'next/server'
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+const mockAuthenticateRequest = jest.fn()
+const mockCreateAuthError = jest.fn(
+  (msg: string, status: number) => NextResponse.json({ success: false, error: msg }, { status })
+)
+jest.mock('@nextsparkjs/core/lib/api/auth/dual-auth', () => ({
+  authenticateRequest: (...args: any[]) => mockAuthenticateRequest(...args),
+  createAuthError: (...args: any[]) => mockCreateAuthError(...args),
+}))
+
+const mockMembershipGet = jest.fn()
+const mockSubscriptionGetActive = jest.fn()
+jest.mock('@nextsparkjs/core/lib/services', () => ({
+  MembershipService: { get: (...args: any[]) => mockMembershipGet(...args) },
+  SubscriptionService: { getActive: (...args: any[]) => mockSubscriptionGetActive(...args) },
+}))
+
+const mockBillingGateway = {
+  createPortalSession: jest.fn(),
+}
+jest.mock('@nextsparkjs/core/lib/billing/gateways/factory', () => ({
+  getBillingGateway: () => mockBillingGateway,
+}))
+
+jest.mock('@nextsparkjs/core/lib/api/rate-limit', () => ({
+  withRateLimitTier: (handler: any) => handler,
+}))
+
+import { POST } from '../../../../../../apps/dev/app/api/v1/billing/portal/route'
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function createRequest(headers: Record<string, string> = {}) {
+  return new NextRequest('http://localhost:3000/api/v1/billing/portal', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', ...headers },
+  }) as any
+}
+
+const fakeUser = { id: 'user-1', email: 'admin@test.com', defaultTeamId: 'team-1' }
+
+function authSuccess() {
+  mockAuthenticateRequest.mockResolvedValue({ success: true, user: fakeUser })
+}
+
+function membershipAllowed() {
+  mockMembershipGet.mockResolvedValue({
+    canPerformAction: () => ({ allowed: true }),
+  })
+}
+
+function membershipDenied(msg = 'Not allowed', reason = 'role') {
+  mockMembershipGet.mockResolvedValue({
+    canPerformAction: () => ({ allowed: false, message: msg, reason, meta: {} }),
+  })
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('POST /api/v1/billing/portal', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    process.env.NEXT_PUBLIC_APP_URL = 'http://localhost:5173'
+  })
+
+  // --- Auth ---
+  test('returns 401 if not authenticated', async () => {
+    mockAuthenticateRequest.mockResolvedValue({ success: false })
+    const res = await POST(createRequest())
+    expect(res.status).toBe(401)
+  })
+
+  // --- Team context ---
+  test('returns 400 if no team context', async () => {
+    mockAuthenticateRequest.mockResolvedValue({
+      success: true,
+      user: { ...fakeUser, defaultTeamId: null },
+    })
+    const res = await POST(createRequest())
+    const json = await res.json()
+    expect(res.status).toBe(400)
+    expect(json.error).toMatch(/team/i)
+  })
+
+  // --- Permission ---
+  test('returns 403 if permission denied', async () => {
+    authSuccess()
+    membershipDenied()
+    const res = await POST(createRequest())
+    const json = await res.json()
+    expect(res.status).toBe(403)
+    expect(json.reason).toBe('role')
+  })
+
+  // --- No subscription ---
+  test('returns 400 if no billing account (no subscription)', async () => {
+    authSuccess()
+    membershipAllowed()
+    mockSubscriptionGetActive.mockResolvedValue(null)
+
+    const res = await POST(createRequest())
+    const json = await res.json()
+    expect(res.status).toBe(400)
+    expect(json.error).toMatch(/no billing account/i)
+  })
+
+  test('returns 400 if subscription has no external customer ID', async () => {
+    authSuccess()
+    membershipAllowed()
+    mockSubscriptionGetActive.mockResolvedValue({
+      id: 'sub-1',
+      externalCustomerId: null,
+    })
+
+    const res = await POST(createRequest())
+    expect(res.status).toBe(400)
+  })
+
+  // --- Happy path ---
+  test('returns portal URL', async () => {
+    authSuccess()
+    membershipAllowed()
+    mockSubscriptionGetActive.mockResolvedValue({
+      id: 'sub-1',
+      externalCustomerId: 'cus_stripe_abc',
+    })
+    mockBillingGateway.createPortalSession.mockResolvedValue({
+      url: 'https://billing.stripe.com/session/abc',
+    })
+
+    const res = await POST(createRequest())
+    const json = await res.json()
+    expect(res.status).toBe(200)
+    expect(json.success).toBe(true)
+    expect(json.data.url).toBe('https://billing.stripe.com/session/abc')
+  })
+
+  test('passes correct customerId and returnUrl to gateway', async () => {
+    authSuccess()
+    membershipAllowed()
+    mockSubscriptionGetActive.mockResolvedValue({
+      id: 'sub-1',
+      externalCustomerId: 'cus_abc',
+    })
+    mockBillingGateway.createPortalSession.mockResolvedValue({ url: 'https://portal.url' })
+
+    await POST(createRequest())
+
+    expect(mockBillingGateway.createPortalSession).toHaveBeenCalledWith({
+      customerId: 'cus_abc',
+      returnUrl: 'http://localhost:5173/dashboard/settings/billing',
+    })
+  })
+
+  // --- Uses x-team-id header ---
+  test('uses x-team-id header for team context', async () => {
+    authSuccess()
+    membershipAllowed()
+    mockSubscriptionGetActive.mockResolvedValue({
+      id: 'sub-1',
+      externalCustomerId: 'cus_abc',
+    })
+    mockBillingGateway.createPortalSession.mockResolvedValue({ url: 'https://portal.url' })
+
+    await POST(createRequest({ 'x-team-id': 'team-override' }))
+
+    expect(mockMembershipGet).toHaveBeenCalledWith('user-1', 'team-override')
+    expect(mockSubscriptionGetActive).toHaveBeenCalledWith('team-override')
+  })
+
+  // --- Gateway error ---
+  test('returns 500 on gateway portal session error', async () => {
+    authSuccess()
+    membershipAllowed()
+    mockSubscriptionGetActive.mockResolvedValue({
+      id: 'sub-1',
+      externalCustomerId: 'cus_abc',
+    })
+    mockBillingGateway.createPortalSession.mockRejectedValue(new Error('Stripe down'))
+
+    const res = await POST(createRequest())
+    const json = await res.json()
+    expect(res.status).toBe(500)
+    expect(json.error).toMatch(/stripe down/i)
+  })
+})

--- a/packages/core/tests/jest/api/marketplace/account.test.ts
+++ b/packages/core/tests/jest/api/marketplace/account.test.ts
@@ -1,0 +1,207 @@
+/**
+ * Marketplace Account API Route Tests
+ *
+ * GET /api/v1/marketplace/account
+ * Retrieves the connected account status for the current team.
+ */
+
+import { describe, test, expect, beforeEach, jest } from '@jest/globals'
+import { NextRequest, NextResponse } from 'next/server'
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+const mockAuthenticateRequest = jest.fn()
+const mockCreateAuthError = jest.fn(
+  (msg: string, status: number) => NextResponse.json({ success: false, error: msg }, { status })
+)
+jest.mock('@nextsparkjs/core/lib/api/auth/dual-auth', () => ({
+  authenticateRequest: (...args: any[]) => mockAuthenticateRequest(...args),
+  createAuthError: (...args: any[]) => mockCreateAuthError(...args),
+}))
+
+const mockMembershipGet = jest.fn()
+jest.mock('@nextsparkjs/core/lib/services', () => ({
+  MembershipService: { get: (...args: any[]) => mockMembershipGet(...args) },
+}))
+
+const mockQueryOne = jest.fn()
+jest.mock('@nextsparkjs/core/lib/db', () => ({
+  queryOne: (...args: any[]) => mockQueryOne(...args),
+}))
+
+const mockGateway = {
+  createDashboardLink: jest.fn(),
+  getAccountBalance: jest.fn(),
+}
+jest.mock('@nextsparkjs/core/lib/marketplace', () => ({
+  getMarketplaceGateway: () => mockGateway,
+}))
+
+jest.mock('@nextsparkjs/core/lib/api/rate-limit', () => ({
+  withRateLimitTier: (handler: any) => handler,
+}))
+
+import { GET } from '../../../../../../apps/dev/app/api/v1/marketplace/account/route'
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function createRequest(headers: Record<string, string> = {}) {
+  return new NextRequest('http://localhost:3000/api/v1/marketplace/account', {
+    method: 'GET',
+    headers: { ...headers },
+  }) as any
+}
+
+const fakeUser = { id: 'user-1', email: 'test@test.com', defaultTeamId: 'team-1' }
+
+function authSuccess() {
+  mockAuthenticateRequest.mockResolvedValue({ success: true, user: fakeUser })
+}
+
+function membershipAllowed() {
+  mockMembershipGet.mockResolvedValue({
+    canPerformAction: () => ({ allowed: true }),
+  })
+}
+
+function membershipDenied(msg = 'Not allowed') {
+  mockMembershipGet.mockResolvedValue({
+    canPerformAction: () => ({ allowed: false, message: msg }),
+  })
+}
+
+const fullAccount = {
+  id: 'acct-1',
+  provider: 'stripe_connect',
+  externalAccountId: 'acct_stripe_789',
+  email: 'biz@test.com',
+  businessName: 'My Business',
+  country: 'US',
+  currency: 'usd',
+  onboardingStatus: 'active',
+  chargesEnabled: true,
+  payoutsEnabled: true,
+  commissionRate: 0.15,
+  fixedFee: 0,
+  payoutSchedule: 'daily',
+  createdAt: '2025-01-01T00:00:00Z',
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('GET /api/v1/marketplace/account', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  // --- Auth ---
+  test('returns 401 if not authenticated', async () => {
+    mockAuthenticateRequest.mockResolvedValue({ success: false })
+    const res = await GET(createRequest())
+    expect(res.status).toBe(401)
+  })
+
+  // --- Team context ---
+  test('returns 400 if no team context', async () => {
+    mockAuthenticateRequest.mockResolvedValue({
+      success: true,
+      user: { ...fakeUser, defaultTeamId: null },
+    })
+    const res = await GET(createRequest())
+    expect(res.status).toBe(400)
+  })
+
+  // --- Permission ---
+  test('returns 403 if permission denied', async () => {
+    authSuccess()
+    membershipDenied()
+    const res = await GET(createRequest())
+    expect(res.status).toBe(403)
+  })
+
+  // --- No account ---
+  test('returns connected:false if no account found', async () => {
+    authSuccess()
+    membershipAllowed()
+    mockQueryOne.mockResolvedValue(null)
+
+    const res = await GET(createRequest())
+    const json = await res.json()
+    expect(res.status).toBe(200)
+    expect(json.success).toBe(true)
+    expect(json.data.connected).toBe(false)
+    expect(json.data.account).toBeNull()
+  })
+
+  // --- Account with charges disabled ---
+  test('returns account data without dashboard/balance when charges not enabled', async () => {
+    authSuccess()
+    membershipAllowed()
+    mockQueryOne.mockResolvedValue({ ...fullAccount, chargesEnabled: false })
+
+    const res = await GET(createRequest())
+    const json = await res.json()
+    expect(res.status).toBe(200)
+    expect(json.data.connected).toBe(true)
+    expect(json.data.account.dashboardUrl).toBeNull()
+    expect(json.data.account.balance).toBeNull()
+    expect(mockGateway.createDashboardLink).not.toHaveBeenCalled()
+  })
+
+  // --- Happy path with full data ---
+  test('returns full account data with dashboard URL and balance', async () => {
+    authSuccess()
+    membershipAllowed()
+    mockQueryOne.mockResolvedValue(fullAccount)
+    mockGateway.createDashboardLink.mockResolvedValue({ url: 'https://dashboard.stripe.com/login' })
+    mockGateway.getAccountBalance.mockResolvedValue({ available: 50000, pending: 12000 })
+
+    const res = await GET(createRequest())
+    const json = await res.json()
+    expect(res.status).toBe(200)
+    expect(json.success).toBe(true)
+    expect(json.data.connected).toBe(true)
+    expect(json.data.account.id).toBe('acct-1')
+    expect(json.data.account.dashboardUrl).toBe('https://dashboard.stripe.com/login')
+    expect(json.data.account.balance).toEqual({ available: 50000, pending: 12000 })
+    expect(json.data.account.commissionRate).toBe(0.15)
+  })
+
+  // --- Provider data fetch error (graceful degradation) ---
+  test('returns account data even if provider calls fail', async () => {
+    authSuccess()
+    membershipAllowed()
+    mockQueryOne.mockResolvedValue(fullAccount)
+    mockGateway.createDashboardLink.mockRejectedValue(new Error('Stripe timeout'))
+    mockGateway.getAccountBalance.mockRejectedValue(new Error('Stripe timeout'))
+
+    const res = await GET(createRequest())
+    const json = await res.json()
+    expect(res.status).toBe(200)
+    expect(json.data.connected).toBe(true)
+    // Dashboard and balance should be null due to error
+    expect(json.data.account.dashboardUrl).toBeNull()
+    expect(json.data.account.balance).toBeNull()
+  })
+
+  // --- Uses x-team-id header ---
+  test('uses x-team-id header for team context', async () => {
+    authSuccess()
+    membershipAllowed()
+    mockQueryOne.mockResolvedValue(null)
+
+    await GET(createRequest({ 'x-team-id': 'team-override' }))
+
+    expect(mockMembershipGet).toHaveBeenCalledWith('user-1', 'team-override')
+    expect(mockQueryOne).toHaveBeenCalledWith(
+      expect.any(String),
+      ['team-override']
+    )
+  })
+})

--- a/packages/core/tests/jest/api/marketplace/checkout.test.ts
+++ b/packages/core/tests/jest/api/marketplace/checkout.test.ts
@@ -1,0 +1,215 @@
+/**
+ * Marketplace Checkout API Route Tests
+ *
+ * POST /api/v1/marketplace/checkout
+ * Creates a checkout session for a marketplace payment.
+ */
+
+import { describe, test, expect, beforeEach, jest } from '@jest/globals'
+import { NextRequest, NextResponse } from 'next/server'
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+const mockAuthenticateRequest = jest.fn()
+const mockCreateAuthError = jest.fn(
+  (msg: string, status: number) => NextResponse.json({ success: false, error: msg }, { status })
+)
+jest.mock('@nextsparkjs/core/lib/api/auth/dual-auth', () => ({
+  authenticateRequest: (...args: any[]) => mockAuthenticateRequest(...args),
+  createAuthError: (...args: any[]) => mockCreateAuthError(...args),
+}))
+
+const mockQuery = jest.fn()
+const mockQueryOne = jest.fn()
+jest.mock('@nextsparkjs/core/lib/db', () => ({
+  query: (...args: any[]) => mockQuery(...args),
+  queryOne: (...args: any[]) => mockQueryOne(...args),
+}))
+
+const mockGateway = {
+  provider: 'stripe_connect',
+  createMarketplaceCheckout: jest.fn(),
+}
+const mockCalculateFee = jest.fn((amount: number) => Math.round(amount * 0.15))
+jest.mock('@nextsparkjs/core/lib/marketplace', () => ({
+  getMarketplaceGateway: () => mockGateway,
+  calculateFee: (...args: any[]) => mockCalculateFee(...args),
+}))
+
+jest.mock('@nextsparkjs/core/lib/api/rate-limit', () => ({
+  withRateLimitTier: (handler: any) => handler,
+}))
+
+import { POST } from '../../../../../../apps/dev/app/api/v1/marketplace/checkout/route'
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function createRequest(body?: any) {
+  return new NextRequest('http://localhost:3000/api/v1/marketplace/checkout', {
+    method: 'POST',
+    body: body !== undefined ? JSON.stringify(body) : undefined,
+    headers: { 'Content-Type': 'application/json' },
+  }) as any
+}
+
+const fakeUser = { id: 'user-1', email: 'buyer@test.com', defaultTeamId: 'team-1' }
+
+function authSuccess() {
+  mockAuthenticateRequest.mockResolvedValue({ success: true, user: fakeUser })
+}
+
+const validBody = {
+  connectedAccountId: 'acct-1',
+  amount: 10000,
+  currency: 'usd',
+  referenceId: 'booking-123',
+  referenceType: 'booking',
+  description: 'Booking for service',
+}
+
+const connectedAccount = {
+  id: 'acct-1',
+  teamId: 'team-seller',
+  externalAccountId: 'acct_stripe_456',
+  commissionRate: 0.15,
+  fixedFee: 0,
+  chargesEnabled: true,
+  onboardingStatus: 'active',
+  provider: 'stripe_connect',
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('POST /api/v1/marketplace/checkout', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    process.env.NEXT_PUBLIC_APP_URL = 'http://localhost:5173'
+  })
+
+  // --- Auth ---
+  test('returns 401 if not authenticated', async () => {
+    mockAuthenticateRequest.mockResolvedValue({ success: false })
+    const res = await POST(createRequest(validBody))
+    expect(res.status).toBe(401)
+  })
+
+  // --- Validation ---
+  test('returns 400 for invalid JSON body', async () => {
+    authSuccess()
+    const req = new NextRequest('http://localhost:3000/api/v1/marketplace/checkout', {
+      method: 'POST',
+      body: '{bad',
+      headers: { 'Content-Type': 'application/json' },
+    }) as any
+    const res = await POST(req)
+    expect(res.status).toBe(400)
+    const json = await res.json()
+    expect(json.error).toMatch(/invalid json/i)
+  })
+
+  test('returns 400 for missing required fields', async () => {
+    authSuccess()
+    const res = await POST(createRequest({ amount: 100 }))
+    const json = await res.json()
+    expect(res.status).toBe(400)
+    expect(json.error).toMatch(/validation/i)
+  })
+
+  test('returns 400 for negative amount', async () => {
+    authSuccess()
+    const res = await POST(createRequest({ ...validBody, amount: -100 }))
+    expect(res.status).toBe(400)
+  })
+
+  // --- 404: account not found ---
+  test('returns 404 if connected account not found', async () => {
+    authSuccess()
+    mockQueryOne.mockResolvedValue(null)
+    const res = await POST(createRequest(validBody))
+    const json = await res.json()
+    expect(res.status).toBe(404)
+    expect(json.error).toMatch(/not found/i)
+  })
+
+  // --- 400: charges not enabled ---
+  test('returns 400 if charges not enabled on account', async () => {
+    authSuccess()
+    mockQueryOne.mockResolvedValue({ ...connectedAccount, chargesEnabled: false })
+    const res = await POST(createRequest(validBody))
+    const json = await res.json()
+    expect(res.status).toBe(400)
+    expect(json.error).toMatch(/cannot accept payments/i)
+  })
+
+  // --- Happy path ---
+  test('creates checkout session and returns URL with fee breakdown', async () => {
+    authSuccess()
+    mockQueryOne.mockResolvedValue(connectedAccount)
+    mockCalculateFee.mockReturnValue(1500)
+    mockGateway.createMarketplaceCheckout.mockResolvedValue({
+      id: 'pi_abc123',
+      url: 'https://checkout.stripe.com/session',
+    })
+    mockQuery.mockResolvedValue(undefined) // INSERT payment record
+
+    const res = await POST(createRequest(validBody))
+    const json = await res.json()
+    expect(res.status).toBe(200)
+    expect(json.success).toBe(true)
+    expect(json.data.url).toBe('https://checkout.stripe.com/session')
+    expect(json.data.paymentId).toBe('pi_abc123')
+    expect(json.data.amount).toBe(10000)
+    expect(json.data.applicationFee).toBe(1500)
+    expect(json.data.businessAmount).toBe(8500)
+    expect(json.data.currency).toBe('usd')
+  })
+
+  test('calculates commission correctly', async () => {
+    authSuccess()
+    mockQueryOne.mockResolvedValue(connectedAccount)
+    mockCalculateFee.mockReturnValue(1500)
+    mockGateway.createMarketplaceCheckout.mockResolvedValue({ id: 'pi_1', url: 'https://example.com' })
+    mockQuery.mockResolvedValue(undefined)
+
+    await POST(createRequest(validBody))
+
+    expect(mockCalculateFee).toHaveBeenCalledWith(
+      10000,
+      expect.objectContaining({ rate: 0.15 })
+    )
+  })
+
+  test('records payment in database', async () => {
+    authSuccess()
+    mockQueryOne.mockResolvedValue(connectedAccount)
+    mockCalculateFee.mockReturnValue(1500)
+    mockGateway.createMarketplaceCheckout.mockResolvedValue({ id: 'pi_1', url: 'https://example.com' })
+    mockQuery.mockResolvedValue(undefined)
+
+    await POST(createRequest(validBody))
+
+    expect(mockQuery).toHaveBeenCalledWith(
+      expect.stringContaining('INSERT INTO "marketplacePayments"'),
+      expect.arrayContaining(['acct-1', 'team-seller', 'booking-123'])
+    )
+  })
+
+  // --- 500: gateway error ---
+  test('returns 500 on gateway checkout error', async () => {
+    authSuccess()
+    mockQueryOne.mockResolvedValue(connectedAccount)
+    mockCalculateFee.mockReturnValue(1500)
+    mockGateway.createMarketplaceCheckout.mockRejectedValue(new Error('Stripe error'))
+
+    const res = await POST(createRequest(validBody))
+    const json = await res.json()
+    expect(res.status).toBe(500)
+    expect(json.error).toMatch(/stripe error/i)
+  })
+})

--- a/packages/core/tests/jest/api/marketplace/connect.test.ts
+++ b/packages/core/tests/jest/api/marketplace/connect.test.ts
@@ -1,0 +1,242 @@
+/**
+ * Marketplace Connect API Route Tests
+ *
+ * POST /api/v1/marketplace/connect
+ * Creates a connected account and returns an onboarding link.
+ */
+
+import { describe, test, expect, beforeEach, jest } from '@jest/globals'
+import { NextRequest, NextResponse } from 'next/server'
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+const mockAuthenticateRequest = jest.fn()
+const mockCreateAuthError = jest.fn(
+  (msg: string, status: number) => NextResponse.json({ success: false, error: msg }, { status })
+)
+jest.mock('@nextsparkjs/core/lib/api/auth/dual-auth', () => ({
+  authenticateRequest: (...args: any[]) => mockAuthenticateRequest(...args),
+  createAuthError: (...args: any[]) => mockCreateAuthError(...args),
+}))
+
+const mockMembershipGet = jest.fn()
+jest.mock('@nextsparkjs/core/lib/services', () => ({
+  MembershipService: { get: (...args: any[]) => mockMembershipGet(...args) },
+}))
+
+const mockQuery = jest.fn()
+const mockQueryOne = jest.fn()
+jest.mock('@nextsparkjs/core/lib/db', () => ({
+  query: (...args: any[]) => mockQuery(...args),
+  queryOne: (...args: any[]) => mockQueryOne(...args),
+}))
+
+const mockGateway = {
+  provider: 'stripe_connect',
+  createConnectedAccount: jest.fn(),
+  createOnboardingLink: jest.fn(),
+}
+jest.mock('@nextsparkjs/core/lib/marketplace', () => ({
+  getMarketplaceGateway: () => mockGateway,
+}))
+
+jest.mock('@nextsparkjs/core/lib/api/rate-limit', () => ({
+  withRateLimitTier: (handler: any) => handler,
+}))
+
+// Must import AFTER mocks
+import { POST } from '../../../../../../apps/dev/app/api/v1/marketplace/connect/route'
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function createRequest(body?: any, headers: Record<string, string> = {}) {
+  return new NextRequest('http://localhost:3000/api/v1/marketplace/connect', {
+    method: 'POST',
+    body: body !== undefined ? JSON.stringify(body) : undefined,
+    headers: { 'Content-Type': 'application/json', ...headers },
+  }) as any
+}
+
+const fakeUser = { id: 'user-1', email: 'test@test.com', defaultTeamId: 'team-1' }
+
+function authSuccess() {
+  mockAuthenticateRequest.mockResolvedValue({ success: true, user: fakeUser })
+}
+
+function membershipAllowed() {
+  mockMembershipGet.mockResolvedValue({
+    canPerformAction: () => ({ allowed: true }),
+  })
+}
+
+function membershipDenied(msg = 'Not allowed', reason = 'role') {
+  mockMembershipGet.mockResolvedValue({
+    canPerformAction: () => ({ allowed: false, message: msg, reason }),
+  })
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('POST /api/v1/marketplace/connect', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    process.env.NEXT_PUBLIC_APP_URL = 'http://localhost:5173'
+  })
+
+  // --- Auth ---
+  test('returns 401 if not authenticated', async () => {
+    mockAuthenticateRequest.mockResolvedValue({ success: false })
+    const res = await POST(createRequest({ country: 'US' }))
+    expect(res.status).toBe(401)
+  })
+
+  // --- Team context ---
+  test('returns 400 if no team context', async () => {
+    mockAuthenticateRequest.mockResolvedValue({
+      success: true,
+      user: { ...fakeUser, defaultTeamId: null },
+    })
+    const res = await POST(createRequest({ country: 'US' }))
+    const json = await res.json()
+    expect(res.status).toBe(400)
+    expect(json.error).toMatch(/team/i)
+  })
+
+  // --- Permission ---
+  test('returns 403 if permission denied', async () => {
+    authSuccess()
+    membershipDenied()
+    const res = await POST(createRequest({ country: 'US' }))
+    expect(res.status).toBe(403)
+  })
+
+  // --- Validation ---
+  test('returns 400 for invalid body (missing country)', async () => {
+    authSuccess()
+    membershipAllowed()
+    mockQueryOne.mockResolvedValue(null) // no existing account
+    const res = await POST(createRequest({}))
+    const json = await res.json()
+    expect(res.status).toBe(400)
+    expect(json.error).toMatch(/validation/i)
+  })
+
+  test('returns 400 for invalid country code', async () => {
+    authSuccess()
+    membershipAllowed()
+    const res = await POST(createRequest({ country: 'USA' }))
+    const json = await res.json()
+    expect(res.status).toBe(400)
+    expect(json.details).toBeDefined()
+  })
+
+  test('returns 400 for invalid JSON body', async () => {
+    authSuccess()
+    membershipAllowed()
+    // Create a request whose .json() throws
+    const req = new NextRequest('http://localhost:3000/api/v1/marketplace/connect', {
+      method: 'POST',
+      body: 'not-json',
+      headers: { 'Content-Type': 'application/json' },
+    }) as any
+    const res = await POST(req)
+    const json = await res.json()
+    expect(res.status).toBe(400)
+    expect(json.error).toMatch(/invalid json/i)
+  })
+
+  // --- 409: already active ---
+  test('returns 409 if team already has active account', async () => {
+    authSuccess()
+    membershipAllowed()
+    mockQueryOne.mockResolvedValue({
+      id: 'acct-1',
+      onboardingStatus: 'active',
+      externalAccountId: 'ext-1',
+    })
+
+    const res = await POST(createRequest({ country: 'US' }))
+    const json = await res.json()
+    expect(res.status).toBe(409)
+    expect(json.error).toMatch(/already has an active/i)
+  })
+
+  // --- Resume onboarding ---
+  test('resumes onboarding if account exists but incomplete', async () => {
+    authSuccess()
+    membershipAllowed()
+    mockQueryOne.mockResolvedValue({
+      id: 'acct-1',
+      onboardingStatus: 'pending',
+      externalAccountId: 'ext-1',
+    })
+    mockQuery.mockResolvedValue(undefined)
+    mockGateway.createOnboardingLink.mockResolvedValue({ url: 'https://onboarding.example.com' })
+
+    const res = await POST(createRequest({ country: 'US' }))
+    const json = await res.json()
+    expect(res.status).toBe(200)
+    expect(json.success).toBe(true)
+    expect(json.data.isResuming).toBe(true)
+    expect(json.data.onboardingUrl).toBe('https://onboarding.example.com')
+  })
+
+  test('returns 500 if resume onboarding link fails', async () => {
+    authSuccess()
+    membershipAllowed()
+    mockQueryOne.mockResolvedValue({
+      id: 'acct-1',
+      onboardingStatus: 'pending',
+      externalAccountId: 'ext-1',
+    })
+    mockQuery.mockResolvedValue(undefined)
+    mockGateway.createOnboardingLink.mockRejectedValue(new Error('Gateway error'))
+
+    const res = await POST(createRequest({ country: 'US' }))
+    expect(res.status).toBe(500)
+  })
+
+  // --- Happy path: new account ---
+  test('creates new connected account and returns onboarding URL', async () => {
+    authSuccess()
+    membershipAllowed()
+    mockQueryOne
+      .mockResolvedValueOnce(null) // no existing account
+      .mockResolvedValueOnce({ id: 'new-acct-1' }) // INSERT RETURNING
+    mockGateway.createConnectedAccount.mockResolvedValue({
+      id: 'acct_stripe_123',
+      email: 'test@test.com',
+      onboardingStatus: 'pending',
+      chargesEnabled: false,
+      payoutsEnabled: false,
+    })
+    mockGateway.createOnboardingLink.mockResolvedValue({ url: 'https://stripe.com/onboard' })
+
+    const res = await POST(createRequest({ country: 'US', businessName: 'My Biz' }))
+    const json = await res.json()
+    expect(res.status).toBe(200)
+    expect(json.success).toBe(true)
+    expect(json.data.onboardingUrl).toBe('https://stripe.com/onboard')
+    expect(json.data.accountId).toBe('new-acct-1')
+    expect(json.data.externalAccountId).toBe('acct_stripe_123')
+  })
+
+  // --- 500: gateway error on creation ---
+  test('returns 500 on gateway error during account creation', async () => {
+    authSuccess()
+    membershipAllowed()
+    mockQueryOne.mockResolvedValue(null)
+    mockGateway.createConnectedAccount.mockRejectedValue(new Error('Stripe down'))
+
+    const res = await POST(createRequest({ country: 'US' }))
+    const json = await res.json()
+    expect(res.status).toBe(500)
+    expect(json.error).toMatch(/stripe down/i)
+  })
+})

--- a/packages/core/tests/jest/api/marketplace/oauth-callback.test.ts
+++ b/packages/core/tests/jest/api/marketplace/oauth-callback.test.ts
@@ -1,0 +1,234 @@
+/**
+ * Marketplace OAuth Callback API Route Tests
+ *
+ * GET /api/v1/marketplace/oauth/callback?code=xxx&state=<token>
+ * Handles OAuth callback from MercadoPago, exchanges code for tokens.
+ */
+
+import { describe, test, expect, beforeEach, jest } from '@jest/globals'
+import { NextResponse } from 'next/server'
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+const mockAuthenticateRequest = jest.fn()
+const mockCreateAuthError = jest.fn(
+  (msg: string, status: number) => NextResponse.json({ success: false, error: msg }, { status })
+)
+jest.mock('@nextsparkjs/core/lib/api/auth/dual-auth', () => ({
+  authenticateRequest: (...args: any[]) => mockAuthenticateRequest(...args),
+  createAuthError: (...args: any[]) => mockCreateAuthError(...args),
+}))
+
+const mockMembershipGet = jest.fn()
+jest.mock('@nextsparkjs/core/lib/services', () => ({
+  MembershipService: { get: (...args: any[]) => mockMembershipGet(...args) },
+}))
+
+const mockQuery = jest.fn()
+const mockQueryOne = jest.fn()
+jest.mock('@nextsparkjs/core/lib/db', () => ({
+  query: (...args: any[]) => mockQuery(...args),
+  queryOne: (...args: any[]) => mockQueryOne(...args),
+}))
+
+const mockExchangeMPAuthorizationCode = jest.fn()
+jest.mock('@nextsparkjs/core/lib/marketplace', () => ({
+  exchangeMPAuthorizationCode: (...args: any[]) => mockExchangeMPAuthorizationCode(...args),
+}))
+
+const mockEncryptTokens = jest.fn((tokens: any) => ({
+  accessToken: 'enc_' + tokens.accessToken,
+  refreshToken: 'enc_' + tokens.refreshToken,
+  expiresAt: tokens.expiresAt,
+  publicKey: tokens.publicKey,
+}))
+jest.mock('@nextsparkjs/core/lib/marketplace/token-encryption', () => ({
+  encryptTokens: (...args: any[]) => mockEncryptTokens(...args),
+}))
+
+jest.mock('@nextsparkjs/core/lib/api/rate-limit', () => ({
+  withRateLimitTier: (handler: any) => handler,
+}))
+
+import { GET } from '../../../../../../apps/dev/app/api/v1/marketplace/oauth/callback/route'
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+// The oauth/callback route uses request.nextUrl.searchParams, which the mock
+// NextRequest doesn't support. We build a minimal compatible request object.
+function createOAuthRequest(params: Record<string, string> = {}, headers: Record<string, string> = {}) {
+  const url = new URL('http://localhost:3000/api/v1/marketplace/oauth/callback')
+  for (const [k, v] of Object.entries(params)) {
+    url.searchParams.set(k, v)
+  }
+
+  return {
+    url: url.toString(),
+    method: 'GET',
+    headers: new Map(Object.entries(headers)),
+    nextUrl: url,
+  } as any
+}
+
+const fakeUser = { id: 'user-1', email: 'test@test.com', defaultTeamId: 'team-1' }
+const appUrl = 'http://localhost:5173'
+
+function authSuccess() {
+  mockAuthenticateRequest.mockResolvedValue({ success: true, user: fakeUser })
+}
+
+function membershipAllowed() {
+  mockMembershipGet.mockResolvedValue({
+    canPerformAction: () => ({ allowed: true }),
+  })
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+// Patch NextResponse.redirect since the mock doesn't include it
+const originalRedirect = (NextResponse as any).redirect
+beforeAll(() => {
+  ;(NextResponse as any).redirect = (url: string | URL) => {
+    const urlStr = typeof url === 'string' ? url : url.toString()
+    const resp = NextResponse.json({ _redirect: urlStr }, { status: 302 })
+    ;(resp as any)._redirectUrl = urlStr
+    return resp
+  }
+})
+
+afterAll(() => {
+  if (originalRedirect) {
+    ;(NextResponse as any).redirect = originalRedirect
+  } else {
+    delete (NextResponse as any).redirect
+  }
+})
+
+describe('GET /api/v1/marketplace/oauth/callback', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    process.env.NEXT_PUBLIC_APP_URL = appUrl
+  })
+
+  // --- Missing code ---
+  test('redirects with error=no_code if no code param', async () => {
+    const res = await GET(createOAuthRequest({ state: 'some-token' }))
+    const url = (res as any)._redirectUrl || ''
+    expect(url).toContain('error=no_code')
+  })
+
+  // --- Missing state ---
+  test('redirects with error=no_state if no state param', async () => {
+    const res = await GET(createOAuthRequest({ code: 'auth-code-123' }))
+    const url = (res as any)._redirectUrl || ''
+    expect(url).toContain('error=no_state')
+  })
+
+  // --- Auth failure ---
+  test('returns 401 if not authenticated', async () => {
+    mockAuthenticateRequest.mockResolvedValue({ success: false })
+    const res = await GET(createOAuthRequest({ code: 'abc', state: 'tok-1' }))
+    expect(res.status).toBe(401)
+  })
+
+  // --- Invalid state token (no matching account) ---
+  test('redirects with error=invalid_state if state token not found in DB', async () => {
+    authSuccess()
+    mockQueryOne.mockResolvedValue(null)
+
+    const res = await GET(createOAuthRequest({ code: 'abc', state: 'bad-token' }))
+    const url = (res as any)._redirectUrl || ''
+    expect(url).toContain('error=invalid_state')
+  })
+
+  // --- User not authorized for team ---
+  test('redirects with error=unauthorized if user cannot perform action', async () => {
+    authSuccess()
+    mockQueryOne.mockResolvedValue({ id: 'acct-1', teamId: 'team-seller' })
+    mockMembershipGet.mockResolvedValue({
+      canPerformAction: () => ({ allowed: false, message: 'No access' }),
+    })
+
+    const res = await GET(createOAuthRequest({ code: 'abc', state: 'valid-token' }))
+    const url = (res as any)._redirectUrl || ''
+    expect(url).toContain('error=unauthorized')
+  })
+
+  test('redirects with error=unauthorized if membership check throws', async () => {
+    authSuccess()
+    mockQueryOne.mockResolvedValue({ id: 'acct-1', teamId: 'team-seller' })
+    mockMembershipGet.mockRejectedValue(new Error('No membership'))
+
+    const res = await GET(createOAuthRequest({ code: 'abc', state: 'valid-token' }))
+    const url = (res as any)._redirectUrl || ''
+    expect(url).toContain('error=unauthorized')
+  })
+
+  // --- Happy path ---
+  test('exchanges code, encrypts tokens, updates DB, redirects to success', async () => {
+    authSuccess()
+    mockQueryOne.mockResolvedValue({ id: 'acct-1', teamId: 'team-seller' })
+    membershipAllowed()
+
+    mockExchangeMPAuthorizationCode.mockResolvedValue({
+      accessToken: 'mp_access_token',
+      refreshToken: 'mp_refresh_token',
+      expiresIn: 21600,
+      userId: 12345678,
+      publicKey: 'APP_USR-pubkey',
+    })
+
+    mockEncryptTokens.mockReturnValue({
+      accessToken: 'encrypted_access',
+      refreshToken: 'encrypted_refresh',
+      expiresAt: '2025-12-31T00:00:00Z',
+      publicKey: 'APP_USR-pubkey',
+    })
+
+    mockQuery.mockResolvedValue(undefined)
+
+    const res = await GET(createOAuthRequest({ code: 'real-code', state: 'valid-state' }))
+    const url = (res as any)._redirectUrl || ''
+
+    // Should redirect to success
+    expect(url).toContain('onboarding=complete')
+
+    // Should have called exchange
+    expect(mockExchangeMPAuthorizationCode).toHaveBeenCalledWith(
+      'real-code',
+      expect.stringContaining('/api/v1/marketplace/oauth/callback')
+    )
+
+    // Should have encrypted tokens
+    expect(mockEncryptTokens).toHaveBeenCalledWith(
+      expect.objectContaining({
+        accessToken: 'mp_access_token',
+        refreshToken: 'mp_refresh_token',
+      })
+    )
+
+    // Should have updated DB with account ID and tokens
+    expect(mockQuery).toHaveBeenCalledWith(
+      expect.stringContaining('UPDATE "connectedAccounts"'),
+      expect.arrayContaining(['12345678', expect.any(String), 'acct-1'])
+    )
+  })
+
+  // --- OAuth exchange failure ---
+  test('redirects with error=oauth_failed if token exchange fails', async () => {
+    authSuccess()
+    mockQueryOne.mockResolvedValue({ id: 'acct-1', teamId: 'team-seller' })
+    membershipAllowed()
+    mockExchangeMPAuthorizationCode.mockRejectedValue(new Error('MP down'))
+
+    const res = await GET(createOAuthRequest({ code: 'bad-code', state: 'valid-state' }))
+    const url = (res as any)._redirectUrl || ''
+    expect(url).toContain('error=oauth_failed')
+  })
+})

--- a/packages/core/tests/jest/lib/api/rate-limit.test.ts
+++ b/packages/core/tests/jest/lib/api/rate-limit.test.ts
@@ -1,0 +1,521 @@
+/**
+ * Tests for Rate Limiting System
+ *
+ * Tests the in-memory rate limiting, distributed rate limit fallback,
+ * webhook tier configuration, getClientIp (via withRateLimitTier), and
+ * rate limit utility functions.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, jest } from '@jest/globals'
+import { NextRequest, NextResponse } from 'next/server'
+import {
+  checkRateLimit,
+  clearRateLimit,
+  checkDistributedRateLimit,
+  withRateLimitTier,
+  createRateLimitErrorResponse,
+  isDistributedRateLimitAvailable,
+  getRateLimitStats,
+  getRateLimitCacheStats,
+  type RateLimitResult,
+} from '@/core/lib/api/rate-limit'
+
+// Ensure Redis is NOT configured so we always exercise the in-memory fallback path
+const originalEnv = { ...process.env }
+
+beforeEach(() => {
+  delete process.env.UPSTASH_REDIS_REST_URL
+  delete process.env.UPSTASH_REDIS_REST_TOKEN
+  delete process.env.DISABLE_RATE_LIMITING
+})
+
+afterEach(() => {
+  // Clean up any rate limit entries created during tests
+  clearRateLimit('test-id')
+  clearRateLimit('api:ip:1.2.3.4')
+  clearRateLimit('webhook:ip:10.0.0.1')
+  clearRateLimit('read:ip:10.0.0.1')
+  clearRateLimit('write:ip:10.0.0.1')
+  clearRateLimit('auth:ip:10.0.0.1')
+  clearRateLimit('strict:ip:10.0.0.1')
+  clearRateLimit('api:ip:10.0.0.1')
+  clearRateLimit('api:apikey:sk_test_12345678')
+  clearRateLimit('webhook:ip:192.168.1.1')
+  clearRateLimit('webhook:ip:unknown')
+  clearRateLimit('api:ip:unknown')
+  clearRateLimit('api:ip:203.0.113.50')
+  clearRateLimit('api:ip:198.51.100.1')
+  clearRateLimit('api:ip:100.200.300.400')
+  clearRateLimit('burst-test')
+  clearRateLimit('window-test')
+  // Restore env
+  process.env = { ...originalEnv }
+})
+
+// ---------------------------------------------------------------------------
+// checkRateLimit (in-memory)
+// ---------------------------------------------------------------------------
+
+describe('checkRateLimit (in-memory)', () => {
+  it('should allow the first request', () => {
+    const result = checkRateLimit('test-id', 10, 60000)
+
+    expect(result.allowed).toBe(true)
+    expect(result.remaining).toBe(9)
+    expect(result.limit).toBe(10)
+    expect(result.resetTime).toBeGreaterThan(Date.now() - 1000)
+  })
+
+  it('should track count across consecutive calls', () => {
+    const r1 = checkRateLimit('test-id', 5, 60000)
+    const r2 = checkRateLimit('test-id', 5, 60000)
+    const r3 = checkRateLimit('test-id', 5, 60000)
+
+    expect(r1.remaining).toBe(4)
+    expect(r2.remaining).toBe(3)
+    expect(r3.remaining).toBe(2)
+  })
+
+  it('should block requests when limit is exceeded', () => {
+    const limit = 3
+
+    checkRateLimit('test-id', limit, 60000) // 1
+    checkRateLimit('test-id', limit, 60000) // 2
+    checkRateLimit('test-id', limit, 60000) // 3 - at limit
+
+    const blocked = checkRateLimit('test-id', limit, 60000) // 4 - over limit
+
+    expect(blocked.allowed).toBe(false)
+    expect(blocked.remaining).toBe(0)
+  })
+
+  it('should return correct remaining count at each step', () => {
+    const limit = 5
+
+    for (let i = 0; i < limit; i++) {
+      const r = checkRateLimit('test-id', limit, 60000)
+      expect(r.remaining).toBe(limit - 1 - i)
+      expect(r.allowed).toBe(true)
+    }
+
+    // One more should be blocked
+    const blocked = checkRateLimit('test-id', limit, 60000)
+    expect(blocked.allowed).toBe(false)
+    expect(blocked.remaining).toBe(0)
+  })
+
+  it('should use default limit and window when not specified', () => {
+    const result = checkRateLimit('test-id')
+
+    expect(result.allowed).toBe(true)
+    // Default limit is 1000 per the function signature
+    expect(result.remaining).toBe(999)
+    expect(result.limit).toBe(1000)
+  })
+
+  it('should maintain separate counters for different identifiers', () => {
+    checkRateLimit('id-a', 2, 60000)
+    checkRateLimit('id-a', 2, 60000)
+    const blockedA = checkRateLimit('id-a', 2, 60000)
+
+    const allowedB = checkRateLimit('id-b', 2, 60000)
+
+    expect(blockedA.allowed).toBe(false)
+    expect(allowedB.allowed).toBe(true)
+    expect(allowedB.remaining).toBe(1)
+
+    // Clean up extra identifiers
+    clearRateLimit('id-a')
+    clearRateLimit('id-b')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// clearRateLimit
+// ---------------------------------------------------------------------------
+
+describe('clearRateLimit', () => {
+  it('should reset the counter so subsequent requests are allowed', () => {
+    const limit = 2
+    checkRateLimit('test-id', limit, 60000)
+    checkRateLimit('test-id', limit, 60000)
+
+    // Should be blocked now
+    expect(checkRateLimit('test-id', limit, 60000).allowed).toBe(false)
+
+    // Clear and retry
+    clearRateLimit('test-id')
+
+    const afterClear = checkRateLimit('test-id', limit, 60000)
+    expect(afterClear.allowed).toBe(true)
+    expect(afterClear.remaining).toBe(1)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// checkDistributedRateLimit (fallback to in-memory)
+// ---------------------------------------------------------------------------
+
+describe('checkDistributedRateLimit (in-memory fallback)', () => {
+  it('should allow first request and return correct shape', async () => {
+    const result = await checkDistributedRateLimit('api:ip:1.2.3.4', 'api')
+
+    expect(result.allowed).toBe(true)
+    expect(result.remaining).toBeLessThanOrEqual(100)
+    expect(result.limit).toBe(100)
+    expect(result.resetTime).toBeGreaterThan(Date.now() - 1000)
+    expect(result.retryAfter).toBeUndefined()
+  })
+
+  it('should use webhook tier with 500 limit and 1hr window', async () => {
+    const result = await checkDistributedRateLimit('webhook:ip:10.0.0.1', 'webhook')
+
+    expect(result.allowed).toBe(true)
+    expect(result.limit).toBe(500)
+    expect(result.remaining).toBe(499)
+    // The reset time should be roughly 1 hour from now (within tolerance)
+    const oneHourMs = 60 * 60 * 1000
+    const resetDelta = result.resetTime - Date.now()
+    expect(resetDelta).toBeGreaterThan(oneHourMs - 5000)
+    expect(resetDelta).toBeLessThanOrEqual(oneHourMs + 1000)
+  })
+
+  it('should use auth tier with 5 limit', async () => {
+    const result = await checkDistributedRateLimit('auth:ip:10.0.0.1', 'auth')
+    expect(result.limit).toBe(5)
+    expect(result.remaining).toBe(4)
+  })
+
+  it('should use strict tier with 10 limit', async () => {
+    const result = await checkDistributedRateLimit('strict:ip:10.0.0.1', 'strict')
+    expect(result.limit).toBe(10)
+    expect(result.remaining).toBe(9)
+  })
+
+  it('should use read tier with 200 limit', async () => {
+    const result = await checkDistributedRateLimit('read:ip:10.0.0.1', 'read')
+    expect(result.limit).toBe(200)
+    expect(result.remaining).toBe(199)
+  })
+
+  it('should use write tier with 50 limit', async () => {
+    const result = await checkDistributedRateLimit('write:ip:10.0.0.1', 'write')
+    expect(result.limit).toBe(50)
+    expect(result.remaining).toBe(49)
+  })
+
+  it('should block after exceeding in-memory webhook limit', async () => {
+    // Exhaust the webhook limit (500 requests)
+    // To avoid 500 iterations, we use checkRateLimit directly with the same key
+    // that checkDistributedRateLimit would use
+    const identifier = 'webhook:webhook:ip:192.168.1.1'
+
+    // Use the lower-level checkRateLimit to fill up the counter quickly
+    for (let i = 0; i < 500; i++) {
+      checkRateLimit(identifier, 500, 60 * 60 * 1000)
+    }
+
+    // Now the distributed check should show blocked
+    const result = await checkDistributedRateLimit('webhook:ip:192.168.1.1', 'webhook')
+    expect(result.allowed).toBe(false)
+    expect(result.remaining).toBe(0)
+    expect(result.retryAfter).toBeGreaterThan(0)
+
+    // Clean up
+    clearRateLimit(identifier)
+  })
+
+  it('should return retryAfter when blocked', async () => {
+    const identifier = 'webhook:webhook:ip:192.168.1.1'
+
+    for (let i = 0; i < 500; i++) {
+      checkRateLimit(identifier, 500, 60 * 60 * 1000)
+    }
+
+    const result = await checkDistributedRateLimit('webhook:ip:192.168.1.1', 'webhook')
+    expect(result.retryAfter).toBeDefined()
+    expect(typeof result.retryAfter).toBe('number')
+    // retryAfter should be in seconds, roughly up to 3600
+    expect(result.retryAfter!).toBeGreaterThan(0)
+    expect(result.retryAfter!).toBeLessThanOrEqual(3600)
+
+    clearRateLimit(identifier)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// isDistributedRateLimitAvailable
+// ---------------------------------------------------------------------------
+
+describe('isDistributedRateLimitAvailable', () => {
+  it('should return false when Redis env vars are not set', () => {
+    expect(isDistributedRateLimitAvailable()).toBe(false)
+  })
+
+  it('should return true when Redis env vars are set', () => {
+    process.env.UPSTASH_REDIS_REST_URL = 'https://fake.upstash.io'
+    process.env.UPSTASH_REDIS_REST_TOKEN = 'fake-token'
+
+    expect(isDistributedRateLimitAvailable()).toBe(true)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// withRateLimitTier - getClientIp and getUserIdentifier integration
+// ---------------------------------------------------------------------------
+
+describe('withRateLimitTier', () => {
+  function createMockRequest(
+    url: string = 'http://localhost:3000/api/test',
+    options: { method?: string; headers?: Record<string, string> } = {}
+  ) {
+    return new NextRequest(url, {
+      method: options.method || 'GET',
+      headers: options.headers || {},
+    }) as unknown as NextRequest
+  }
+
+  const successHandler = async (_req: NextRequest) => {
+    return NextResponse.json({ success: true })
+  }
+
+  it('should pass requests through when within rate limit', async () => {
+    const wrapped = withRateLimitTier(successHandler, 'api')
+    const req = createMockRequest('http://localhost:3000/api/test', {
+      headers: { 'x-forwarded-for': '10.0.0.1' },
+    })
+
+    const res = await wrapped(req)
+    const body = typeof res.body === 'object' ? res.body : JSON.parse(String(res.body))
+
+    expect(body.success).toBe(true)
+  })
+
+  it('should add rate limit headers to successful responses', async () => {
+    const wrapped = withRateLimitTier(successHandler, 'api')
+    const req = createMockRequest('http://localhost:3000/api/test', {
+      headers: { 'x-forwarded-for': '10.0.0.1' },
+    })
+
+    const res = await wrapped(req)
+
+    // The mock NextResponse uses a Map for headers
+    expect(res.headers.get('X-RateLimit-Limit')).toBeDefined()
+    expect(res.headers.get('X-RateLimit-Remaining')).toBeDefined()
+    expect(res.headers.get('X-RateLimit-Reset')).toBeDefined()
+  })
+
+  it('should extract IP from cf-connecting-ip header (Cloudflare)', async () => {
+    const wrapped = withRateLimitTier(successHandler, 'api')
+
+    // First exhaust limit for cf IP
+    const cfIp = '203.0.113.50'
+    const cfIdentifier = `api:api:ip:${cfIp}`
+    for (let i = 0; i < 100; i++) {
+      checkRateLimit(cfIdentifier, 100, 60000)
+    }
+
+    const req = createMockRequest('http://localhost:3000/api/test', {
+      headers: { 'cf-connecting-ip': cfIp },
+    })
+
+    const res = await wrapped(req)
+    // Should be rate limited (429)
+    expect(res.status).toBe(429)
+
+    clearRateLimit(cfIdentifier)
+  })
+
+  it('should extract rightmost IP from x-forwarded-for header', async () => {
+    const wrapped = withRateLimitTier(successHandler, 'api')
+
+    // The rightmost IP is 198.51.100.1
+    const rightmostIp = '198.51.100.1'
+    const identifier = `api:api:ip:${rightmostIp}`
+    for (let i = 0; i < 100; i++) {
+      checkRateLimit(identifier, 100, 60000)
+    }
+
+    const req = createMockRequest('http://localhost:3000/api/test', {
+      headers: { 'x-forwarded-for': '10.0.0.1, 172.16.0.1, 198.51.100.1' },
+    })
+
+    const res = await wrapped(req)
+    expect(res.status).toBe(429)
+
+    clearRateLimit(identifier)
+  })
+
+  it('should extract IP from x-real-ip header', async () => {
+    const wrapped = withRateLimitTier(successHandler, 'api')
+
+    const realIp = '100.200.300.400'
+    const identifier = `api:api:ip:${realIp}`
+    for (let i = 0; i < 100; i++) {
+      checkRateLimit(identifier, 100, 60000)
+    }
+
+    const req = createMockRequest('http://localhost:3000/api/test', {
+      headers: { 'x-real-ip': realIp },
+    })
+
+    const res = await wrapped(req)
+    expect(res.status).toBe(429)
+
+    clearRateLimit(identifier)
+  })
+
+  it('should fall back to "unknown" when no IP headers present', async () => {
+    const wrapped = withRateLimitTier(successHandler, 'api')
+
+    const identifier = 'api:api:ip:unknown'
+    for (let i = 0; i < 100; i++) {
+      checkRateLimit(identifier, 100, 60000)
+    }
+
+    const req = createMockRequest('http://localhost:3000/api/test')
+
+    const res = await wrapped(req)
+    expect(res.status).toBe(429)
+
+    clearRateLimit(identifier)
+  })
+
+  it('should use API key as identifier when x-api-key header is present', async () => {
+    const wrapped = withRateLimitTier(successHandler, 'api')
+    const apiKey = 'sk_test_1234567890abcdef1234567890abcdef'
+
+    const identifier = `api:api:apikey:${apiKey.substring(0, 16)}`
+    for (let i = 0; i < 100; i++) {
+      checkRateLimit(identifier, 100, 60000)
+    }
+
+    const req = createMockRequest('http://localhost:3000/api/test', {
+      headers: { 'x-api-key': apiKey },
+    })
+
+    const res = await wrapped(req)
+    expect(res.status).toBe(429)
+
+    clearRateLimit(identifier)
+  })
+
+  it('should use the specified rate limit tier', async () => {
+    const wrapped = withRateLimitTier(successHandler, 'webhook')
+    const req = createMockRequest('http://localhost:3000/api/webhook', {
+      headers: { 'x-forwarded-for': '10.0.0.1' },
+    })
+
+    const res = await wrapped(req)
+    const body = typeof res.body === 'object' ? res.body : JSON.parse(String(res.body))
+
+    expect(body.success).toBe(true)
+    // webhook tier has 500 limit
+    expect(res.headers.get('X-RateLimit-Limit')).toBe('500')
+  })
+
+  it('should skip rate limiting when DISABLE_RATE_LIMITING is true', async () => {
+    process.env.DISABLE_RATE_LIMITING = 'true'
+
+    // Exhaust the limit first
+    const identifier = 'api:api:ip:10.0.0.1'
+    for (let i = 0; i < 100; i++) {
+      checkRateLimit(identifier, 100, 60000)
+    }
+
+    const wrapped = withRateLimitTier(successHandler, 'api')
+    const req = createMockRequest('http://localhost:3000/api/test', {
+      headers: { 'x-forwarded-for': '10.0.0.1' },
+    })
+
+    const res = await wrapped(req)
+    // Should NOT be rate limited because DISABLE_RATE_LIMITING=true
+    const body = typeof res.body === 'object' ? res.body : JSON.parse(String(res.body))
+    expect(body.success).toBe(true)
+
+    clearRateLimit(identifier)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// createRateLimitErrorResponse
+// ---------------------------------------------------------------------------
+
+describe('createRateLimitErrorResponse', () => {
+  it('should return a 429 response with correct structure', () => {
+    const rateLimitResult: RateLimitResult & { retryAfter?: number } = {
+      allowed: false,
+      remaining: 0,
+      resetTime: Date.now() + 60000,
+      limit: 100,
+      retryAfter: 60,
+    }
+
+    const response = createRateLimitErrorResponse(rateLimitResult)
+
+    expect(response.status).toBe(429)
+    expect(response.headers.get('X-RateLimit-Limit')).toBe('100')
+    expect(response.headers.get('X-RateLimit-Remaining')).toBe('0')
+    expect(response.headers.get('Retry-After')).toBe('60')
+  })
+
+  it('should include error details in response body', () => {
+    const rateLimitResult: RateLimitResult & { retryAfter?: number } = {
+      allowed: false,
+      remaining: 0,
+      resetTime: Date.now() + 60000,
+      limit: 50,
+      retryAfter: 30,
+    }
+
+    const response = createRateLimitErrorResponse(rateLimitResult)
+    // Body should be the data object passed to NextResponse.json
+    const body = typeof response.body === 'object' ? response.body : null
+
+    expect(body).toBeDefined()
+    if (body && typeof body === 'object') {
+      expect((body as Record<string, unknown>).success).toBe(false)
+      expect((body as Record<string, unknown>).error).toBe('Rate limit exceeded')
+      expect((body as Record<string, unknown>).code).toBe('RATE_LIMIT_EXCEEDED')
+    }
+  })
+})
+
+// ---------------------------------------------------------------------------
+// getRateLimitStats
+// ---------------------------------------------------------------------------
+
+describe('getRateLimitStats', () => {
+  it('should return null for unknown keyId', () => {
+    const stats = getRateLimitStats('nonexistent-key')
+    expect(stats).toBeNull()
+  })
+
+  it('should return stats after rate limit entries exist', () => {
+    // Create some rate limit entries
+    checkRateLimit('test-id', 100, 60000)
+
+    const stats = getRateLimitStats('test-id')
+
+    expect(stats).not.toBeNull()
+    expect(stats!.currentUsage).toBe(1)
+    expect(stats!.resetTime).toBeGreaterThan(Date.now() - 1000)
+    expect(typeof stats!.isNearLimit).toBe('boolean')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// getRateLimitCacheStats
+// ---------------------------------------------------------------------------
+
+describe('getRateLimitCacheStats', () => {
+  it('should return cache statistics', () => {
+    const stats = getRateLimitCacheStats()
+
+    expect(stats).toBeDefined()
+    expect(typeof stats.total).toBe('number')
+    expect(typeof stats.active).toBe('number')
+    expect(typeof stats.expired).toBe('number')
+    expect(typeof stats.maxSize).toBe('number')
+  })
+})

--- a/packages/core/tests/jest/lib/billing/polar.test.ts
+++ b/packages/core/tests/jest/lib/billing/polar.test.ts
@@ -186,6 +186,108 @@ describe('Polar Gateway', () => {
       })
     })
 
+    describe('createOneTimeCheckout', () => {
+      test('should create one-time checkout with correct parameters', async () => {
+        mockCheckoutsCreate.mockResolvedValue({
+          id: 'polar_checkout_onetime_123',
+          url: 'https://polar.sh/checkout/onetime',
+        })
+
+        const result = await gateway.createOneTimeCheckout({
+          teamId: 'team-123',
+          priceId: 'polar_product_addon_123',
+          successUrl: 'http://localhost:3000/success',
+          cancelUrl: 'http://localhost:3000/cancel',
+          metadata: { itemType: 'addon', itemId: 'item-456' },
+        })
+
+        expect(result).toEqual({
+          id: 'polar_checkout_onetime_123',
+          url: 'https://polar.sh/checkout/onetime',
+        })
+
+        expect(mockCheckoutsCreate).toHaveBeenCalledWith(
+          expect.objectContaining({
+            products: ['polar_product_addon_123'],
+            successUrl: 'http://localhost:3000/success',
+            returnUrl: 'http://localhost:3000/cancel',
+            metadata: { teamId: 'team-123', itemType: 'addon', itemId: 'item-456' },
+          })
+        )
+      })
+
+      test('should set allowTrial to false for one-time purchases', async () => {
+        mockCheckoutsCreate.mockResolvedValue({
+          id: 'polar_checkout_no_trial',
+          url: 'https://polar.sh/checkout/no-trial',
+        })
+
+        await gateway.createOneTimeCheckout({
+          teamId: 'team-123',
+          priceId: 'polar_product_onetime_456',
+          successUrl: 'http://localhost:3000/success',
+        })
+
+        const calledWith = mockCheckoutsCreate.mock.calls[0]?.[0] as Record<string, unknown>
+        expect(calledWith.allowTrial).toBe(false)
+      })
+
+      test('should pass customerEmail and customerId when provided', async () => {
+        mockCheckoutsCreate.mockResolvedValue({
+          id: 'polar_checkout_with_customer',
+          url: 'https://polar.sh/checkout/customer',
+        })
+
+        await gateway.createOneTimeCheckout({
+          teamId: 'team-789',
+          priceId: 'polar_product_onetime_789',
+          successUrl: 'http://localhost:3000/success',
+          customerEmail: 'buyer@test.com',
+          customerId: 'polar_cus_existing_123',
+        })
+
+        expect(mockCheckoutsCreate).toHaveBeenCalledWith(
+          expect.objectContaining({
+            customerEmail: 'buyer@test.com',
+            customerId: 'polar_cus_existing_123',
+          })
+        )
+      })
+
+      test('should not include customerEmail and customerId when not provided', async () => {
+        mockCheckoutsCreate.mockResolvedValue({
+          id: 'polar_checkout_minimal',
+          url: 'https://polar.sh/checkout/minimal',
+        })
+
+        await gateway.createOneTimeCheckout({
+          teamId: 'team-minimal',
+          priceId: 'polar_product_onetime_min',
+          successUrl: 'http://localhost:3000/success',
+        })
+
+        const calledWith = mockCheckoutsCreate.mock.calls[0]?.[0] as Record<string, unknown>
+        expect(calledWith).not.toHaveProperty('customerEmail')
+        expect(calledWith).not.toHaveProperty('customerId')
+        expect(calledWith).not.toHaveProperty('returnUrl')
+      })
+
+      test('should handle null url in response', async () => {
+        mockCheckoutsCreate.mockResolvedValue({
+          id: 'polar_checkout_no_url',
+          url: undefined,
+        })
+
+        const result = await gateway.createOneTimeCheckout({
+          teamId: 'team-no-url',
+          priceId: 'polar_product_no_url',
+          successUrl: 'http://localhost:3000/success',
+        })
+
+        expect(result.url).toBeNull()
+      })
+    })
+
     describe('createPortalSession', () => {
       test('should create customer session and return customerPortalUrl', async () => {
         mockCustomerSessionsCreate.mockResolvedValue({

--- a/packages/core/tests/jest/lib/billing/stripe-webhook.test.ts
+++ b/packages/core/tests/jest/lib/billing/stripe-webhook.test.ts
@@ -1,0 +1,744 @@
+/**
+ * Unit tests for Stripe Webhook Handler
+ *
+ * Tests handleStripeWebhook() which processes the full Stripe subscription lifecycle.
+ * Mocks: NextRequest, billing gateway factory, billing registry, and database layer.
+ */
+
+import { describe, test, expect, beforeEach, jest } from '@jest/globals'
+import type { NextRequest } from 'next/server'
+
+// ─── Mock: Database layer ──────────────────────────────────────────────────────
+const mockQuery = jest.fn<(...args: unknown[]) => Promise<{ rows: unknown[] }>>()
+const mockQueryOne = jest.fn<(...args: unknown[]) => Promise<unknown>>()
+
+jest.mock('@/core/lib/db', () => ({
+  query: (...args: unknown[]) => mockQuery(...args),
+  queryOne: (...args: unknown[]) => mockQueryOne(...args),
+}))
+
+// ─── Mock: Billing gateway factory ─────────────────────────────────────────────
+const mockVerifyWebhookSignature = jest.fn()
+
+jest.mock('@/core/lib/billing/gateways/factory', () => ({
+  getBillingGateway: () => ({
+    verifyWebhookSignature: mockVerifyWebhookSignature,
+  }),
+}))
+
+// ─── Mock: Billing registry (uses moduleNameMapper from jest.config.cjs) ──────
+// The auto-mock at tests/jest/__mocks__/@nextsparkjs/registries/billing-registry.ts
+// is loaded by moduleNameMapper. We import it here for reference in tests.
+
+// ─── Import SUT after mocks are set up ─────────────────────────────────────────
+import { handleStripeWebhook } from '@/core/lib/billing/stripe-webhook'
+import type { StripeWebhookExtensions } from '@/core/lib/billing/stripe-webhook'
+
+// ─── Helpers ────────────────────────────────────────────────────────────────────
+
+function createMockRequest(payload: string, signature: string | null = 'sig_test'): NextRequest {
+  return {
+    text: jest.fn<() => Promise<string>>().mockResolvedValue(payload),
+    headers: {
+      get: jest.fn((name: string) => (name === 'stripe-signature' ? signature : null)),
+    },
+  } as unknown as NextRequest
+}
+
+function buildStripeEvent(type: string, dataObject: Record<string, unknown>, eventId = 'evt_test_123') {
+  return {
+    id: eventId,
+    type,
+    data: { object: dataObject },
+  }
+}
+
+function setupVerifiedEvent(type: string, dataObject: Record<string, unknown>, eventId?: string) {
+  const event = buildStripeEvent(type, dataObject, eventId)
+  mockVerifyWebhookSignature.mockReturnValue(event)
+  // Default: event not yet processed (idempotency check)
+  mockQueryOne.mockResolvedValueOnce(null)
+  return event
+}
+
+// ─── Test Suite ─────────────────────────────────────────────────────────────────
+
+describe('handleStripeWebhook', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    // Default: query returns empty rows
+    mockQuery.mockResolvedValue({ rows: [] })
+  })
+
+  // ===========================================================================
+  // 1. Signature verification
+  // ===========================================================================
+
+  describe('signature verification', () => {
+    test('returns 400 if no stripe-signature header', async () => {
+      const req = createMockRequest('payload', null)
+
+      const res = await handleStripeWebhook(req)
+
+      expect(res.status).toBe(400)
+      const body = await res.json()
+      expect(body.error).toBe('No signature provided')
+      expect(mockVerifyWebhookSignature).not.toHaveBeenCalled()
+    })
+
+    test('returns 400 if signature verification fails', async () => {
+      mockVerifyWebhookSignature.mockImplementation(() => {
+        throw new Error('Invalid signature')
+      })
+      const req = createMockRequest('payload', 'bad_sig')
+
+      const res = await handleStripeWebhook(req)
+
+      expect(res.status).toBe(400)
+      const body = await res.json()
+      expect(body.error).toBe('Invalid signature')
+    })
+
+    test('calls verifyWebhookSignature with payload and signature', async () => {
+      const event = buildStripeEvent('unknown.event', {})
+      mockVerifyWebhookSignature.mockReturnValue(event)
+      mockQueryOne.mockResolvedValueOnce(null) // idempotency check
+
+      const req = createMockRequest('raw_payload', 'sig_abc')
+      await handleStripeWebhook(req)
+
+      expect(mockVerifyWebhookSignature).toHaveBeenCalledWith('raw_payload', 'sig_abc')
+    })
+  })
+
+  // ===========================================================================
+  // 2. Idempotency
+  // ===========================================================================
+
+  describe('idempotency', () => {
+    test('skips duplicate events when queryOne returns existing record', async () => {
+      const event = buildStripeEvent('checkout.session.completed', { id: 'cs_123' })
+      mockVerifyWebhookSignature.mockReturnValue(event)
+      // Return existing record -> duplicate
+      mockQueryOne.mockResolvedValueOnce({ id: 'existing-billing-event-id' })
+
+      const req = createMockRequest('payload')
+      const res = await handleStripeWebhook(req)
+
+      const body = await res.json()
+      expect(body.status).toBe('duplicate')
+      expect(body.received).toBe(true)
+      // Should only have the idempotency queryOne call, no handler queries
+      expect(mockQueryOne).toHaveBeenCalledTimes(1)
+    })
+
+    test('processes new events when queryOne returns null', async () => {
+      setupVerifiedEvent('customer.subscription.deleted', {
+        id: 'sub_123',
+      })
+
+      const req = createMockRequest('payload')
+      const res = await handleStripeWebhook(req)
+
+      const body = await res.json()
+      expect(body.received).toBe(true)
+      expect(body.status).toBeUndefined()
+      // Handler should have run (query called for the UPDATE)
+      expect(mockQuery).toHaveBeenCalled()
+    })
+  })
+
+  // ===========================================================================
+  // 3. checkout.session.completed (subscription)
+  // ===========================================================================
+
+  describe('checkout.session.completed (subscription)', () => {
+    const sessionData = {
+      id: 'cs_checkout_123',
+      metadata: {
+        teamId: 'team-abc',
+        planSlug: 'pro',
+        billingPeriod: 'monthly',
+        userId: 'user-xyz',
+      },
+      subscription: 'sub_new_123',
+      customer: 'cus_new_123',
+      amount_total: 4900,
+      currency: 'usd',
+      client_reference_id: null,
+    }
+
+    test('updates subscription with Stripe IDs when planSlug is in metadata', async () => {
+      setupVerifiedEvent('checkout.session.completed', sessionData)
+      // queryOne for plan lookup -> return plan ID
+      mockQueryOne.mockResolvedValueOnce({ id: 'plan-uuid-pro' })
+      // queryOne for logBillingEvent -> subscription lookup
+      mockQueryOne.mockResolvedValueOnce({ id: 'sub-uuid-123' })
+
+      const req = createMockRequest('payload')
+      await handleStripeWebhook(req)
+
+      // UPDATE subscriptions with plan, stripe IDs, status active
+      expect(mockQuery).toHaveBeenCalledWith(
+        expect.stringContaining('"externalSubscriptionId"'),
+        expect.arrayContaining(['sub_new_123', 'cus_new_123', 'plan-uuid-pro', 'monthly', 'team-abc'])
+      )
+    })
+
+    test('updates plan, billingInterval, status to active', async () => {
+      setupVerifiedEvent('checkout.session.completed', sessionData)
+      mockQueryOne.mockResolvedValueOnce({ id: 'plan-uuid-pro' })
+      mockQueryOne.mockResolvedValueOnce({ id: 'sub-uuid-123' })
+
+      const req = createMockRequest('payload')
+      await handleStripeWebhook(req)
+
+      const updateCall = mockQuery.mock.calls[0]
+      const sql = updateCall[0] as string
+      expect(sql).toContain('"planId"')
+      expect(sql).toContain('"billingInterval"')
+      expect(sql).toContain("status = 'active'")
+    })
+
+    test('logs billing event after checkout completed', async () => {
+      setupVerifiedEvent('checkout.session.completed', sessionData)
+      mockQueryOne.mockResolvedValueOnce({ id: 'plan-uuid-pro' })
+      // logBillingEvent: subscription lookup
+      mockQueryOne.mockResolvedValueOnce({ id: 'sub-uuid-123' })
+
+      const req = createMockRequest('payload')
+      await handleStripeWebhook(req)
+
+      // The INSERT into billing_events
+      const insertCall = mockQuery.mock.calls.find(
+        (call) => (call[0] as string).includes('billing_events')
+      )
+      expect(insertCall).toBeDefined()
+      const params = insertCall![1] as unknown[]
+      expect(params).toContain('sub-uuid-123') // subscriptionId
+      expect(params).toContain('payment') // type
+      expect(params).toContain('succeeded') // status
+      expect(params).toContain(4900) // amount
+      expect(params).toContain('usd') // currency
+    })
+
+    test('falls back to update without plan when planSlug not found in DB', async () => {
+      setupVerifiedEvent('checkout.session.completed', sessionData)
+      // Plan lookup returns null
+      mockQueryOne.mockResolvedValueOnce(null)
+      // logBillingEvent subscription lookup
+      mockQueryOne.mockResolvedValueOnce({ id: 'sub-uuid-123' })
+
+      const req = createMockRequest('payload')
+      await handleStripeWebhook(req)
+
+      const updateCall = mockQuery.mock.calls[0]
+      const sql = updateCall[0] as string
+      // Fallback SQL should NOT contain planId
+      expect(sql).not.toContain('"planId"')
+      expect(sql).toContain("status = 'active'")
+    })
+
+    test('uses client_reference_id as teamId fallback', async () => {
+      const sessionNoTeamMeta = {
+        ...sessionData,
+        metadata: { planSlug: 'pro', billingPeriod: 'monthly' },
+        client_reference_id: 'team-from-ref',
+      }
+      setupVerifiedEvent('checkout.session.completed', sessionNoTeamMeta)
+      mockQueryOne.mockResolvedValueOnce({ id: 'plan-uuid-pro' })
+      mockQueryOne.mockResolvedValueOnce({ id: 'sub-uuid-123' })
+
+      const req = createMockRequest('payload')
+      await handleStripeWebhook(req)
+
+      const updateCall = mockQuery.mock.calls[0]
+      const params = updateCall[1] as unknown[]
+      expect(params).toContain('team-from-ref')
+    })
+
+    test('throws error when no team ID in session', async () => {
+      const sessionNoTeam = {
+        ...sessionData,
+        metadata: { planSlug: 'pro' },
+        client_reference_id: null,
+      }
+      setupVerifiedEvent('checkout.session.completed', sessionNoTeam)
+
+      const req = createMockRequest('payload')
+      const res = await handleStripeWebhook(req)
+
+      expect(res.status).toBe(500)
+    })
+  })
+
+  // ===========================================================================
+  // 4. checkout.session.completed (one-time payment)
+  // ===========================================================================
+
+  describe('checkout.session.completed (one-time payment)', () => {
+    const oneTimeSession = {
+      id: 'cs_onetime_123',
+      metadata: { teamId: 'team-abc', userId: 'user-xyz' },
+      subscription: null,
+      customer: 'cus_123',
+      amount_total: 9900,
+      currency: 'usd',
+      client_reference_id: null,
+    }
+
+    test('calls extensions.onOneTimePaymentCompleted when no planSlug', async () => {
+      setupVerifiedEvent('checkout.session.completed', oneTimeSession)
+
+      const mockExtension = jest.fn<() => Promise<void>>().mockResolvedValue(undefined)
+      const extensions: StripeWebhookExtensions = {
+        onOneTimePaymentCompleted: mockExtension,
+      }
+
+      const req = createMockRequest('payload')
+      await handleStripeWebhook(req, extensions)
+
+      expect(mockExtension).toHaveBeenCalledTimes(1)
+    })
+
+    test('creates StripeSessionData with correct fields', async () => {
+      setupVerifiedEvent('checkout.session.completed', oneTimeSession)
+
+      const mockExtension = jest.fn<() => Promise<void>>().mockResolvedValue(undefined)
+      const extensions: StripeWebhookExtensions = {
+        onOneTimePaymentCompleted: mockExtension,
+      }
+
+      const req = createMockRequest('payload')
+      await handleStripeWebhook(req, extensions)
+
+      const [sessionData, context] = mockExtension.mock.calls[0] as [Record<string, unknown>, Record<string, unknown>]
+      expect(sessionData).toEqual({
+        id: 'cs_onetime_123',
+        amountTotal: 9900,
+        currency: 'usd',
+        customerId: 'cus_123',
+        subscriptionId: null,
+        metadata: { teamId: 'team-abc', userId: 'user-xyz' },
+        clientReferenceId: null,
+      })
+      expect(context).toEqual({ teamId: 'team-abc', userId: 'user-xyz' })
+    })
+
+    test('skips when no extension handler registered', async () => {
+      setupVerifiedEvent('checkout.session.completed', oneTimeSession)
+
+      const req = createMockRequest('payload')
+      const res = await handleStripeWebhook(req)
+
+      expect(res.status).toBe(200)
+      const body = await res.json()
+      expect(body.received).toBe(true)
+      // No DB updates should have happened (no subscription checkout, no handler)
+      expect(mockQuery).not.toHaveBeenCalled()
+    })
+  })
+
+  // ===========================================================================
+  // 5. invoice.paid
+  // ===========================================================================
+
+  describe('invoice.paid', () => {
+    const invoiceData = {
+      id: 'in_paid_123',
+      subscription: 'sub_existing_123',
+      number: 'INV-001',
+      total: 4900,
+      currency: 'usd',
+      created: 1700000000,
+      invoice_pdf: 'https://stripe.com/invoice.pdf',
+      hosted_invoice_url: null,
+      description: null,
+      lines: {
+        data: [
+          {
+            period: {
+              start: 1700000000,
+              end: 1702592000,
+            },
+          },
+        ],
+      },
+    }
+
+    test('updates subscription status to active', async () => {
+      setupVerifiedEvent('invoice.paid', invoiceData)
+      // syncInvoiceToDatabase: subscription lookup
+      mockQuery.mockResolvedValueOnce({ rows: [] }) // UPDATE subscription
+      mockQuery.mockResolvedValueOnce({ rows: [{ teamId: 'team-abc' }] }) // SELECT teamId
+
+      const req = createMockRequest('payload')
+      await handleStripeWebhook(req)
+
+      const updateCall = mockQuery.mock.calls[0]
+      const sql = updateCall[0] as string
+      expect(sql).toContain("status = 'active'")
+      expect(sql).toContain('"externalSubscriptionId"')
+    })
+
+    test('updates currentPeriodStart/End from invoice line items', async () => {
+      setupVerifiedEvent('invoice.paid', invoiceData)
+      mockQuery.mockResolvedValueOnce({ rows: [] })
+      mockQuery.mockResolvedValueOnce({ rows: [{ teamId: 'team-abc' }] })
+
+      const req = createMockRequest('payload')
+      await handleStripeWebhook(req)
+
+      const updateCall = mockQuery.mock.calls[0]
+      const sql = updateCall[0] as string
+      const params = updateCall[1] as unknown[]
+      expect(sql).toContain('"currentPeriodStart"')
+      expect(sql).toContain('"currentPeriodEnd"')
+      expect(params).toContain(1700000000) // period.start
+      expect(params).toContain(1702592000) // period.end
+      expect(params).toContain('sub_existing_123')
+    })
+
+    test('syncs invoice to database', async () => {
+      setupVerifiedEvent('invoice.paid', invoiceData)
+      // UPDATE subscription
+      mockQuery.mockResolvedValueOnce({ rows: [] })
+      // syncInvoiceToDatabase: SELECT teamId
+      mockQuery.mockResolvedValueOnce({ rows: [{ teamId: 'team-abc' }] })
+
+      const req = createMockRequest('payload')
+      await handleStripeWebhook(req)
+
+      const insertCall = mockQuery.mock.calls.find(
+        (call) => (call[0] as string).includes('INSERT INTO invoices')
+      )
+      expect(insertCall).toBeDefined()
+      const params = insertCall![1] as unknown[]
+      expect(params).toContain('team-abc')
+      expect(params).toContain('INV-001')
+      expect(params).toContain(49) // 4900/100 = amountInDollars
+      expect(params).toContain('USD')
+      expect(params).toContain('paid')
+    })
+
+    test('skips when invoice has no subscription ID', async () => {
+      setupVerifiedEvent('invoice.paid', {
+        ...invoiceData,
+        subscription: null,
+      })
+
+      const req = createMockRequest('payload')
+      const res = await handleStripeWebhook(req)
+
+      expect(res.status).toBe(200)
+      expect(mockQuery).not.toHaveBeenCalled()
+    })
+
+    test('updates without period dates when no line items', async () => {
+      setupVerifiedEvent('invoice.paid', {
+        ...invoiceData,
+        lines: { data: [] },
+      })
+      mockQuery.mockResolvedValueOnce({ rows: [] })
+      mockQuery.mockResolvedValueOnce({ rows: [{ teamId: 'team-abc' }] })
+
+      const req = createMockRequest('payload')
+      await handleStripeWebhook(req)
+
+      const updateCall = mockQuery.mock.calls[0]
+      const sql = updateCall[0] as string
+      expect(sql).toContain("status = 'active'")
+      expect(sql).not.toContain('"currentPeriodStart"')
+    })
+  })
+
+  // ===========================================================================
+  // 6. invoice.payment_failed
+  // ===========================================================================
+
+  describe('invoice.payment_failed', () => {
+    const failedInvoiceData = {
+      id: 'in_failed_123',
+      subscription: 'sub_existing_123',
+      number: 'INV-002',
+      total: 4900,
+      currency: 'usd',
+      created: 1700000000,
+      invoice_pdf: null,
+      hosted_invoice_url: 'https://stripe.com/hosted',
+      description: 'Pro plan monthly',
+      lines: { data: [] },
+    }
+
+    test('updates subscription status to past_due', async () => {
+      setupVerifiedEvent('invoice.payment_failed', failedInvoiceData)
+      mockQuery.mockResolvedValueOnce({ rows: [] }) // UPDATE subscription
+      mockQuery.mockResolvedValueOnce({ rows: [{ teamId: 'team-abc' }] }) // SELECT teamId
+
+      const req = createMockRequest('payload')
+      await handleStripeWebhook(req)
+
+      const updateCall = mockQuery.mock.calls[0]
+      const sql = updateCall[0] as string
+      expect(sql).toContain("status = 'past_due'")
+      expect(sql).toContain('"externalSubscriptionId"')
+    })
+
+    test('syncs invoice with failed status', async () => {
+      setupVerifiedEvent('invoice.payment_failed', failedInvoiceData)
+      mockQuery.mockResolvedValueOnce({ rows: [] })
+      mockQuery.mockResolvedValueOnce({ rows: [{ teamId: 'team-abc' }] })
+
+      const req = createMockRequest('payload')
+      await handleStripeWebhook(req)
+
+      const insertCall = mockQuery.mock.calls.find(
+        (call) => (call[0] as string).includes('INSERT INTO invoices')
+      )
+      expect(insertCall).toBeDefined()
+      const params = insertCall![1] as unknown[]
+      expect(params).toContain('failed')
+      expect(params).toContain('team-abc')
+    })
+
+    test('skips when invoice has no subscription ID', async () => {
+      setupVerifiedEvent('invoice.payment_failed', {
+        ...failedInvoiceData,
+        subscription: null,
+      })
+
+      const req = createMockRequest('payload')
+      const res = await handleStripeWebhook(req)
+
+      expect(res.status).toBe(200)
+      expect(mockQuery).not.toHaveBeenCalled()
+    })
+  })
+
+  // ===========================================================================
+  // 7. customer.subscription.updated
+  // ===========================================================================
+
+  describe('customer.subscription.updated', () => {
+    const subscriptionData = {
+      id: 'sub_updated_123',
+      status: 'active',
+      cancel_at_period_end: false,
+      current_period_end: 1702592000,
+      current_period_start: 1700000000,
+      items: {
+        data: [
+          {
+            price: { id: 'price_pro' },
+          },
+        ],
+      },
+    }
+
+    test('updates subscription status mapping (active)', async () => {
+      setupVerifiedEvent('customer.subscription.updated', subscriptionData)
+      // queryOne for plan lookup by slug
+      mockQueryOne.mockResolvedValueOnce({ id: 'plan-uuid-pro' })
+
+      const req = createMockRequest('payload')
+      await handleStripeWebhook(req)
+
+      const updateCall = mockQuery.mock.calls[0]
+      const params = updateCall[1] as unknown[]
+      expect(params[0]).toBe('active')
+    })
+
+    test('maps trialing status correctly', async () => {
+      setupVerifiedEvent('customer.subscription.updated', {
+        ...subscriptionData,
+        status: 'trialing',
+      })
+      mockQueryOne.mockResolvedValueOnce({ id: 'plan-uuid-pro' })
+
+      const req = createMockRequest('payload')
+      await handleStripeWebhook(req)
+
+      const params = mockQuery.mock.calls[0][1] as unknown[]
+      expect(params[0]).toBe('trialing')
+    })
+
+    test('maps past_due status correctly', async () => {
+      setupVerifiedEvent('customer.subscription.updated', {
+        ...subscriptionData,
+        status: 'past_due',
+      })
+      mockQueryOne.mockResolvedValueOnce({ id: 'plan-uuid-pro' })
+
+      const req = createMockRequest('payload')
+      await handleStripeWebhook(req)
+
+      const params = mockQuery.mock.calls[0][1] as unknown[]
+      expect(params[0]).toBe('past_due')
+    })
+
+    test('maps unpaid to past_due', async () => {
+      setupVerifiedEvent('customer.subscription.updated', {
+        ...subscriptionData,
+        status: 'unpaid',
+      })
+      mockQueryOne.mockResolvedValueOnce({ id: 'plan-uuid-pro' })
+
+      const req = createMockRequest('payload')
+      await handleStripeWebhook(req)
+
+      const params = mockQuery.mock.calls[0][1] as unknown[]
+      expect(params[0]).toBe('past_due')
+    })
+
+    test('maps incomplete_expired to expired', async () => {
+      setupVerifiedEvent('customer.subscription.updated', {
+        ...subscriptionData,
+        status: 'incomplete_expired',
+      })
+      mockQueryOne.mockResolvedValueOnce({ id: 'plan-uuid-pro' })
+
+      const req = createMockRequest('payload')
+      await handleStripeWebhook(req)
+
+      const params = mockQuery.mock.calls[0][1] as unknown[]
+      expect(params[0]).toBe('expired')
+    })
+
+    test('maps canceled status correctly', async () => {
+      setupVerifiedEvent('customer.subscription.updated', {
+        ...subscriptionData,
+        status: 'canceled',
+      })
+      mockQueryOne.mockResolvedValueOnce({ id: 'plan-uuid-pro' })
+
+      const req = createMockRequest('payload')
+      await handleStripeWebhook(req)
+
+      const params = mockQuery.mock.calls[0][1] as unknown[]
+      expect(params[0]).toBe('canceled')
+    })
+
+    test('updates cancelAtPeriodEnd', async () => {
+      setupVerifiedEvent('customer.subscription.updated', {
+        ...subscriptionData,
+        cancel_at_period_end: true,
+      })
+      mockQueryOne.mockResolvedValueOnce({ id: 'plan-uuid-pro' })
+
+      const req = createMockRequest('payload')
+      await handleStripeWebhook(req)
+
+      const updateCall = mockQuery.mock.calls[0]
+      const sql = updateCall[0] as string
+      const params = updateCall[1] as unknown[]
+      expect(sql).toContain('"cancelAtPeriodEnd"')
+      expect(params[1]).toBe(true)
+    })
+
+    test('finds and updates plan by priceId from billing registry', async () => {
+      setupVerifiedEvent('customer.subscription.updated', subscriptionData)
+      // The billing registry mock has price_pro for the 'pro' plan
+      // queryOne for plan DB lookup returns plan UUID
+      mockQueryOne.mockResolvedValueOnce({ id: 'plan-uuid-pro' })
+
+      const req = createMockRequest('payload')
+      await handleStripeWebhook(req)
+
+      const updateCall = mockQuery.mock.calls[0]
+      const sql = updateCall[0] as string
+      const params = updateCall[1] as unknown[]
+      expect(sql).toContain('"planId"')
+      expect(params).toContain('plan-uuid-pro')
+    })
+
+    test('does not update plan when priceId not found in registry', async () => {
+      setupVerifiedEvent('customer.subscription.updated', {
+        ...subscriptionData,
+        items: { data: [{ price: { id: 'price_unknown_xyz' } }] },
+      })
+
+      const req = createMockRequest('payload')
+      await handleStripeWebhook(req)
+
+      const updateCall = mockQuery.mock.calls[0]
+      const sql = updateCall[0] as string
+      expect(sql).not.toContain('"planId"')
+    })
+
+    test('defaults to active for unknown Stripe status', async () => {
+      setupVerifiedEvent('customer.subscription.updated', {
+        ...subscriptionData,
+        status: 'some_future_status',
+      })
+
+      const req = createMockRequest('payload')
+      await handleStripeWebhook(req)
+
+      const params = mockQuery.mock.calls[0][1] as unknown[]
+      expect(params[0]).toBe('active')
+    })
+  })
+
+  // ===========================================================================
+  // 8. customer.subscription.deleted
+  // ===========================================================================
+
+  describe('customer.subscription.deleted', () => {
+    test('updates subscription to canceled with canceledAt timestamp', async () => {
+      setupVerifiedEvent('customer.subscription.deleted', {
+        id: 'sub_deleted_123',
+      })
+
+      const req = createMockRequest('payload')
+      await handleStripeWebhook(req)
+
+      const updateCall = mockQuery.mock.calls[0]
+      const sql = updateCall[0] as string
+      const params = updateCall[1] as unknown[]
+      expect(sql).toContain("status = 'canceled'")
+      expect(sql).toContain('"canceledAt"')
+      expect(sql).toContain('"externalSubscriptionId"')
+      expect(params).toContain('sub_deleted_123')
+    })
+  })
+
+  // ===========================================================================
+  // 9. Error handling
+  // ===========================================================================
+
+  describe('error handling', () => {
+    test('returns 500 on handler error', async () => {
+      setupVerifiedEvent('checkout.session.completed', {
+        id: 'cs_error',
+        metadata: { teamId: 'team-abc', planSlug: 'pro' },
+        subscription: 'sub_123',
+        customer: 'cus_123',
+        amount_total: 100,
+        currency: 'usd',
+        client_reference_id: null,
+      })
+      // Force plan lookup to throw
+      mockQueryOne.mockRejectedValueOnce(new Error('DB connection lost'))
+
+      const req = createMockRequest('payload')
+      const res = await handleStripeWebhook(req)
+
+      expect(res.status).toBe(500)
+      const body = await res.json()
+      expect(body.error).toBe('Handler failed')
+    })
+
+    test('logs unhandled event types without error', async () => {
+      setupVerifiedEvent('payment_intent.created', { id: 'pi_123' })
+
+      const req = createMockRequest('payload')
+      const res = await handleStripeWebhook(req)
+
+      expect(res.status).toBe(200)
+      const body = await res.json()
+      expect(body.received).toBe(true)
+      // No DB calls should have been made for unhandled event
+      expect(mockQuery).not.toHaveBeenCalled()
+    })
+  })
+})

--- a/packages/core/tests/jest/lib/helpers.simple.test.ts
+++ b/packages/core/tests/jest/lib/helpers.simple.test.ts
@@ -3,6 +3,14 @@
  * Testing basic imports and function definitions
  */
 
+// Mock MetaService to avoid transitive ESM imports (auth -> better-auth/plugins -> rou3)
+jest.mock('@/core/lib/services/meta.service', () => ({
+  MetaService: {
+    getEntityMetas: jest.fn().mockResolvedValue({}),
+    setBulkEntityMetas: jest.fn().mockResolvedValue(undefined),
+  },
+}));
+
 describe('Entity Meta Helpers - Basic Tests', () => {
   test('should import helper functions correctly', () => {
     const helpers = require('@/core/lib/helpers/entity-meta.helpers');

--- a/packages/core/tests/jest/lib/marketplace/commission.test.ts
+++ b/packages/core/tests/jest/lib/marketplace/commission.test.ts
@@ -1,0 +1,130 @@
+/**
+ * Commission Calculator Tests
+ */
+
+import { describe, test, expect } from '@jest/globals'
+import { calculateFee, describeCommission } from '@/core/lib/marketplace/commission'
+import type { CommissionConfig } from '@/core/lib/marketplace/types'
+
+describe('Commission Calculator', () => {
+  describe('calculateFee', () => {
+    describe('percentage model', () => {
+      test('should calculate percentage fee correctly', () => {
+        const config: CommissionConfig = { model: 'percentage', rate: 0.15 }
+        expect(calculateFee(10000, config)).toBe(1500) // 15% of $100.00
+      })
+
+      test('should round to nearest integer', () => {
+        const config: CommissionConfig = { model: 'percentage', rate: 0.15 }
+        expect(calculateFee(9999, config)).toBe(1500) // 0.15 * 9999 = 1499.85 -> 1500
+      })
+
+      test('should handle zero amount', () => {
+        const config: CommissionConfig = { model: 'percentage', rate: 0.15 }
+        expect(calculateFee(0, config)).toBe(0)
+      })
+
+      test('should handle zero rate', () => {
+        const config: CommissionConfig = { model: 'percentage', rate: 0 }
+        expect(calculateFee(10000, config)).toBe(0)
+      })
+    })
+
+    describe('fixed model', () => {
+      test('should return fixed fee regardless of amount', () => {
+        const config: CommissionConfig = { model: 'fixed', fixedAmount: 200 }
+        expect(calculateFee(10000, config)).toBe(200)
+        expect(calculateFee(50000, config)).toBe(200)
+        expect(calculateFee(100, config)).toBe(100) // Capped at amount
+      })
+    })
+
+    describe('hybrid model', () => {
+      test('should combine percentage and fixed fees', () => {
+        const config: CommissionConfig = { model: 'hybrid', rate: 0.10, fixedAmount: 100 }
+        expect(calculateFee(10000, config)).toBe(1100) // 10% + $1.00
+      })
+    })
+
+    describe('tiered model', () => {
+      test('should use correct tier based on volume', () => {
+        const config: CommissionConfig = {
+          model: 'tiered',
+          rate: 0.15, // default
+          tiers: [
+            { minVolume: 0, rate: 0.15 },
+            { minVolume: 500000, rate: 0.12 },
+            { minVolume: 2000000, rate: 0.10 },
+            { minVolume: 5000000, rate: 0.08 },
+          ],
+        }
+
+        // Low volume: 15%
+        expect(calculateFee(10000, config, 100000)).toBe(1500)
+        // Medium volume: 12%
+        expect(calculateFee(10000, config, 600000)).toBe(1200)
+        // High volume: 10%
+        expect(calculateFee(10000, config, 3000000)).toBe(1000)
+        // Very high volume: 8%
+        expect(calculateFee(10000, config, 5000000)).toBe(800)
+      })
+
+      test('should use default rate when no volume provided', () => {
+        const config: CommissionConfig = {
+          model: 'tiered',
+          rate: 0.15,
+          tiers: [{ minVolume: 500000, rate: 0.10 }],
+        }
+        expect(calculateFee(10000, config)).toBe(1500)
+      })
+    })
+
+    describe('constraints', () => {
+      test('should enforce minimum fee', () => {
+        const config: CommissionConfig = { model: 'percentage', rate: 0.01, minFee: 100 }
+        expect(calculateFee(1000, config)).toBe(100) // 1% of $10 = $0.10, but min is $1.00
+      })
+
+      test('should enforce maximum fee', () => {
+        const config: CommissionConfig = { model: 'percentage', rate: 0.50, maxFee: 5000 }
+        expect(calculateFee(100000, config)).toBe(5000) // 50% of $1000 = $500, but max is $50
+      })
+
+      test('should not exceed payment amount', () => {
+        const config: CommissionConfig = { model: 'fixed', fixedAmount: 500 }
+        expect(calculateFee(200, config)).toBe(200) // $5 fee on $2 payment, capped at $2
+      })
+
+      test('should not return negative fees', () => {
+        const config: CommissionConfig = { model: 'percentage', rate: -0.10 }
+        expect(calculateFee(10000, config)).toBe(0)
+      })
+    })
+  })
+
+  describe('describeCommission', () => {
+    test('should describe percentage model', () => {
+      expect(describeCommission({ model: 'percentage', rate: 0.15 })).toBe('15%')
+    })
+
+    test('should describe fixed model', () => {
+      expect(describeCommission({ model: 'fixed', fixedAmount: 200 })).toBe('$2.00')
+    })
+
+    test('should describe hybrid model', () => {
+      expect(describeCommission({ model: 'hybrid', rate: 0.10, fixedAmount: 100 })).toBe('10% + $1.00')
+    })
+
+    test('should describe tiered model', () => {
+      const result = describeCommission({
+        model: 'tiered',
+        tiers: [
+          { minVolume: 0, rate: 0.15 },
+          { minVolume: 500000, rate: 0.10 },
+        ],
+      })
+      expect(result).toContain('15%')
+      expect(result).toContain('10%')
+    })
+  })
+})

--- a/packages/core/tests/jest/lib/marketplace/factory.test.ts
+++ b/packages/core/tests/jest/lib/marketplace/factory.test.ts
@@ -1,0 +1,94 @@
+/**
+ * Marketplace Gateway Factory Tests
+ */
+
+import { describe, test, expect, beforeEach, afterEach } from '@jest/globals'
+
+// Mock Stripe before importing
+jest.mock('stripe', () => {
+  return jest.fn().mockImplementation(() => ({}))
+})
+
+import {
+  getMarketplaceGateway,
+  resetMarketplaceGateway,
+  setMarketplaceProvider,
+} from '@/core/lib/marketplace/gateways/factory'
+import { StripeConnectGateway } from '@/core/lib/marketplace/gateways/stripe-connect'
+import { MercadoPagoSplitGateway } from '@/core/lib/marketplace/gateways/mercadopago-split'
+
+describe('Marketplace Gateway Factory', () => {
+  const originalEnv = process.env
+
+  beforeEach(() => {
+    resetMarketplaceGateway()
+    process.env = {
+      ...originalEnv,
+      STRIPE_SECRET_KEY: 'sk_test_mock',
+      MP_ACCESS_TOKEN: 'TEST-mock-token',
+    }
+  })
+
+  afterEach(() => {
+    process.env = originalEnv
+    resetMarketplaceGateway()
+  })
+
+  test('should return StripeConnectGateway by default', () => {
+    const gw = getMarketplaceGateway('stripe_connect')
+    expect(gw).toBeInstanceOf(StripeConnectGateway)
+  })
+
+  test('should return MercadoPagoSplitGateway when configured', () => {
+    const gw = getMarketplaceGateway('mercadopago_split')
+    expect(gw).toBeInstanceOf(MercadoPagoSplitGateway)
+  })
+
+  test('should return singleton instance', () => {
+    const gw1 = getMarketplaceGateway('stripe_connect')
+    const gw2 = getMarketplaceGateway()
+    expect(gw1).toBe(gw2)
+  })
+
+  test('should return new instance after reset', () => {
+    const gw1 = getMarketplaceGateway('stripe_connect')
+    resetMarketplaceGateway()
+    const gw2 = getMarketplaceGateway('stripe_connect')
+    expect(gw1).not.toBe(gw2)
+  })
+
+  test('should switch provider when different provider requested', () => {
+    const gw1 = getMarketplaceGateway('stripe_connect')
+    expect(gw1).toBeInstanceOf(StripeConnectGateway)
+
+    const gw2 = getMarketplaceGateway('mercadopago_split')
+    expect(gw2).toBeInstanceOf(MercadoPagoSplitGateway)
+  })
+
+  test('should use setMarketplaceProvider configuration', () => {
+    setMarketplaceProvider('mercadopago_split')
+    const gw = getMarketplaceGateway()
+    expect(gw).toBeInstanceOf(MercadoPagoSplitGateway)
+  })
+
+  test('should throw for unsupported provider', () => {
+    expect(() => {
+      getMarketplaceGateway('unknown' as any)
+    }).toThrow('Unsupported marketplace provider')
+  })
+
+  test('should use MARKETPLACE_PROVIDER env var as fallback', () => {
+    process.env.MARKETPLACE_PROVIDER = 'mercadopago_split'
+    const gw = getMarketplaceGateway()
+    expect(gw).toBeInstanceOf(MercadoPagoSplitGateway)
+  })
+
+  test('gateway should expose provider name', () => {
+    const stripe = getMarketplaceGateway('stripe_connect')
+    expect(stripe.provider).toBe('stripe_connect')
+
+    resetMarketplaceGateway()
+    const mp = getMarketplaceGateway('mercadopago_split')
+    expect(mp.provider).toBe('mercadopago_split')
+  })
+})

--- a/packages/core/tests/jest/lib/marketplace/mercadopago-split.test.ts
+++ b/packages/core/tests/jest/lib/marketplace/mercadopago-split.test.ts
@@ -1,0 +1,575 @@
+/**
+ * MercadoPago Split Gateway Tests
+ */
+
+import { describe, test, expect, beforeEach, afterEach, jest } from '@jest/globals'
+import { createHmac } from 'crypto'
+
+// Mock global.fetch
+const mockFetch = jest.fn() as jest.MockedFunction<typeof fetch>
+global.fetch = mockFetch
+
+import {
+  MercadoPagoSplitGateway,
+  setMPTokenProvider,
+  exchangeMPAuthorizationCode,
+  refreshMPToken,
+} from '@/core/lib/marketplace/gateways/mercadopago-split'
+
+describe('MercadoPagoSplitGateway', () => {
+  const originalEnv = process.env
+  let gateway: MercadoPagoSplitGateway
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    process.env = {
+      ...originalEnv,
+      MP_APP_ID: 'test-app-id',
+      MP_CLIENT_SECRET: 'test-client-secret',
+      MP_ACCESS_TOKEN: 'test-platform-token',
+      MP_WEBHOOK_SECRET: 'test-webhook-secret',
+    }
+    gateway = new MercadoPagoSplitGateway()
+
+    // Set mock token provider for seller tokens
+    setMPTokenProvider({
+      getAccessToken: async () => 'test-seller-token',
+    })
+  })
+
+  afterEach(() => {
+    process.env = originalEnv
+    // Reset token provider to default
+    setMPTokenProvider({
+      async getAccessToken(): Promise<string> {
+        const token = process.env.MP_ACCESS_TOKEN
+        if (!token) throw new Error('MP_ACCESS_TOKEN is not configured')
+        return token
+      },
+    })
+  })
+
+  test('provider should be mercadopago_split', () => {
+    expect(gateway.provider).toBe('mercadopago_split')
+  })
+
+  describe('createConnectedAccount', () => {
+    test('should return pending result with the teamId', async () => {
+      const result = await gateway.createConnectedAccount({
+        teamId: 'team-456',
+        email: 'seller@test.com',
+        businessName: 'Test Store',
+        country: 'AR',
+      })
+
+      expect(result).toEqual({
+        id: 'pending_team-456',
+        email: 'seller@test.com',
+        chargesEnabled: false,
+        payoutsEnabled: false,
+        detailsSubmitted: false,
+        onboardingStatus: 'pending',
+      })
+    })
+  })
+
+  describe('createOnboardingLink', () => {
+    test('should construct correct OAuth URL with client_id and state', async () => {
+      const result = await gateway.createOnboardingLink({
+        externalAccountId: 'acct_mp_123',
+        returnUrl: 'https://app.com/callback',
+        refreshUrl: 'https://app.com/refresh',
+      })
+
+      expect(result.url).toContain('https://auth.mercadopago.com/authorization')
+      expect(result.url).toContain('client_id=test-app-id')
+      expect(result.url).toContain('response_type=code')
+      expect(result.url).toContain(`state=${encodeURIComponent('acct_mp_123')}`)
+      expect(result.url).toContain(`redirect_uri=${encodeURIComponent('https://app.com/callback')}`)
+    })
+
+    test('should throw when MP_APP_ID is missing', async () => {
+      delete process.env.MP_APP_ID
+
+      await expect(
+        gateway.createOnboardingLink({
+          externalAccountId: 'acct_mp_123',
+          returnUrl: 'https://app.com/callback',
+          refreshUrl: 'https://app.com/refresh',
+        })
+      ).rejects.toThrow('MP_APP_ID is not configured')
+    })
+  })
+
+  describe('createMarketplaceCheckout', () => {
+    test('should call /checkout/preferences with marketplace_fee', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          id: 'pref_test_123',
+          init_point: 'https://www.mercadopago.com/checkout/v1/redirect?pref_id=pref_test_123',
+          sandbox_init_point: 'https://sandbox.mercadopago.com/checkout/v1/redirect?pref_id=pref_test_123',
+        }),
+      } as Response)
+
+      const result = await gateway.createMarketplaceCheckout({
+        connectedAccountId: 'internal-id-123',
+        externalAccountId: 'acct_mp_seller',
+        amount: 10000,
+        currency: 'ars',
+        applicationFee: 1500,
+        referenceId: 'order-789',
+        description: 'Premium Service',
+        customerEmail: 'customer@test.com',
+        successUrl: 'https://app.com/success',
+        cancelUrl: 'https://app.com/cancel',
+      })
+
+      expect(result).toEqual({
+        id: 'pref_test_123',
+        status: 'pending',
+        url: 'https://sandbox.mercadopago.com/checkout/v1/redirect?pref_id=pref_test_123',
+      })
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        'https://api.mercadopago.com/checkout/preferences',
+        expect.objectContaining({
+          method: 'POST',
+        })
+      )
+
+      // Verify the body sent to MercadoPago
+      const callArgs = mockFetch.mock.calls[0]
+      const body = JSON.parse((callArgs[1] as RequestInit).body as string)
+
+      expect(body.marketplace_fee).toBe(1500)
+      expect(body.items).toEqual([
+        expect.objectContaining({
+          id: 'order-789',
+          title: 'Premium Service',
+          quantity: 1,
+          unit_price: 10000,
+          currency_id: 'ARS',
+        }),
+      ])
+      expect(body.back_urls).toEqual({
+        success: 'https://app.com/success',
+        failure: 'https://app.com/cancel',
+        pending: 'https://app.com/success',
+      })
+      expect(body.payer).toEqual({ email: 'customer@test.com' })
+      expect(body.external_reference).toBe('order-789')
+    })
+  })
+
+  describe('createMarketplacePayment', () => {
+    test('should call /v1/payments with marketplace_fee', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          id: 12345678,
+          status: 'approved',
+          status_detail: 'accredited',
+          transaction_amount: 5000,
+          currency_id: 'ARS',
+        }),
+      } as Response)
+
+      const result = await gateway.createMarketplacePayment({
+        connectedAccountId: 'internal-id-123',
+        externalAccountId: 'acct_mp_seller',
+        amount: 5000,
+        currency: 'ars',
+        applicationFee: 750,
+        referenceId: 'order-456',
+        description: 'Basic Service',
+        customerEmail: 'buyer@test.com',
+      })
+
+      expect(result).toEqual({
+        id: '12345678',
+        status: 'succeeded',
+        statusDetail: 'accredited',
+      })
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        'https://api.mercadopago.com/v1/payments',
+        expect.objectContaining({ method: 'POST' })
+      )
+
+      const callArgs = mockFetch.mock.calls[0]
+      const body = JSON.parse((callArgs[1] as RequestInit).body as string)
+
+      expect(body.transaction_amount).toBe(5000)
+      expect(body.marketplace_fee).toBe(750)
+      expect(body.payer).toEqual({ email: 'buyer@test.com' })
+      expect(body.external_reference).toBe('order-456')
+    })
+  })
+
+  describe('getPaymentStatus', () => {
+    test('should fetch payment and map status correctly', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          id: 99887766,
+          status: 'approved',
+          status_detail: 'accredited',
+          transaction_amount: 10000,
+          currency_id: 'ARS',
+        }),
+      } as Response)
+
+      const result = await gateway.getPaymentStatus('99887766')
+
+      expect(result).toEqual({
+        id: '99887766',
+        status: 'succeeded',
+        statusDetail: 'accredited',
+      })
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        'https://api.mercadopago.com/v1/payments/99887766',
+        expect.objectContaining({
+          headers: expect.objectContaining({
+            Authorization: 'Bearer test-platform-token',
+          }),
+        })
+      )
+    })
+
+    test('should map pending status correctly', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          id: 11223344,
+          status: 'pending',
+          status_detail: 'pending_waiting_payment',
+        }),
+      } as Response)
+
+      const result = await gateway.getPaymentStatus('11223344')
+      expect(result.status).toBe('pending')
+    })
+
+    test('should map rejected status to failed', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          id: 55667788,
+          status: 'rejected',
+          status_detail: 'cc_rejected_other_reason',
+        }),
+      } as Response)
+
+      const result = await gateway.getPaymentStatus('55667788')
+      expect(result.status).toBe('failed')
+    })
+
+    test('should throw when MP_ACCESS_TOKEN is missing', async () => {
+      delete process.env.MP_ACCESS_TOKEN
+
+      await expect(gateway.getPaymentStatus('12345')).rejects.toThrow(
+        'MP_ACCESS_TOKEN is not configured'
+      )
+    })
+  })
+
+  describe('refundPayment', () => {
+    test('should POST to /v1/payments/{id}/refunds', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          id: 111222333,
+          amount: 10000,
+          status: 'approved',
+        }),
+      } as Response)
+
+      const result = await gateway.refundPayment({
+        externalPaymentId: '99887766',
+      })
+
+      expect(result).toEqual({
+        id: '111222333',
+        amount: 10000,
+        status: 'approved',
+        feeRefunded: 0,
+      })
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        'https://api.mercadopago.com/v1/payments/99887766/refunds',
+        expect.objectContaining({ method: 'POST' })
+      )
+    })
+
+    test('should support partial refund with amount', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          id: 444555666,
+          amount: 5000,
+          status: 'approved',
+        }),
+      } as Response)
+
+      const result = await gateway.refundPayment({
+        externalPaymentId: '99887766',
+        amount: 5000,
+      })
+
+      expect(result.amount).toBe(5000)
+
+      const callArgs = mockFetch.mock.calls[0]
+      const body = JSON.parse((callArgs[1] as RequestInit).body as string)
+      expect(body.amount).toBe(5000)
+    })
+  })
+
+  describe('getAccountBalance', () => {
+    test('should return available and pending amounts', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          available_balance: 50000,
+          unavailable_balance: 12000,
+          currency_id: 'ARS',
+        }),
+      } as Response)
+
+      const result = await gateway.getAccountBalance('acct_mp_seller')
+
+      expect(result).toEqual({
+        available: 50000,
+        pending: 12000,
+        currency: 'ars',
+      })
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        'https://api.mercadopago.com/users/me/mercadopago_account/balance',
+        expect.objectContaining({
+          headers: expect.objectContaining({
+            Authorization: 'Bearer test-seller-token',
+          }),
+        })
+      )
+    })
+  })
+
+  describe('verifyWebhookSignature', () => {
+    function buildSignature(dataId: string, requestId: string, ts: string, secret: string): string {
+      const manifest = `id:${dataId};request-id:${requestId};ts:${ts};`
+      const hmac = createHmac('sha256', secret).update(manifest).digest('hex')
+      return `ts=${ts},v1=${hmac}`
+    }
+
+    test('should verify a valid signature', () => {
+      const payload = JSON.stringify({
+        id: 'webhook-event-1',
+        type: 'payment',
+        data: { id: 'pay_123' },
+        user_id: 12345,
+      })
+      const requestId = 'req-abc-123'
+      const ts = '1700000000'
+      const xSignature = buildSignature('pay_123', requestId, ts, 'test-webhook-secret')
+
+      const result = gateway.verifyWebhookSignature(payload, {
+        'x-signature': xSignature,
+        'x-request-id': requestId,
+      })
+
+      expect(result).toEqual({
+        id: 'webhook-event-1',
+        type: 'payment',
+        account: '12345',
+        data: { id: 'pay_123' },
+      })
+    })
+
+    test('should throw on invalid signature', () => {
+      const payload = JSON.stringify({
+        id: 'webhook-event-2',
+        type: 'payment',
+        data: { id: 'pay_456' },
+      })
+
+      expect(() =>
+        gateway.verifyWebhookSignature(payload, {
+          'x-signature': 'ts=1700000000,v1=invalid_hash_value',
+          'x-request-id': 'req-xyz-789',
+        })
+      ).toThrow('MercadoPago webhook signature verification failed')
+    })
+
+    test('should throw when MP_WEBHOOK_SECRET is missing', () => {
+      delete process.env.MP_WEBHOOK_SECRET
+
+      const payload = JSON.stringify({ id: '1', type: 'payment', data: { id: '2' } })
+
+      expect(() =>
+        gateway.verifyWebhookSignature(payload, {
+          'x-signature': 'ts=123,v1=abc',
+          'x-request-id': 'req-1',
+        })
+      ).toThrow('MP_WEBHOOK_SECRET is not configured')
+    })
+  })
+
+  describe('createPayout', () => {
+    test('should throw because MercadoPago handles payouts automatically', async () => {
+      await expect(
+        gateway.createPayout({
+          externalAccountId: 'acct_mp_seller',
+          amount: 1000,
+          currency: 'ars',
+        })
+      ).rejects.toThrow('MercadoPago handles payouts automatically')
+    })
+  })
+})
+
+describe('exchangeMPAuthorizationCode', () => {
+  const originalEnv = process.env
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    process.env = {
+      ...originalEnv,
+      MP_APP_ID: 'test-app-id',
+      MP_CLIENT_SECRET: 'test-client-secret',
+    }
+  })
+
+  afterEach(() => {
+    process.env = originalEnv
+  })
+
+  test('should POST to /oauth/token and return tokens', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        access_token: 'APP_USR-new-access-token',
+        refresh_token: 'TG-new-refresh-token',
+        expires_in: 15552000,
+        user_id: 987654,
+        public_key: 'APP_USR-public-key',
+      }),
+    } as Response)
+
+    const result = await exchangeMPAuthorizationCode('auth-code-xyz', 'https://app.com/callback')
+
+    expect(result).toEqual({
+      accessToken: 'APP_USR-new-access-token',
+      refreshToken: 'TG-new-refresh-token',
+      expiresIn: 15552000,
+      userId: 987654,
+      publicKey: 'APP_USR-public-key',
+    })
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      'https://api.mercadopago.com/oauth/token',
+      expect.objectContaining({
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+      })
+    )
+
+    const callArgs = mockFetch.mock.calls[0]
+    const body = JSON.parse((callArgs[1] as RequestInit).body as string)
+
+    expect(body).toEqual({
+      client_id: 'test-app-id',
+      client_secret: 'test-client-secret',
+      grant_type: 'authorization_code',
+      code: 'auth-code-xyz',
+      redirect_uri: 'https://app.com/callback',
+    })
+  })
+
+  test('should throw when MP_APP_ID or MP_CLIENT_SECRET is missing', async () => {
+    delete process.env.MP_APP_ID
+    delete process.env.MP_CLIENT_SECRET
+
+    await expect(
+      exchangeMPAuthorizationCode('code', 'https://app.com/callback')
+    ).rejects.toThrow('MP_APP_ID and MP_CLIENT_SECRET are required for OAuth')
+  })
+
+  test('should throw on non-ok response', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      text: async () => 'invalid_grant',
+    } as Response)
+
+    await expect(
+      exchangeMPAuthorizationCode('bad-code', 'https://app.com/callback')
+    ).rejects.toThrow('MercadoPago OAuth token exchange failed: invalid_grant')
+  })
+})
+
+describe('refreshMPToken', () => {
+  const originalEnv = process.env
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    process.env = {
+      ...originalEnv,
+      MP_APP_ID: 'test-app-id',
+      MP_CLIENT_SECRET: 'test-client-secret',
+    }
+  })
+
+  afterEach(() => {
+    process.env = originalEnv
+  })
+
+  test('should POST to /oauth/token with refresh_token grant', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        access_token: 'APP_USR-refreshed-token',
+        refresh_token: 'TG-new-refresh',
+        expires_in: 15552000,
+      }),
+    } as Response)
+
+    const result = await refreshMPToken('TG-old-refresh-token')
+
+    expect(result).toEqual({
+      accessToken: 'APP_USR-refreshed-token',
+      refreshToken: 'TG-new-refresh',
+      expiresIn: 15552000,
+    })
+
+    const callArgs = mockFetch.mock.calls[0]
+    const body = JSON.parse((callArgs[1] as RequestInit).body as string)
+
+    expect(body).toEqual({
+      client_id: 'test-app-id',
+      client_secret: 'test-client-secret',
+      grant_type: 'refresh_token',
+      refresh_token: 'TG-old-refresh-token',
+    })
+  })
+
+  test('should throw when MP_APP_ID or MP_CLIENT_SECRET is missing', async () => {
+    delete process.env.MP_APP_ID
+    delete process.env.MP_CLIENT_SECRET
+
+    await expect(refreshMPToken('some-token')).rejects.toThrow(
+      'MP_APP_ID and MP_CLIENT_SECRET are required for OAuth'
+    )
+  })
+
+  test('should throw on non-ok response', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      text: async () => 'invalid_refresh_token',
+    } as Response)
+
+    await expect(refreshMPToken('bad-token')).rejects.toThrow(
+      'MercadoPago token refresh failed: invalid_refresh_token'
+    )
+  })
+})

--- a/packages/core/tests/jest/lib/marketplace/mercadopago-split.test.ts
+++ b/packages/core/tests/jest/lib/marketplace/mercadopago-split.test.ts
@@ -416,6 +416,110 @@ describe('MercadoPagoSplitGateway', () => {
     })
   })
 
+  describe('createDashboardLink', () => {
+    test('should return static MercadoPago activities URL', async () => {
+      const result = await gateway.createDashboardLink('acct_mp_seller')
+
+      expect(result).toEqual({
+        url: 'https://www.mercadopago.com/activities',
+      })
+    })
+  })
+
+  describe('getAccountStatus', () => {
+    test('should call /users/me and map active status', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          id: 123456,
+          email: 'seller@test.com',
+          nickname: 'test_seller',
+          status: { site_status: 'active' },
+        }),
+      } as Response)
+
+      const result = await gateway.getAccountStatus('acct_mp_seller')
+
+      expect(result).toEqual({
+        id: '123456',
+        email: 'seller@test.com',
+        chargesEnabled: true,
+        payoutsEnabled: true,
+        detailsSubmitted: true,
+        onboardingStatus: 'active',
+      })
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        'https://api.mercadopago.com/users/me',
+        expect.objectContaining({
+          headers: expect.objectContaining({
+            Authorization: 'Bearer test-seller-token',
+          }),
+        })
+      )
+    })
+
+    test('should map non-active site_status to restricted', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          id: 789012,
+          email: 'restricted@test.com',
+          nickname: 'restricted_seller',
+          status: { site_status: 'deactive' },
+        }),
+      } as Response)
+
+      const result = await gateway.getAccountStatus('acct_mp_restricted')
+
+      expect(result).toEqual({
+        id: '789012',
+        email: 'restricted@test.com',
+        chargesEnabled: false,
+        payoutsEnabled: false,
+        detailsSubmitted: true,
+        onboardingStatus: 'restricted',
+      })
+    })
+  })
+
+  describe('mapMPPaymentStatus (via getPaymentStatus)', () => {
+    test.each([
+      ['authorized', 'processing'],
+      ['in_process', 'processing'],
+      ['in_mediation', 'disputed'],
+      ['cancelled', 'canceled'],
+      ['refunded', 'refunded'],
+      ['charged_back', 'disputed'],
+    ])('should map %s to %s', async (mpStatus, expectedStatus) => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          id: 44556677,
+          status: mpStatus,
+          status_detail: `detail_${mpStatus}`,
+        }),
+      } as Response)
+
+      const result = await gateway.getPaymentStatus('44556677')
+      expect(result.status).toBe(expectedStatus)
+    })
+
+    test('should map unknown status to failed', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          id: 99999999,
+          status: 'some_unknown_status',
+          status_detail: 'unknown',
+        }),
+      } as Response)
+
+      const result = await gateway.getPaymentStatus('99999999')
+      expect(result.status).toBe('failed')
+    })
+  })
+
   describe('createPayout', () => {
     test('should throw because MercadoPago handles payouts automatically', async () => {
       await expect(

--- a/packages/core/tests/jest/lib/marketplace/mercadopago-webhook.test.ts
+++ b/packages/core/tests/jest/lib/marketplace/mercadopago-webhook.test.ts
@@ -1,0 +1,599 @@
+/**
+ * MercadoPago Webhook Handler Tests
+ *
+ * Tests the pure logic functions used by the MP marketplace webhook handler:
+ * - Signature verification (HMAC-SHA256 algorithm)
+ * - Status mapping (MP status → MarketplacePaymentStatus)
+ * - Payment context building (marketplace detection, fees, references)
+ *
+ * NOTE: The main handleMPMarketplaceWebhook function requires NextRequest and DB,
+ * so it's tested at integration level. These tests cover the algorithmic core.
+ */
+
+import { describe, test, expect } from '@jest/globals'
+import { createHmac } from 'crypto'
+import type {
+  MPFullPayment,
+  MPPaymentContext,
+  MPWebhookNotification,
+  MPMarketplaceWebhookExtensions,
+} from '@/core/lib/marketplace/mercadopago-webhook'
+
+// ===========================================
+// Signature Verification Algorithm
+// ===========================================
+
+describe('MercadoPago Webhook Signature Verification', () => {
+  const webhookSecret = 'test-webhook-secret-123'
+
+  /**
+   * Recreates the HMAC algorithm used in verifyMPWebhookSignature.
+   * This validates our understanding of the MP signature format:
+   *   manifest = "id:{dataId};request-id:{xRequestId};ts:{ts};"
+   *   hash = HMAC-SHA256(manifest, secret)
+   */
+  function computeSignature(params: {
+    dataId?: string
+    xRequestId?: string
+    ts?: string
+    secret: string
+  }): string {
+    let manifest = ''
+    if (params.dataId) manifest += `id:${params.dataId};`
+    if (params.xRequestId) manifest += `request-id:${params.xRequestId};`
+    if (params.ts) manifest += `ts:${params.ts};`
+
+    return createHmac('sha256', params.secret).update(manifest).digest('hex')
+  }
+
+  test('should produce correct HMAC for known inputs', () => {
+    const dataId = '12345'
+    const requestId = 'req-abc-123'
+    const ts = '1700000000'
+
+    const manifest = `id:${dataId};request-id:${requestId};ts:${ts};`
+    const hmac = createHmac('sha256', webhookSecret).update(manifest).digest('hex')
+
+    expect(manifest).toBe('id:12345;request-id:req-abc-123;ts:1700000000;')
+    expect(hmac).toHaveLength(64) // SHA-256 hex = 64 chars
+  })
+
+  test('should produce different HMAC for different timestamps', () => {
+    const hmac1 = computeSignature({
+      dataId: '12345',
+      xRequestId: 'req-1',
+      ts: '1000',
+      secret: webhookSecret,
+    })
+    const hmac2 = computeSignature({
+      dataId: '12345',
+      xRequestId: 'req-1',
+      ts: '1001',
+      secret: webhookSecret,
+    })
+
+    expect(hmac1).not.toBe(hmac2)
+  })
+
+  test('should produce different HMAC for different data IDs', () => {
+    const hmac1 = computeSignature({
+      dataId: '12345',
+      xRequestId: 'req-1',
+      ts: '1000',
+      secret: webhookSecret,
+    })
+    const hmac2 = computeSignature({
+      dataId: '99999',
+      xRequestId: 'req-1',
+      ts: '1000',
+      secret: webhookSecret,
+    })
+
+    expect(hmac1).not.toBe(hmac2)
+  })
+
+  test('should produce different HMAC for different secrets', () => {
+    const params = { dataId: '12345', xRequestId: 'req-1', ts: '1000' }
+
+    const hmac1 = computeSignature({ ...params, secret: 'secret-a' })
+    const hmac2 = computeSignature({ ...params, secret: 'secret-b' })
+
+    expect(hmac1).not.toBe(hmac2)
+  })
+
+  test('should produce deterministic HMAC for same inputs', () => {
+    const params = {
+      dataId: '12345',
+      xRequestId: 'req-1',
+      ts: '1000',
+      secret: webhookSecret,
+    }
+
+    const hmac1 = computeSignature(params)
+    const hmac2 = computeSignature(params)
+
+    expect(hmac1).toBe(hmac2)
+  })
+
+  test('manifest should only include present parts', () => {
+    // With all parts
+    const manifestFull = 'id:123;request-id:req-1;ts:1000;'
+    const hmacFull = createHmac('sha256', webhookSecret).update(manifestFull).digest('hex')
+
+    // Without request-id
+    const manifestNoReqId = 'id:123;ts:1000;'
+    const hmacNoReqId = createHmac('sha256', webhookSecret).update(manifestNoReqId).digest('hex')
+
+    expect(hmacFull).not.toBe(hmacNoReqId)
+
+    // Verify our computeSignature helper matches
+    expect(computeSignature({ dataId: '123', xRequestId: 'req-1', ts: '1000', secret: webhookSecret }))
+      .toBe(hmacFull)
+    expect(computeSignature({ dataId: '123', ts: '1000', secret: webhookSecret }))
+      .toBe(hmacNoReqId)
+  })
+
+  test('x-signature header should be parseable as ts=...,v1=... format', () => {
+    const ts = '1700000000'
+    const hash = computeSignature({
+      dataId: '12345',
+      xRequestId: 'req-abc',
+      ts,
+      secret: webhookSecret,
+    })
+
+    // Build x-signature header the way MP sends it
+    const xSignature = `ts=${ts},v1=${hash}`
+
+    // Parse it the same way the handler does
+    const parts: Record<string, string> = {}
+    xSignature.split(',').forEach((segment) => {
+      const eqIndex = segment.indexOf('=')
+      if (eqIndex > 0) {
+        const key = segment.substring(0, eqIndex).trim()
+        const value = segment.substring(eqIndex + 1).trim()
+        parts[key] = value
+      }
+    })
+
+    expect(parts['ts']).toBe(ts)
+    expect(parts['v1']).toBe(hash)
+    expect(parts['v1']).toHaveLength(64)
+  })
+
+  test('should handle v1 hash containing = characters', () => {
+    // SHA-256 hex output never contains '=' but test robustness of parsing
+    // The parser uses indexOf('=') and substring, not split('=')
+    const xSignature = 'ts=12345,v1=abc123def456'
+
+    const parts: Record<string, string> = {}
+    xSignature.split(',').forEach((segment) => {
+      const eqIndex = segment.indexOf('=')
+      if (eqIndex > 0) {
+        const key = segment.substring(0, eqIndex).trim()
+        const value = segment.substring(eqIndex + 1).trim()
+        parts[key] = value
+      }
+    })
+
+    expect(parts['ts']).toBe('12345')
+    expect(parts['v1']).toBe('abc123def456')
+  })
+})
+
+// ===========================================
+// Status Mapping
+// ===========================================
+
+describe('MercadoPago Status Mapping', () => {
+  /**
+   * Recreates the status mapping from mapMPStatus.
+   * This ensures our mapping matches what the handler uses.
+   */
+  const statusMap: Record<string, string> = {
+    pending: 'pending',
+    approved: 'succeeded',
+    authorized: 'processing',
+    in_process: 'processing',
+    in_mediation: 'disputed',
+    rejected: 'failed',
+    cancelled: 'canceled',
+    refunded: 'refunded',
+    charged_back: 'disputed',
+  }
+
+  test.each(Object.entries(statusMap))(
+    'MP status "%s" should map to "%s"',
+    (mpStatus, expectedStatus) => {
+      // Apply the same logic as mapMPStatus
+      const mapped = statusMap[mpStatus] || 'failed'
+      expect(mapped).toBe(expectedStatus)
+    }
+  )
+
+  test('unknown status should default to "failed"', () => {
+    const mapped = statusMap['unknown_status'] || 'failed'
+    expect(mapped).toBe('failed')
+  })
+
+  test('empty status should default to "failed"', () => {
+    const mapped = statusMap[''] || 'failed'
+    expect(mapped).toBe('failed')
+  })
+
+  test('should cover all standard MercadoPago payment statuses', () => {
+    // These are ALL payment statuses documented by MercadoPago
+    const allMPStatuses = [
+      'pending',
+      'approved',
+      'authorized',
+      'in_process',
+      'in_mediation',
+      'rejected',
+      'cancelled',
+      'refunded',
+      'charged_back',
+    ]
+
+    for (const status of allMPStatuses) {
+      expect(statusMap[status]).toBeDefined()
+    }
+  })
+
+  test('disputed statuses should both map to "disputed"', () => {
+    expect(statusMap['in_mediation']).toBe('disputed')
+    expect(statusMap['charged_back']).toBe('disputed')
+  })
+
+  test('processing statuses should both map to "processing"', () => {
+    expect(statusMap['authorized']).toBe('processing')
+    expect(statusMap['in_process']).toBe('processing')
+  })
+})
+
+// ===========================================
+// Payment Context Building
+// ===========================================
+
+describe('MercadoPago Payment Context Building', () => {
+  /**
+   * Recreates the buildPaymentContext logic from the handler.
+   * This lets us test marketplace detection, fee extraction, and reference resolution.
+   */
+  function buildPaymentContext(payment: MPFullPayment): MPPaymentContext {
+    const statusMap: Record<string, string> = {
+      pending: 'pending',
+      approved: 'succeeded',
+      authorized: 'processing',
+      in_process: 'processing',
+      in_mediation: 'disputed',
+      rejected: 'failed',
+      cancelled: 'canceled',
+      refunded: 'refunded',
+      charged_back: 'disputed',
+    }
+
+    const applicationFeeEntry = payment.fee_details?.find(f => f.type === 'application_fee')
+    const providerFeeEntry = payment.fee_details?.find(f => f.type === 'mercadopago_fee')
+
+    const applicationFee = applicationFeeEntry?.amount ?? 0
+    const providerFee = providerFeeEntry?.amount ?? 0
+    const netAmount = payment.transaction_details?.net_received_amount
+      ?? (payment.transaction_amount - applicationFee - providerFee)
+
+    const isMarketplacePayment = payment.marketplace_owner !== null || applicationFee > 0
+
+    return {
+      referenceId: payment.external_reference ?? payment.metadata?.referenceId ?? null,
+      connectedAccountId: payment.metadata?.connectedAccountId ?? null,
+      sellerUserId: payment.collector_id,
+      isMarketplacePayment,
+      applicationFee,
+      providerFee,
+      netAmount,
+      mappedStatus: (statusMap[payment.status] || 'failed') as MPPaymentContext['mappedStatus'],
+    }
+  }
+
+  /** Helper to create a minimal valid payment */
+  function makePayment(overrides: Partial<MPFullPayment> = {}): MPFullPayment {
+    return {
+      id: 12345,
+      status: 'approved',
+      status_detail: 'accredited',
+      transaction_amount: 10000,
+      currency_id: 'ARS',
+      description: 'Test payment',
+      payment_method_id: 'visa',
+      payment_type_id: 'credit_card',
+      date_approved: '2025-06-15T10:30:00.000-03:00',
+      date_created: '2025-06-15T10:29:55.000-03:00',
+      external_reference: null,
+      collector_id: 98765,
+      payer: { id: 54321, email: 'buyer@test.com', type: 'customer' },
+      fee_details: [],
+      transaction_details: null,
+      metadata: null,
+      marketplace_owner: null,
+      installments: 1,
+      refunds: null,
+      ...overrides,
+    }
+  }
+
+  describe('marketplace detection', () => {
+    test('payment with marketplace_owner set should be detected as marketplace', () => {
+      const payment = makePayment({ marketplace_owner: 111222 })
+      const context = buildPaymentContext(payment)
+
+      expect(context.isMarketplacePayment).toBe(true)
+    })
+
+    test('payment with application_fee in fee_details should be detected as marketplace', () => {
+      const payment = makePayment({
+        fee_details: [
+          { type: 'mercadopago_fee', amount: 450, fee_payer: 'collector' },
+          { type: 'application_fee', amount: 1500, fee_payer: 'collector' },
+        ],
+      })
+      const context = buildPaymentContext(payment)
+
+      expect(context.isMarketplacePayment).toBe(true)
+    })
+
+    test('payment with both marketplace_owner AND application_fee should be marketplace', () => {
+      const payment = makePayment({
+        marketplace_owner: 111222,
+        fee_details: [
+          { type: 'application_fee', amount: 1500, fee_payer: 'collector' },
+        ],
+      })
+      const context = buildPaymentContext(payment)
+
+      expect(context.isMarketplacePayment).toBe(true)
+    })
+
+    test('regular payment (no marketplace_owner, no application_fee) should NOT be marketplace', () => {
+      const payment = makePayment({
+        marketplace_owner: null,
+        fee_details: [
+          { type: 'mercadopago_fee', amount: 450, fee_payer: 'collector' },
+        ],
+      })
+      const context = buildPaymentContext(payment)
+
+      expect(context.isMarketplacePayment).toBe(false)
+    })
+
+    test('payment with empty fee_details and null marketplace_owner should NOT be marketplace', () => {
+      const payment = makePayment({
+        marketplace_owner: null,
+        fee_details: [],
+      })
+      const context = buildPaymentContext(payment)
+
+      expect(context.isMarketplacePayment).toBe(false)
+    })
+  })
+
+  describe('fee extraction', () => {
+    test('should extract application_fee from fee_details', () => {
+      const payment = makePayment({
+        fee_details: [
+          { type: 'mercadopago_fee', amount: 450, fee_payer: 'collector' },
+          { type: 'application_fee', amount: 1500, fee_payer: 'collector' },
+        ],
+      })
+      const context = buildPaymentContext(payment)
+
+      expect(context.applicationFee).toBe(1500)
+    })
+
+    test('should extract mercadopago_fee from fee_details', () => {
+      const payment = makePayment({
+        fee_details: [
+          { type: 'mercadopago_fee', amount: 450, fee_payer: 'collector' },
+          { type: 'application_fee', amount: 1500, fee_payer: 'collector' },
+        ],
+      })
+      const context = buildPaymentContext(payment)
+
+      expect(context.providerFee).toBe(450)
+    })
+
+    test('should default fees to 0 when not present', () => {
+      const payment = makePayment({ fee_details: [] })
+      const context = buildPaymentContext(payment)
+
+      expect(context.applicationFee).toBe(0)
+      expect(context.providerFee).toBe(0)
+    })
+  })
+
+  describe('net amount calculation', () => {
+    test('should use transaction_details.net_received_amount when available', () => {
+      const payment = makePayment({
+        transaction_amount: 10000,
+        transaction_details: {
+          net_received_amount: 8050,
+          total_paid_amount: 10000,
+          overpaid_amount: 0,
+          installment_amount: 10000,
+        },
+        fee_details: [
+          { type: 'mercadopago_fee', amount: 450, fee_payer: 'collector' },
+          { type: 'application_fee', amount: 1500, fee_payer: 'collector' },
+        ],
+      })
+      const context = buildPaymentContext(payment)
+
+      // Should use net_received_amount from transaction_details, not calculate
+      expect(context.netAmount).toBe(8050)
+    })
+
+    test('should calculate net amount when transaction_details is null', () => {
+      const payment = makePayment({
+        transaction_amount: 10000,
+        transaction_details: null,
+        fee_details: [
+          { type: 'mercadopago_fee', amount: 450, fee_payer: 'collector' },
+          { type: 'application_fee', amount: 1500, fee_payer: 'collector' },
+        ],
+      })
+      const context = buildPaymentContext(payment)
+
+      // 10000 - 1500 - 450 = 8050
+      expect(context.netAmount).toBe(8050)
+    })
+
+    test('net amount should equal transaction_amount when no fees', () => {
+      const payment = makePayment({
+        transaction_amount: 5000,
+        transaction_details: null,
+        fee_details: [],
+      })
+      const context = buildPaymentContext(payment)
+
+      expect(context.netAmount).toBe(5000)
+    })
+  })
+
+  describe('reference resolution', () => {
+    test('should use external_reference when available', () => {
+      const payment = makePayment({
+        external_reference: 'booking-123',
+        metadata: { referenceId: 'meta-456' },
+      })
+      const context = buildPaymentContext(payment)
+
+      expect(context.referenceId).toBe('booking-123')
+    })
+
+    test('should fall back to metadata.referenceId when external_reference is null', () => {
+      const payment = makePayment({
+        external_reference: null,
+        metadata: { referenceId: 'meta-456' },
+      })
+      const context = buildPaymentContext(payment)
+
+      expect(context.referenceId).toBe('meta-456')
+    })
+
+    test('should be null when no reference is available', () => {
+      const payment = makePayment({
+        external_reference: null,
+        metadata: null,
+      })
+      const context = buildPaymentContext(payment)
+
+      expect(context.referenceId).toBeNull()
+    })
+
+    test('should extract connectedAccountId from metadata', () => {
+      const payment = makePayment({
+        metadata: { connectedAccountId: 'ca-789', referenceId: 'ref-1' },
+      })
+      const context = buildPaymentContext(payment)
+
+      expect(context.connectedAccountId).toBe('ca-789')
+    })
+
+    test('connectedAccountId should be null when not in metadata', () => {
+      const payment = makePayment({ metadata: null })
+      const context = buildPaymentContext(payment)
+
+      expect(context.connectedAccountId).toBeNull()
+    })
+  })
+
+  describe('status mapping in context', () => {
+    test('approved payment should map to "succeeded"', () => {
+      const payment = makePayment({ status: 'approved' })
+      const context = buildPaymentContext(payment)
+
+      expect(context.mappedStatus).toBe('succeeded')
+    })
+
+    test('pending payment should map to "pending"', () => {
+      const payment = makePayment({ status: 'pending' })
+      const context = buildPaymentContext(payment)
+
+      expect(context.mappedStatus).toBe('pending')
+    })
+
+    test('rejected payment should map to "failed"', () => {
+      const payment = makePayment({ status: 'rejected' })
+      const context = buildPaymentContext(payment)
+
+      expect(context.mappedStatus).toBe('failed')
+    })
+
+    test('charged_back payment should map to "disputed"', () => {
+      const payment = makePayment({ status: 'charged_back' })
+      const context = buildPaymentContext(payment)
+
+      expect(context.mappedStatus).toBe('disputed')
+    })
+  })
+
+  describe('seller identification', () => {
+    test('should set sellerUserId from collector_id', () => {
+      const payment = makePayment({ collector_id: 555888 })
+      const context = buildPaymentContext(payment)
+
+      expect(context.sellerUserId).toBe(555888)
+    })
+  })
+})
+
+// ===========================================
+// Type Validation (compile-time checks)
+// ===========================================
+
+describe('MercadoPago Webhook Types', () => {
+  test('MPWebhookNotification should have required fields', () => {
+    const notification: MPWebhookNotification = {
+      id: 1,
+      live_mode: true,
+      type: 'payment',
+      date_created: '2025-06-15T10:00:00.000Z',
+      user_id: 12345,
+      api_version: 'v1',
+      action: 'payment.created',
+      data: { id: '67890' },
+    }
+
+    expect(notification.type).toBe('payment')
+    expect(notification.data.id).toBe('67890')
+    expect(notification.action).toBe('payment.created')
+  })
+
+  test('MPMarketplaceWebhookExtensions should allow all optional hooks', () => {
+    const extensions: MPMarketplaceWebhookExtensions = {
+      onPaymentApproved: async () => {},
+      onPaymentRejected: async () => {},
+      onPaymentPending: async () => {},
+      onChargeBack: async () => {},
+      onPaymentRefunded: async () => {},
+      onPaymentCancelled: async () => {},
+      onPaymentInMediation: async () => {},
+      onPaymentUpdated: async () => {},
+    }
+
+    // All hooks should be defined
+    expect(extensions.onPaymentApproved).toBeDefined()
+    expect(extensions.onPaymentRejected).toBeDefined()
+    expect(extensions.onPaymentPending).toBeDefined()
+    expect(extensions.onChargeBack).toBeDefined()
+    expect(extensions.onPaymentRefunded).toBeDefined()
+    expect(extensions.onPaymentCancelled).toBeDefined()
+    expect(extensions.onPaymentInMediation).toBeDefined()
+    expect(extensions.onPaymentUpdated).toBeDefined()
+  })
+
+  test('MPMarketplaceWebhookExtensions should allow empty object', () => {
+    const extensions: MPMarketplaceWebhookExtensions = {}
+
+    expect(extensions.onPaymentApproved).toBeUndefined()
+  })
+})

--- a/packages/core/tests/jest/lib/marketplace/refresh-mp-tokens.test.ts
+++ b/packages/core/tests/jest/lib/marketplace/refresh-mp-tokens.test.ts
@@ -1,0 +1,260 @@
+/**
+ * Unit Tests: Refresh MercadoPago OAuth Tokens Handler
+ *
+ * Tests the scheduled action that proactively refreshes expiring
+ * MercadoPago OAuth tokens for connected seller accounts.
+ */
+
+import { describe, test, expect, beforeEach, afterEach, jest } from '@jest/globals'
+
+// --- Mocks ---
+
+// Mock the DB module
+const mockQueryWithRLS = jest.fn() as jest.MockedFunction<typeof import('@/core/lib/db').queryWithRLS>
+const mockMutateWithRLS = jest.fn() as jest.MockedFunction<typeof import('@/core/lib/db').mutateWithRLS>
+
+jest.mock('@/core/lib/db', () => ({
+  queryWithRLS: (...args: unknown[]) => mockQueryWithRLS(...args as Parameters<typeof mockQueryWithRLS>),
+  mutateWithRLS: (...args: unknown[]) => mockMutateWithRLS(...args as Parameters<typeof mockMutateWithRLS>),
+}))
+
+// Mock refreshMPToken
+const mockRefreshMPToken = jest.fn() as jest.MockedFunction<typeof import('@/core/lib/marketplace/gateways/mercadopago-split').refreshMPToken>
+
+jest.mock('@/core/lib/marketplace/gateways/mercadopago-split', () => ({
+  refreshMPToken: (...args: unknown[]) => mockRefreshMPToken(...args as Parameters<typeof mockRefreshMPToken>),
+}))
+
+// Mock token encryption
+const mockDecryptToken = jest.fn() as jest.MockedFunction<typeof import('@/core/lib/marketplace/token-encryption').decryptToken>
+const mockEncryptTokens = jest.fn() as jest.MockedFunction<typeof import('@/core/lib/marketplace/token-encryption').encryptTokens>
+
+jest.mock('@/core/lib/marketplace/token-encryption', () => ({
+  decryptToken: (...args: unknown[]) => mockDecryptToken(...args as Parameters<typeof mockDecryptToken>),
+  encryptTokens: (...args: unknown[]) => mockEncryptTokens(...args as Parameters<typeof mockEncryptTokens>),
+}))
+
+// Mock the registry (prevent console output)
+jest.mock('@/core/lib/scheduled-actions/registry', () => ({
+  registerScheduledAction: jest.fn(),
+}))
+
+import { refreshMPTokensHandler, registerRefreshMPTokensHandler } from '@/core/lib/marketplace/handlers/refresh-mp-tokens'
+import { registerScheduledAction } from '@/core/lib/scheduled-actions/registry'
+
+describe('refreshMPTokensHandler', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  afterEach(() => {
+    jest.restoreAllMocks()
+  })
+
+  test('should return zeros when no accounts have expiring tokens', async () => {
+    mockQueryWithRLS.mockResolvedValueOnce([] as never)
+
+    const result = await refreshMPTokensHandler()
+
+    expect(result).toEqual({
+      refreshed: 0,
+      failed: 0,
+      skipped: 0,
+      errors: [],
+    })
+    expect(mockQueryWithRLS).toHaveBeenCalledTimes(1)
+    // Verify the query targets mercadopago_split active accounts
+    expect(mockQueryWithRLS).toHaveBeenCalledWith(
+      expect.stringContaining("provider = 'mercadopago_split'"),
+      expect.any(Array),
+      null
+    )
+  })
+
+  test('should refresh tokens for accounts expiring within 30 days', async () => {
+    const expiringAccount = {
+      id: 'ca-001',
+      teamId: 'team-123',
+      externalAccountId: 'mp-ext-001',
+      metadata: {
+        mpTokens: {
+          accessToken: 'encrypted-access-token',
+          refreshToken: 'encrypted-refresh-token',
+          expiresAt: new Date(Date.now() + 15 * 24 * 60 * 60 * 1000).toISOString(), // 15 days from now
+          publicKey: 'TEST-public-key',
+        },
+      },
+    }
+
+    mockQueryWithRLS.mockResolvedValueOnce([expiringAccount] as never)
+    mockDecryptToken.mockReturnValue('decrypted-refresh-token')
+    mockRefreshMPToken.mockResolvedValueOnce({
+      accessToken: 'new-access-token',
+      refreshToken: 'new-refresh-token',
+      expiresIn: 15552000, // ~180 days in seconds
+    })
+    mockEncryptTokens.mockReturnValueOnce({
+      accessToken: 'encrypted-new-access',
+      refreshToken: 'encrypted-new-refresh',
+      expiresAt: expect.any(String) as unknown as string,
+      publicKey: 'TEST-public-key',
+    })
+    mockMutateWithRLS.mockResolvedValueOnce(undefined as never)
+
+    const result = await refreshMPTokensHandler()
+
+    expect(result.refreshed).toBe(1)
+    expect(result.failed).toBe(0)
+    expect(result.skipped).toBe(0)
+    expect(result.errors).toHaveLength(0)
+
+    // Verify decrypt was called with the stored refresh token
+    expect(mockDecryptToken).toHaveBeenCalledWith('encrypted-refresh-token')
+
+    // Verify refreshMPToken was called with decrypted token
+    expect(mockRefreshMPToken).toHaveBeenCalledWith('decrypted-refresh-token')
+
+    // Verify new tokens were encrypted before storage
+    expect(mockEncryptTokens).toHaveBeenCalledWith(
+      expect.objectContaining({
+        accessToken: 'new-access-token',
+        refreshToken: 'new-refresh-token',
+        publicKey: 'TEST-public-key',
+      })
+    )
+
+    // Verify DB update was called
+    expect(mockMutateWithRLS).toHaveBeenCalledWith(
+      expect.stringContaining('UPDATE "connectedAccounts"'),
+      expect.arrayContaining(['ca-001']),
+      null
+    )
+  })
+
+  test('should skip accounts with missing refresh tokens', async () => {
+    const accountNoRefresh = {
+      id: 'ca-002',
+      teamId: 'team-456',
+      externalAccountId: 'mp-ext-002',
+      metadata: {
+        mpTokens: {
+          accessToken: 'encrypted-access',
+          refreshToken: '', // empty
+          expiresAt: new Date(Date.now() + 10 * 24 * 60 * 60 * 1000).toISOString(),
+          publicKey: 'pk',
+        },
+      },
+    }
+
+    mockQueryWithRLS.mockResolvedValueOnce([accountNoRefresh] as never)
+
+    const result = await refreshMPTokensHandler()
+
+    expect(result.skipped).toBe(1)
+    expect(result.refreshed).toBe(0)
+    expect(result.failed).toBe(0)
+    expect(mockRefreshMPToken).not.toHaveBeenCalled()
+  })
+
+  test('should continue processing when one account fails', async () => {
+    const account1 = {
+      id: 'ca-fail',
+      teamId: 'team-1',
+      externalAccountId: 'mp-1',
+      metadata: {
+        mpTokens: {
+          accessToken: 'enc-a1',
+          refreshToken: 'enc-r1',
+          expiresAt: new Date(Date.now() + 5 * 24 * 60 * 60 * 1000).toISOString(),
+          publicKey: 'pk1',
+        },
+      },
+    }
+    const account2 = {
+      id: 'ca-ok',
+      teamId: 'team-2',
+      externalAccountId: 'mp-2',
+      metadata: {
+        mpTokens: {
+          accessToken: 'enc-a2',
+          refreshToken: 'enc-r2',
+          expiresAt: new Date(Date.now() + 10 * 24 * 60 * 60 * 1000).toISOString(),
+          publicKey: 'pk2',
+        },
+      },
+    }
+
+    mockQueryWithRLS.mockResolvedValueOnce([account1, account2] as never)
+
+    // First call to decryptToken (for account1) throws
+    mockDecryptToken
+      .mockImplementationOnce(() => { throw new Error('Decryption failed') })
+      .mockReturnValueOnce('decrypted-r2')
+
+    mockRefreshMPToken.mockResolvedValueOnce({
+      accessToken: 'new-a2',
+      refreshToken: 'new-r2',
+      expiresIn: 15552000,
+    })
+    mockEncryptTokens.mockReturnValueOnce({
+      accessToken: 'enc-new-a2',
+      refreshToken: 'enc-new-r2',
+      expiresAt: 'some-date',
+      publicKey: 'pk2',
+    })
+    mockMutateWithRLS.mockResolvedValueOnce(undefined as never)
+
+    const result = await refreshMPTokensHandler()
+
+    expect(result.refreshed).toBe(1)
+    expect(result.failed).toBe(1)
+    expect(result.errors).toHaveLength(1)
+    expect(result.errors[0]).toContain('ca-fail')
+    expect(result.errors[0]).toContain('Decryption failed')
+  })
+
+  test('should handle MercadoPago API refresh failure gracefully', async () => {
+    const account = {
+      id: 'ca-api-fail',
+      teamId: 'team-3',
+      externalAccountId: 'mp-3',
+      metadata: {
+        mpTokens: {
+          accessToken: 'enc-a3',
+          refreshToken: 'enc-r3',
+          expiresAt: new Date(Date.now() + 20 * 24 * 60 * 60 * 1000).toISOString(),
+          publicKey: 'pk3',
+        },
+      },
+    }
+
+    mockQueryWithRLS.mockResolvedValueOnce([account] as never)
+    mockDecryptToken.mockReturnValue('decrypted-r3')
+    mockRefreshMPToken.mockRejectedValueOnce(
+      new Error('MercadoPago token refresh failed: 401 Unauthorized')
+    )
+
+    const result = await refreshMPTokensHandler()
+
+    expect(result.refreshed).toBe(0)
+    expect(result.failed).toBe(1)
+    expect(result.errors[0]).toContain('401 Unauthorized')
+    // DB should not have been updated
+    expect(mockMutateWithRLS).not.toHaveBeenCalled()
+  })
+})
+
+describe('registerRefreshMPTokensHandler', () => {
+  test('should register the handler with the scheduled actions registry', () => {
+    registerRefreshMPTokensHandler()
+
+    expect(registerScheduledAction).toHaveBeenCalledWith(
+      'marketplace:refresh-mp-tokens',
+      expect.any(Function),
+      {
+        description: 'Refresh MercadoPago OAuth tokens expiring within 30 days',
+        timeout: 120000,
+      }
+    )
+  })
+})

--- a/packages/core/tests/jest/lib/marketplace/stripe-connect-webhook.test.ts
+++ b/packages/core/tests/jest/lib/marketplace/stripe-connect-webhook.test.ts
@@ -1,0 +1,662 @@
+/**
+ * Stripe Connect Webhook Handler Tests
+ */
+
+import { describe, test, expect, beforeEach, afterEach, jest } from '@jest/globals'
+import type { NextRequest } from 'next/server'
+
+// Mock Stripe SDK
+const mockWebhooksConstructEvent = jest.fn()
+
+jest.mock('stripe', () => {
+  return jest.fn().mockImplementation(() => ({
+    webhooks: { constructEvent: mockWebhooksConstructEvent },
+  }))
+})
+
+// Mock DB
+const mockQuery = jest.fn()
+const mockQueryOne = jest.fn()
+
+jest.mock('@/core/lib/db', () => ({
+  query: (...args: any[]) => mockQuery(...args),
+  queryOne: (...args: any[]) => mockQueryOne(...args),
+}))
+
+import { handleStripeConnectWebhook, type StripeConnectWebhookExtensions } from '@/core/lib/marketplace/stripe-connect-webhook'
+
+// ============================================================
+// HELPERS
+// ============================================================
+
+function createMockRequest(payload: string, signature: string | null): NextRequest {
+  return {
+    text: jest.fn().mockResolvedValue(payload),
+    headers: {
+      get: (name: string) => (name === 'stripe-signature' ? signature : null),
+    },
+  } as unknown as NextRequest
+}
+
+function createMockStripeEvent(type: string, data: any, account: string = 'acct_test') {
+  return {
+    id: 'evt_test_' + Math.random().toString(36).slice(2),
+    type,
+    account,
+    data: { object: data },
+  }
+}
+
+// ============================================================
+// TESTS
+// ============================================================
+
+describe('handleStripeConnectWebhook', () => {
+  const originalEnv = process.env
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    process.env = {
+      ...originalEnv,
+      STRIPE_SECRET_KEY: 'sk_test_mock',
+      STRIPE_CONNECT_WEBHOOK_SECRET: 'whsec_connect_mock',
+    }
+    // Default: no duplicate events
+    mockQueryOne.mockResolvedValue(null)
+    // Default: queries succeed
+    mockQuery.mockResolvedValue({ rows: [], rowCount: 0 })
+  })
+
+  afterEach(() => {
+    process.env = originalEnv
+  })
+
+  // ----------------------------------------------------------
+  // 1. Signature verification
+  // ----------------------------------------------------------
+  describe('signature verification', () => {
+    test('returns 400 with no signature header', async () => {
+      const req = createMockRequest('{}', null)
+
+      const res = await handleStripeConnectWebhook(req)
+
+      expect(res.status).toBe(400)
+      const body = await res.json()
+      expect(body.error).toMatch(/no signature/i)
+    })
+
+    test('returns 400 on invalid signature', async () => {
+      mockWebhooksConstructEvent.mockImplementation(() => {
+        throw new Error('Signature verification failed')
+      })
+
+      const req = createMockRequest('{}', 'sig_invalid')
+
+      const res = await handleStripeConnectWebhook(req)
+
+      expect(res.status).toBe(400)
+      const body = await res.json()
+      expect(body.error).toMatch(/invalid signature/i)
+    })
+
+    test('returns 500 when STRIPE_CONNECT_WEBHOOK_SECRET is missing', async () => {
+      delete process.env.STRIPE_CONNECT_WEBHOOK_SECRET
+
+      const req = createMockRequest('{}', 'sig_test')
+
+      const res = await handleStripeConnectWebhook(req)
+
+      expect(res.status).toBe(500)
+      const body = await res.json()
+      expect(body.error).toMatch(/not configured/i)
+    })
+  })
+
+  // ----------------------------------------------------------
+  // 2. Idempotency
+  // ----------------------------------------------------------
+  describe('idempotency', () => {
+    test('returns 200 with duplicate status for already-processed events', async () => {
+      const event = createMockStripeEvent('account.updated', { id: 'acct_123' })
+      mockWebhooksConstructEvent.mockReturnValue(event)
+      mockQueryOne.mockResolvedValue({ id: 'existing-row-id' })
+
+      const req = createMockRequest('{}', 'sig_valid')
+
+      const res = await handleStripeConnectWebhook(req)
+
+      expect(res.status).toBe(200)
+      const body = await res.json()
+      expect(body.status).toBe('duplicate')
+      expect(body.received).toBe(true)
+    })
+
+    test('processes new events normally', async () => {
+      const event = createMockStripeEvent('account.updated', {
+        id: 'acct_new',
+        charges_enabled: true,
+        payouts_enabled: true,
+        details_submitted: true,
+        requirements: { disabled_reason: null, past_due: [] },
+      })
+      mockWebhooksConstructEvent.mockReturnValue(event)
+      mockQueryOne.mockResolvedValue(null)
+
+      const req = createMockRequest('{}', 'sig_valid')
+
+      const res = await handleStripeConnectWebhook(req)
+
+      expect(res.status).toBe(200)
+      const body = await res.json()
+      expect(body.received).toBe(true)
+      expect(body.status).toBeUndefined()
+      // Should have inserted the webhook event row
+      expect(mockQuery).toHaveBeenCalledWith(
+        expect.stringContaining('INSERT INTO "marketplaceWebhookEvents"'),
+        expect.arrayContaining([event.id])
+      )
+    })
+  })
+
+  // ----------------------------------------------------------
+  // 3. account.updated
+  // ----------------------------------------------------------
+  describe('account.updated', () => {
+    test('updates connectedAccount with chargesEnabled, payoutsEnabled, onboardingStatus', async () => {
+      const account = {
+        id: 'acct_seller1',
+        charges_enabled: true,
+        payouts_enabled: true,
+        details_submitted: true,
+        requirements: { disabled_reason: null, past_due: [] },
+      }
+      const event = createMockStripeEvent('account.updated', account)
+      mockWebhooksConstructEvent.mockReturnValue(event)
+
+      const req = createMockRequest('{}', 'sig_valid')
+      await handleStripeConnectWebhook(req)
+
+      // The UPDATE call for connectedAccounts
+      expect(mockQuery).toHaveBeenCalledWith(
+        expect.stringContaining('UPDATE "connectedAccounts"'),
+        ['active', true, true, 'acct_seller1']
+      )
+    })
+
+    test('maps status to active when charges and payouts enabled', async () => {
+      const account = {
+        id: 'acct_active',
+        charges_enabled: true,
+        payouts_enabled: true,
+        details_submitted: true,
+        requirements: { disabled_reason: null, past_due: [] },
+      }
+      const event = createMockStripeEvent('account.updated', account)
+      mockWebhooksConstructEvent.mockReturnValue(event)
+
+      const req = createMockRequest('{}', 'sig_valid')
+      await handleStripeConnectWebhook(req)
+
+      expect(mockQuery).toHaveBeenCalledWith(
+        expect.stringContaining('UPDATE "connectedAccounts"'),
+        expect.arrayContaining(['active'])
+      )
+    })
+
+    test('maps status to restricted when past_due requirements exist', async () => {
+      const account = {
+        id: 'acct_restricted',
+        charges_enabled: true,
+        payouts_enabled: false,
+        details_submitted: true,
+        requirements: {
+          disabled_reason: null,
+          past_due: ['individual.verification.document'],
+        },
+      }
+      const event = createMockStripeEvent('account.updated', account)
+      mockWebhooksConstructEvent.mockReturnValue(event)
+
+      const req = createMockRequest('{}', 'sig_valid')
+      await handleStripeConnectWebhook(req)
+
+      expect(mockQuery).toHaveBeenCalledWith(
+        expect.stringContaining('UPDATE "connectedAccounts"'),
+        expect.arrayContaining(['restricted'])
+      )
+    })
+
+    test('maps status to disabled when disabled_reason is set', async () => {
+      const account = {
+        id: 'acct_disabled',
+        charges_enabled: false,
+        payouts_enabled: false,
+        details_submitted: true,
+        requirements: {
+          disabled_reason: 'rejected.fraud',
+          past_due: [],
+        },
+      }
+      const event = createMockStripeEvent('account.updated', account)
+      mockWebhooksConstructEvent.mockReturnValue(event)
+
+      const req = createMockRequest('{}', 'sig_valid')
+      await handleStripeConnectWebhook(req)
+
+      expect(mockQuery).toHaveBeenCalledWith(
+        expect.stringContaining('UPDATE "connectedAccounts"'),
+        expect.arrayContaining(['disabled'])
+      )
+    })
+
+    test('maps status to in_progress when details submitted but not yet enabled', async () => {
+      const account = {
+        id: 'acct_inprogress',
+        charges_enabled: false,
+        payouts_enabled: false,
+        details_submitted: true,
+        requirements: { disabled_reason: null, past_due: [] },
+      }
+      const event = createMockStripeEvent('account.updated', account)
+      mockWebhooksConstructEvent.mockReturnValue(event)
+
+      const req = createMockRequest('{}', 'sig_valid')
+      await handleStripeConnectWebhook(req)
+
+      expect(mockQuery).toHaveBeenCalledWith(
+        expect.stringContaining('UPDATE "connectedAccounts"'),
+        expect.arrayContaining(['in_progress'])
+      )
+    })
+  })
+
+  // ----------------------------------------------------------
+  // 4. payment_intent.succeeded
+  // ----------------------------------------------------------
+  describe('payment_intent.succeeded', () => {
+    test('updates marketplacePayment status to succeeded with charge id', async () => {
+      const pi = {
+        id: 'pi_success_1',
+        latest_charge: 'ch_charge_1',
+      }
+      const event = createMockStripeEvent('payment_intent.succeeded', pi, 'acct_seller')
+      mockWebhooksConstructEvent.mockReturnValue(event)
+
+      const req = createMockRequest('{}', 'sig_valid')
+      await handleStripeConnectWebhook(req)
+
+      expect(mockQuery).toHaveBeenCalledWith(
+        expect.stringContaining('UPDATE "marketplacePayments"'),
+        ['ch_charge_1', 'pi_success_1']
+      )
+    })
+
+    test('handles latest_charge as object', async () => {
+      const pi = {
+        id: 'pi_success_2',
+        latest_charge: { id: 'ch_obj_charge' },
+      }
+      const event = createMockStripeEvent('payment_intent.succeeded', pi, 'acct_seller')
+      mockWebhooksConstructEvent.mockReturnValue(event)
+
+      const req = createMockRequest('{}', 'sig_valid')
+      await handleStripeConnectWebhook(req)
+
+      expect(mockQuery).toHaveBeenCalledWith(
+        expect.stringContaining('UPDATE "marketplacePayments"'),
+        ['ch_obj_charge', 'pi_success_2']
+      )
+    })
+
+    test('calls extensions.onPaymentSucceeded if provided', async () => {
+      const pi = { id: 'pi_ext_1', latest_charge: 'ch_ext' }
+      const event = createMockStripeEvent('payment_intent.succeeded', pi, 'acct_ext')
+      mockWebhooksConstructEvent.mockReturnValue(event)
+
+      const onPaymentSucceeded = jest.fn().mockResolvedValue(undefined) as jest.Mock<() => Promise<void>>
+      const extensions: StripeConnectWebhookExtensions = { onPaymentSucceeded }
+
+      const req = createMockRequest('{}', 'sig_valid')
+      await handleStripeConnectWebhook(req, extensions)
+
+      expect(onPaymentSucceeded).toHaveBeenCalledWith(pi, 'acct_ext')
+    })
+
+    test('does not call extensions.onPaymentSucceeded when not provided', async () => {
+      const pi = { id: 'pi_noext', latest_charge: 'ch_noext' }
+      const event = createMockStripeEvent('payment_intent.succeeded', pi, 'acct_noext')
+      mockWebhooksConstructEvent.mockReturnValue(event)
+
+      const req = createMockRequest('{}', 'sig_valid')
+
+      // Should not throw
+      const res = await handleStripeConnectWebhook(req)
+      expect(res.status).toBe(200)
+    })
+  })
+
+  // ----------------------------------------------------------
+  // 5. payment_intent.payment_failed
+  // ----------------------------------------------------------
+  describe('payment_intent.payment_failed', () => {
+    test('updates marketplacePayment status to failed with error message', async () => {
+      const pi = {
+        id: 'pi_failed_1',
+        last_payment_error: { message: 'Card declined' },
+      }
+      const event = createMockStripeEvent('payment_intent.payment_failed', pi)
+      mockWebhooksConstructEvent.mockReturnValue(event)
+
+      const req = createMockRequest('{}', 'sig_valid')
+      await handleStripeConnectWebhook(req)
+
+      expect(mockQuery).toHaveBeenCalledWith(
+        expect.stringContaining('UPDATE "marketplacePayments"'),
+        ['Card declined', 'pi_failed_1']
+      )
+    })
+
+    test('uses default message when last_payment_error is missing', async () => {
+      const pi = {
+        id: 'pi_failed_2',
+        last_payment_error: null,
+      }
+      const event = createMockStripeEvent('payment_intent.payment_failed', pi)
+      mockWebhooksConstructEvent.mockReturnValue(event)
+
+      const req = createMockRequest('{}', 'sig_valid')
+      await handleStripeConnectWebhook(req)
+
+      expect(mockQuery).toHaveBeenCalledWith(
+        expect.stringContaining('UPDATE "marketplacePayments"'),
+        ['Payment failed', 'pi_failed_2']
+      )
+    })
+  })
+
+  // ----------------------------------------------------------
+  // 6. charge.refunded
+  // ----------------------------------------------------------
+  describe('charge.refunded', () => {
+    test('updates status to refunded for full refund', async () => {
+      const charge = {
+        id: 'ch_refund_full',
+        refunded: true,
+        amount_refunded: 10000,
+      }
+      const event = createMockStripeEvent('charge.refunded', charge)
+      mockWebhooksConstructEvent.mockReturnValue(event)
+
+      const req = createMockRequest('{}', 'sig_valid')
+      await handleStripeConnectWebhook(req)
+
+      expect(mockQuery).toHaveBeenCalledWith(
+        expect.stringContaining('UPDATE "marketplacePayments"'),
+        ['refunded', 10000, 'ch_refund_full']
+      )
+    })
+
+    test('updates status to partially_refunded for partial refund', async () => {
+      const charge = {
+        id: 'ch_refund_partial',
+        refunded: false,
+        amount_refunded: 5000,
+      }
+      const event = createMockStripeEvent('charge.refunded', charge)
+      mockWebhooksConstructEvent.mockReturnValue(event)
+
+      const req = createMockRequest('{}', 'sig_valid')
+      await handleStripeConnectWebhook(req)
+
+      expect(mockQuery).toHaveBeenCalledWith(
+        expect.stringContaining('UPDATE "marketplacePayments"'),
+        ['partially_refunded', 5000, 'ch_refund_partial']
+      )
+    })
+
+    test('sets refundedAmount correctly', async () => {
+      const charge = {
+        id: 'ch_refund_amount',
+        refunded: false,
+        amount_refunded: 3500,
+      }
+      const event = createMockStripeEvent('charge.refunded', charge)
+      mockWebhooksConstructEvent.mockReturnValue(event)
+
+      const req = createMockRequest('{}', 'sig_valid')
+      await handleStripeConnectWebhook(req)
+
+      // Verify the refundedAmount param
+      const updateCall = mockQuery.mock.calls.find(
+        (call: any[]) => typeof call[0] === 'string' && call[0].includes('"refundedAmount"')
+      )
+      expect(updateCall).toBeDefined()
+      expect(updateCall![1]).toContain(3500)
+    })
+  })
+
+  // ----------------------------------------------------------
+  // 7. charge.dispute.created
+  // ----------------------------------------------------------
+  describe('charge.dispute.created', () => {
+    test('updates marketplacePayment status to disputed', async () => {
+      const dispute = {
+        id: 'dp_test_1',
+        charge: 'ch_disputed',
+        reason: 'fraudulent',
+      }
+      const event = createMockStripeEvent('charge.dispute.created', dispute, 'acct_disputed')
+      mockWebhooksConstructEvent.mockReturnValue(event)
+
+      const req = createMockRequest('{}', 'sig_valid')
+      await handleStripeConnectWebhook(req)
+
+      expect(mockQuery).toHaveBeenCalledWith(
+        expect.stringContaining('UPDATE "marketplacePayments"'),
+        ['Dispute: fraudulent', 'ch_disputed']
+      )
+    })
+
+    test('handles charge as object', async () => {
+      const dispute = {
+        id: 'dp_test_2',
+        charge: { id: 'ch_disputed_obj' },
+        reason: 'product_not_received',
+      }
+      const event = createMockStripeEvent('charge.dispute.created', dispute, 'acct_dp2')
+      mockWebhooksConstructEvent.mockReturnValue(event)
+
+      const req = createMockRequest('{}', 'sig_valid')
+      await handleStripeConnectWebhook(req)
+
+      expect(mockQuery).toHaveBeenCalledWith(
+        expect.stringContaining('UPDATE "marketplacePayments"'),
+        ['Dispute: product_not_received', 'ch_disputed_obj']
+      )
+    })
+
+    test('calls extensions.onDisputeCreated if provided', async () => {
+      const dispute = {
+        id: 'dp_test_ext',
+        charge: 'ch_ext_dispute',
+        reason: 'general',
+      }
+      const event = createMockStripeEvent('charge.dispute.created', dispute, 'acct_dp_ext')
+      mockWebhooksConstructEvent.mockReturnValue(event)
+
+      const onDisputeCreated = jest.fn().mockResolvedValue(undefined) as jest.Mock<() => Promise<void>>
+      const extensions: StripeConnectWebhookExtensions = { onDisputeCreated }
+
+      const req = createMockRequest('{}', 'sig_valid')
+      await handleStripeConnectWebhook(req, extensions)
+
+      expect(onDisputeCreated).toHaveBeenCalledWith(dispute, 'acct_dp_ext')
+    })
+
+    test('does not update payment when charge id is missing', async () => {
+      const dispute = {
+        id: 'dp_no_charge',
+        charge: null,
+        reason: 'general',
+      }
+      const event = createMockStripeEvent('charge.dispute.created', dispute, 'acct_dp_nc')
+      mockWebhooksConstructEvent.mockReturnValue(event)
+
+      const req = createMockRequest('{}', 'sig_valid')
+      await handleStripeConnectWebhook(req)
+
+      // Should NOT have an UPDATE for marketplacePayments with status=disputed
+      const disputeUpdateCalls = mockQuery.mock.calls.filter(
+        (call: any[]) =>
+          typeof call[0] === 'string' &&
+          call[0].includes('UPDATE "marketplacePayments"') &&
+          call[0].includes("'disputed'")
+      )
+      expect(disputeUpdateCalls).toHaveLength(0)
+    })
+  })
+
+  // ----------------------------------------------------------
+  // 8. Error handling
+  // ----------------------------------------------------------
+  describe('error handling', () => {
+    test('returns 500 on handler error', async () => {
+      const account = {
+        id: 'acct_error',
+        charges_enabled: true,
+        payouts_enabled: true,
+        requirements: { disabled_reason: null, past_due: [] },
+      }
+      const event = createMockStripeEvent('account.updated', account)
+      mockWebhooksConstructEvent.mockReturnValue(event)
+
+      // Make the handler's UPDATE query throw
+      let callCount = 0
+      mockQuery.mockImplementation(async (sql: string) => {
+        callCount++
+        // First call is the INSERT for the webhook event — let it succeed
+        if (sql.includes('INSERT INTO "marketplaceWebhookEvents"')) {
+          return { rows: [], rowCount: 1 }
+        }
+        // Second call is the handler's UPDATE — throw
+        if (sql.includes('UPDATE "connectedAccounts"')) {
+          throw new Error('DB connection lost')
+        }
+        // Allow error recording UPDATE
+        return { rows: [], rowCount: 0 }
+      })
+
+      const req = createMockRequest('{}', 'sig_valid')
+      const res = await handleStripeConnectWebhook(req)
+
+      expect(res.status).toBe(500)
+      const body = await res.json()
+      expect(body.error).toMatch(/handler failed/i)
+    })
+
+    test('records error in webhookEvents table', async () => {
+      const account = {
+        id: 'acct_err2',
+        charges_enabled: true,
+        payouts_enabled: true,
+        requirements: { disabled_reason: null, past_due: [] },
+      }
+      const event = createMockStripeEvent('account.updated', account)
+      mockWebhooksConstructEvent.mockReturnValue(event)
+
+      mockQuery.mockImplementation(async (sql: string) => {
+        if (sql.includes('INSERT INTO "marketplaceWebhookEvents"')) {
+          return { rows: [], rowCount: 1 }
+        }
+        if (sql.includes('UPDATE "connectedAccounts"')) {
+          throw new Error('Unexpected DB error')
+        }
+        // Allow the error recording UPDATE
+        return { rows: [], rowCount: 0 }
+      })
+
+      const req = createMockRequest('{}', 'sig_valid')
+      await handleStripeConnectWebhook(req)
+
+      // Verify error was recorded in the webhook events table
+      const errorUpdateCall = mockQuery.mock.calls.find(
+        (call: any[]) =>
+          typeof call[0] === 'string' &&
+          call[0].includes('UPDATE "marketplaceWebhookEvents"') &&
+          call[0].includes('error')
+      )
+      expect(errorUpdateCall).toBeDefined()
+      expect(errorUpdateCall![1]).toContain('Unexpected DB error')
+    })
+
+    test('logs unhandled event types gracefully', async () => {
+      const consoleSpy = jest.spyOn(console, 'log').mockImplementation(() => {})
+
+      const event = createMockStripeEvent('unknown.event.type', { id: 'obj_unknown' })
+      mockWebhooksConstructEvent.mockReturnValue(event)
+
+      const req = createMockRequest('{}', 'sig_valid')
+      const res = await handleStripeConnectWebhook(req)
+
+      expect(res.status).toBe(200)
+      const body = await res.json()
+      expect(body.received).toBe(true)
+
+      expect(consoleSpy).toHaveBeenCalledWith(
+        expect.stringContaining('Unhandled event: unknown.event.type')
+      )
+
+      consoleSpy.mockRestore()
+    })
+  })
+
+  // ----------------------------------------------------------
+  // 9. Payout events (bonus coverage)
+  // ----------------------------------------------------------
+  describe('payout events', () => {
+    test('handles payout.paid event', async () => {
+      const payout = { id: 'po_paid_1', amount: 25000, currency: 'usd' }
+      const event = createMockStripeEvent('payout.paid', payout)
+      mockWebhooksConstructEvent.mockReturnValue(event)
+
+      const req = createMockRequest('{}', 'sig_valid')
+      const res = await handleStripeConnectWebhook(req)
+
+      expect(res.status).toBe(200)
+    })
+
+    test('handles payout.failed event', async () => {
+      const payout = { id: 'po_failed_1', amount: 15000, currency: 'usd' }
+      const event = createMockStripeEvent('payout.failed', payout)
+      mockWebhooksConstructEvent.mockReturnValue(event)
+
+      const req = createMockRequest('{}', 'sig_valid')
+      const res = await handleStripeConnectWebhook(req)
+
+      expect(res.status).toBe(200)
+    })
+  })
+
+  // ----------------------------------------------------------
+  // 10. Event marking as processed
+  // ----------------------------------------------------------
+  describe('event lifecycle', () => {
+    test('marks event as processed after successful handling', async () => {
+      const event = createMockStripeEvent('payout.paid', { id: 'po_lifecycle' })
+      mockWebhooksConstructEvent.mockReturnValue(event)
+
+      const req = createMockRequest('{}', 'sig_valid')
+      await handleStripeConnectWebhook(req)
+
+      // Verify the "mark as processed" UPDATE was called
+      const processedCall = mockQuery.mock.calls.find(
+        (call: any[]) =>
+          typeof call[0] === 'string' &&
+          call[0].includes('UPDATE "marketplaceWebhookEvents"') &&
+          call[0].includes('processed = true')
+      )
+      expect(processedCall).toBeDefined()
+      expect(processedCall![1]).toContain(event.id)
+    })
+  })
+})

--- a/packages/core/tests/jest/lib/marketplace/stripe-connect.test.ts
+++ b/packages/core/tests/jest/lib/marketplace/stripe-connect.test.ts
@@ -1,0 +1,352 @@
+/**
+ * Stripe Connect Gateway Tests
+ */
+
+import { describe, test, expect, beforeEach, afterEach, jest } from '@jest/globals'
+
+// Mock Stripe SDK
+const mockAccountsCreate = jest.fn()
+const mockAccountsRetrieve = jest.fn()
+const mockAccountLinksCreate = jest.fn()
+const mockAccountsCreateLoginLink = jest.fn()
+const mockCheckoutSessionsCreate = jest.fn()
+const mockPaymentIntentsCreate = jest.fn()
+const mockPaymentIntentsRetrieve = jest.fn()
+const mockRefundsCreate = jest.fn()
+const mockPayoutsCreate = jest.fn()
+const mockBalanceRetrieve = jest.fn()
+const mockWebhooksConstructEvent = jest.fn()
+const mockSubscriptionsUpdate = jest.fn()
+
+jest.mock('stripe', () => {
+  return jest.fn().mockImplementation(() => ({
+    accounts: {
+      create: mockAccountsCreate,
+      retrieve: mockAccountsRetrieve,
+      createLoginLink: mockAccountsCreateLoginLink,
+    },
+    accountLinks: { create: mockAccountLinksCreate },
+    checkout: { sessions: { create: mockCheckoutSessionsCreate } },
+    paymentIntents: {
+      create: mockPaymentIntentsCreate,
+      retrieve: mockPaymentIntentsRetrieve,
+    },
+    refunds: { create: mockRefundsCreate },
+    payouts: { create: mockPayoutsCreate },
+    balance: { retrieve: mockBalanceRetrieve },
+    webhooks: { constructEvent: mockWebhooksConstructEvent },
+    subscriptions: { update: mockSubscriptionsUpdate },
+  }))
+})
+
+import { StripeConnectGateway } from '@/core/lib/marketplace/gateways/stripe-connect'
+
+describe('StripeConnectGateway', () => {
+  const originalEnv = process.env
+  let gateway: StripeConnectGateway
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    process.env = {
+      ...originalEnv,
+      STRIPE_SECRET_KEY: 'sk_test_mock',
+      STRIPE_CONNECT_WEBHOOK_SECRET: 'whsec_connect_mock',
+    }
+    gateway = new StripeConnectGateway()
+  })
+
+  afterEach(() => {
+    process.env = originalEnv
+  })
+
+  test('provider should be stripe_connect', () => {
+    expect(gateway.provider).toBe('stripe_connect')
+  })
+
+  describe('createConnectedAccount', () => {
+    test('should create Express account with correct params', async () => {
+      mockAccountsCreate.mockResolvedValue({
+        id: 'acct_test123',
+        email: 'salon@test.com',
+        charges_enabled: false,
+        payouts_enabled: false,
+        details_submitted: false,
+        requirements: { currently_due: ['business_url'], past_due: [], eventually_due: [] },
+      })
+
+      const result = await gateway.createConnectedAccount({
+        teamId: 'team-123',
+        email: 'salon@test.com',
+        businessName: 'Salon Test',
+        country: 'US',
+        businessType: 'individual',
+      })
+
+      expect(mockAccountsCreate).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: 'express',
+          country: 'US',
+          email: 'salon@test.com',
+          business_type: 'individual',
+          capabilities: {
+            card_payments: { requested: true },
+            transfers: { requested: true },
+          },
+        })
+      )
+
+      expect(result).toEqual({
+        id: 'acct_test123',
+        email: 'salon@test.com',
+        chargesEnabled: false,
+        payoutsEnabled: false,
+        detailsSubmitted: false,
+        onboardingStatus: 'pending',
+        requirements: expect.objectContaining({
+          currentlyDue: ['business_url'],
+        }),
+      })
+    })
+  })
+
+  describe('createOnboardingLink', () => {
+    test('should create account link with correct URLs', async () => {
+      mockAccountLinksCreate.mockResolvedValue({
+        url: 'https://connect.stripe.com/setup/e/acct_test',
+        expires_at: Math.floor(Date.now() / 1000) + 300,
+      })
+
+      const result = await gateway.createOnboardingLink({
+        externalAccountId: 'acct_test123',
+        refreshUrl: 'https://app.com/refresh',
+        returnUrl: 'https://app.com/return',
+      })
+
+      expect(result.url).toBe('https://connect.stripe.com/setup/e/acct_test')
+      expect(result.expiresAt).toBeInstanceOf(Date)
+
+      expect(mockAccountLinksCreate).toHaveBeenCalledWith({
+        account: 'acct_test123',
+        refresh_url: 'https://app.com/refresh',
+        return_url: 'https://app.com/return',
+        type: 'account_onboarding',
+      })
+    })
+  })
+
+  describe('createMarketplaceCheckout', () => {
+    test('should create checkout session with application_fee and transfer_data', async () => {
+      mockCheckoutSessionsCreate.mockResolvedValue({
+        id: 'cs_test_456',
+        url: 'https://checkout.stripe.com/pay/cs_test_456',
+      })
+
+      const result = await gateway.createMarketplaceCheckout({
+        connectedAccountId: 'internal-id-123',
+        externalAccountId: 'acct_salon',
+        amount: 10000,
+        currency: 'usd',
+        applicationFee: 1500,
+        referenceId: 'booking-789',
+        description: 'Haircut - Salon Elegante',
+        customerEmail: 'customer@test.com',
+        successUrl: 'https://app.com/success',
+        cancelUrl: 'https://app.com/cancel',
+      })
+
+      expect(result).toEqual({
+        id: 'cs_test_456',
+        status: 'pending',
+        url: 'https://checkout.stripe.com/pay/cs_test_456',
+      })
+
+      expect(mockCheckoutSessionsCreate).toHaveBeenCalledWith(
+        expect.objectContaining({
+          mode: 'payment',
+          payment_intent_data: expect.objectContaining({
+            application_fee_amount: 1500,
+            transfer_data: { destination: 'acct_salon' },
+          }),
+        })
+      )
+    })
+  })
+
+  describe('createMarketplacePayment', () => {
+    test('should create payment intent with split', async () => {
+      mockPaymentIntentsCreate.mockResolvedValue({
+        id: 'pi_test_789',
+        status: 'requires_payment_method',
+        latest_charge: null,
+      })
+
+      const result = await gateway.createMarketplacePayment({
+        connectedAccountId: 'internal-id-123',
+        externalAccountId: 'acct_salon',
+        amount: 5000,
+        currency: 'usd',
+        applicationFee: 750,
+        referenceId: 'booking-456',
+        description: 'Beard trim',
+      })
+
+      expect(result.id).toBe('pi_test_789')
+      expect(result.status).toBe('pending')
+
+      expect(mockPaymentIntentsCreate).toHaveBeenCalledWith(
+        expect.objectContaining({
+          amount: 5000,
+          currency: 'usd',
+          application_fee_amount: 750,
+          transfer_data: { destination: 'acct_salon' },
+        })
+      )
+    })
+  })
+
+  describe('refundPayment', () => {
+    test('should refund with application fee refund by default', async () => {
+      mockRefundsCreate.mockResolvedValue({
+        id: 're_test_123',
+        amount: 10000,
+        status: 'succeeded',
+      })
+
+      const result = await gateway.refundPayment({
+        externalPaymentId: 'pi_test_789',
+      })
+
+      expect(result).toEqual({
+        id: 're_test_123',
+        amount: 10000,
+        status: 'succeeded',
+        feeRefunded: 0,
+      })
+
+      expect(mockRefundsCreate).toHaveBeenCalledWith(
+        expect.objectContaining({
+          payment_intent: 'pi_test_789',
+          refund_application_fee: true,
+        })
+      )
+    })
+
+    test('should support partial refund without fee refund', async () => {
+      mockRefundsCreate.mockResolvedValue({
+        id: 're_partial_456',
+        amount: 5000,
+        status: 'succeeded',
+      })
+
+      await gateway.refundPayment({
+        externalPaymentId: 'pi_test_789',
+        amount: 5000,
+        refundApplicationFee: false,
+      })
+
+      expect(mockRefundsCreate).toHaveBeenCalledWith(
+        expect.objectContaining({
+          amount: 5000,
+          refund_application_fee: false,
+        })
+      )
+    })
+  })
+
+  describe('getAccountBalance', () => {
+    test('should return available and pending balance', async () => {
+      mockBalanceRetrieve.mockResolvedValue({
+        available: [{ amount: 50000, currency: 'usd' }],
+        pending: [{ amount: 10000, currency: 'usd' }],
+      })
+
+      const result = await gateway.getAccountBalance('acct_salon')
+
+      expect(result).toEqual({
+        available: 50000,
+        pending: 10000,
+        currency: 'usd',
+      })
+
+      expect(mockBalanceRetrieve).toHaveBeenCalledWith({
+        stripeAccount: 'acct_salon',
+      })
+    })
+  })
+
+  describe('verifyWebhookSignature', () => {
+    test('should verify and return parsed event with account', () => {
+      mockWebhooksConstructEvent.mockReturnValue({
+        id: 'evt_connect_123',
+        type: 'payment_intent.succeeded',
+        account: 'acct_salon',
+        data: { object: { id: 'pi_123' } },
+      })
+
+      const result = gateway.verifyWebhookSignature('payload', 'sig_test')
+
+      expect(result).toEqual({
+        id: 'evt_connect_123',
+        type: 'payment_intent.succeeded',
+        account: 'acct_salon',
+        data: { object: { id: 'pi_123' } },
+      })
+    })
+
+    test('should throw when STRIPE_CONNECT_WEBHOOK_SECRET is missing', () => {
+      delete process.env.STRIPE_CONNECT_WEBHOOK_SECRET
+
+      expect(() => gateway.verifyWebhookSignature('payload', 'sig'))
+        .toThrow('STRIPE_CONNECT_WEBHOOK_SECRET is not configured')
+    })
+  })
+
+  describe('getAccountStatus', () => {
+    test('should map active account correctly', async () => {
+      mockAccountsRetrieve.mockResolvedValue({
+        id: 'acct_active',
+        email: 'active@salon.com',
+        charges_enabled: true,
+        payouts_enabled: true,
+        details_submitted: true,
+        requirements: { currently_due: [], past_due: [], eventually_due: [], disabled_reason: null },
+      })
+
+      const result = await gateway.getAccountStatus('acct_active')
+
+      expect(result.onboardingStatus).toBe('active')
+      expect(result.chargesEnabled).toBe(true)
+      expect(result.payoutsEnabled).toBe(true)
+    })
+
+    test('should map restricted account correctly', async () => {
+      mockAccountsRetrieve.mockResolvedValue({
+        id: 'acct_restricted',
+        email: 'restricted@salon.com',
+        charges_enabled: true,
+        payouts_enabled: false,
+        details_submitted: true,
+        requirements: { currently_due: [], past_due: ['individual.verification.document'], eventually_due: [], disabled_reason: null },
+      })
+
+      const result = await gateway.getAccountStatus('acct_restricted')
+
+      expect(result.onboardingStatus).toBe('restricted')
+    })
+
+    test('should map disabled account correctly', async () => {
+      mockAccountsRetrieve.mockResolvedValue({
+        id: 'acct_disabled',
+        email: 'disabled@salon.com',
+        charges_enabled: false,
+        payouts_enabled: false,
+        details_submitted: true,
+        requirements: { currently_due: [], past_due: [], eventually_due: [], disabled_reason: 'rejected.fraud' },
+      })
+
+      const result = await gateway.getAccountStatus('acct_disabled')
+
+      expect(result.onboardingStatus).toBe('disabled')
+    })
+  })
+})

--- a/packages/core/tests/jest/lib/marketplace/stripe-connect.test.ts
+++ b/packages/core/tests/jest/lib/marketplace/stripe-connect.test.ts
@@ -301,6 +301,142 @@ describe('StripeConnectGateway', () => {
     })
   })
 
+  describe('createDashboardLink', () => {
+    test('should call stripe.accounts.createLoginLink and return URL', async () => {
+      mockAccountsCreateLoginLink.mockResolvedValue({
+        url: 'https://connect.stripe.com/express/login/acct_salon',
+      })
+
+      const result = await gateway.createDashboardLink('acct_salon')
+
+      expect(result).toEqual({
+        url: 'https://connect.stripe.com/express/login/acct_salon',
+      })
+
+      expect(mockAccountsCreateLoginLink).toHaveBeenCalledWith('acct_salon')
+    })
+  })
+
+  describe('getPaymentStatus', () => {
+    test('should call stripe.paymentIntents.retrieve and map status', async () => {
+      mockPaymentIntentsRetrieve.mockResolvedValue({
+        id: 'pi_test_status',
+        status: 'succeeded',
+        latest_charge: 'ch_abc123',
+      })
+
+      const result = await gateway.getPaymentStatus('pi_test_status')
+
+      expect(result).toEqual({
+        id: 'pi_test_status',
+        status: 'succeeded',
+        chargeId: 'ch_abc123',
+      })
+
+      expect(mockPaymentIntentsRetrieve).toHaveBeenCalledWith('pi_test_status')
+    })
+
+    test('should handle latest_charge as object', async () => {
+      mockPaymentIntentsRetrieve.mockResolvedValue({
+        id: 'pi_test_obj',
+        status: 'processing',
+        latest_charge: { id: 'ch_obj123' },
+      })
+
+      const result = await gateway.getPaymentStatus('pi_test_obj')
+
+      expect(result).toEqual({
+        id: 'pi_test_obj',
+        status: 'processing',
+        chargeId: 'ch_obj123',
+      })
+    })
+
+    test('should handle null latest_charge', async () => {
+      mockPaymentIntentsRetrieve.mockResolvedValue({
+        id: 'pi_test_null',
+        status: 'requires_payment_method',
+        latest_charge: null,
+      })
+
+      const result = await gateway.getPaymentStatus('pi_test_null')
+
+      expect(result).toEqual({
+        id: 'pi_test_null',
+        status: 'pending',
+        chargeId: undefined,
+      })
+    })
+  })
+
+  describe('createPayout', () => {
+    test('should call stripe.payouts.create with stripeAccount param', async () => {
+      mockPayoutsCreate.mockResolvedValue({
+        id: 'po_test_123',
+        amount: 25000,
+        currency: 'usd',
+        status: 'in_transit',
+        arrival_date: 1700000000,
+      })
+
+      const result = await gateway.createPayout({
+        externalAccountId: 'acct_salon',
+        amount: 25000,
+        currency: 'usd',
+        description: 'Weekly payout',
+      })
+
+      expect(result).toEqual({
+        id: 'po_test_123',
+        amount: 25000,
+        currency: 'usd',
+        status: 'in_transit',
+        arrivalDate: new Date(1700000000 * 1000),
+      })
+
+      expect(mockPayoutsCreate).toHaveBeenCalledWith(
+        {
+          amount: 25000,
+          currency: 'usd',
+          description: 'Weekly payout',
+        },
+        { stripeAccount: 'acct_salon' }
+      )
+    })
+  })
+
+  describe('mapPaymentStatus', () => {
+    test.each([
+      ['requires_payment_method', 'pending'],
+      ['requires_action', 'pending'],
+      ['requires_confirmation', 'pending'],
+      ['processing', 'processing'],
+      ['requires_capture', 'processing'],
+      ['succeeded', 'succeeded'],
+      ['canceled', 'canceled'],
+    ])('should map %s to %s', async (stripeStatus, expectedStatus) => {
+      mockPaymentIntentsRetrieve.mockResolvedValue({
+        id: 'pi_map_test',
+        status: stripeStatus,
+        latest_charge: null,
+      })
+
+      const result = await gateway.getPaymentStatus('pi_map_test')
+      expect(result.status).toBe(expectedStatus)
+    })
+
+    test('should map unknown status to failed', async () => {
+      mockPaymentIntentsRetrieve.mockResolvedValue({
+        id: 'pi_unknown',
+        status: 'some_unknown_status',
+        latest_charge: null,
+      })
+
+      const result = await gateway.getPaymentStatus('pi_unknown')
+      expect(result.status).toBe('failed')
+    })
+  })
+
   describe('getAccountStatus', () => {
     test('should map active account correctly', async () => {
       mockAccountsRetrieve.mockResolvedValue({

--- a/packages/core/tests/jest/lib/marketplace/token-encryption.test.ts
+++ b/packages/core/tests/jest/lib/marketplace/token-encryption.test.ts
@@ -1,0 +1,158 @@
+/**
+ * Token Encryption Tests
+ *
+ * AES-256-GCM encryption/decryption for marketplace OAuth tokens.
+ */
+
+import { describe, test, expect, beforeEach, afterEach } from '@jest/globals'
+import { encryptToken, decryptToken, encryptTokens, decryptTokens } from '@/core/lib/marketplace/token-encryption'
+
+const VALID_KEY = 'a'.repeat(64) // 32 bytes in hex
+
+describe('Token Encryption', () => {
+  let originalKey: string | undefined
+
+  beforeEach(() => {
+    originalKey = process.env.MARKETPLACE_TOKEN_ENCRYPTION_KEY
+    process.env.MARKETPLACE_TOKEN_ENCRYPTION_KEY = VALID_KEY
+  })
+
+  afterEach(() => {
+    if (originalKey === undefined) {
+      delete process.env.MARKETPLACE_TOKEN_ENCRYPTION_KEY
+    } else {
+      process.env.MARKETPLACE_TOKEN_ENCRYPTION_KEY = originalKey
+    }
+  })
+
+  describe('encryptToken', () => {
+    test('should return a string in "iv:authTag:ciphertext" format', () => {
+      const encrypted = encryptToken('my-secret-token')
+      const parts = encrypted.split(':')
+
+      expect(parts).toHaveLength(3)
+      // IV = 12 bytes = 24 hex chars
+      expect(parts[0]).toHaveLength(24)
+      // Auth tag = 16 bytes = 32 hex chars
+      expect(parts[1]).toHaveLength(32)
+      // Ciphertext should be non-empty hex
+      expect(parts[2].length).toBeGreaterThan(0)
+      // All parts should be valid hex
+      parts.forEach((part) => {
+        expect(part).toMatch(/^[0-9a-f]+$/)
+      })
+    })
+
+    test('should produce different ciphertext for same plaintext (random IV)', () => {
+      const plaintext = 'same-token-value'
+      const encrypted1 = encryptToken(plaintext)
+      const encrypted2 = encryptToken(plaintext)
+
+      expect(encrypted1).not.toBe(encrypted2)
+
+      // Both should still decrypt to the same value
+      expect(decryptToken(encrypted1)).toBe(plaintext)
+      expect(decryptToken(encrypted2)).toBe(plaintext)
+    })
+  })
+
+  describe('decryptToken', () => {
+    test('should reverse encryptToken correctly (roundtrip)', () => {
+      const plaintext = 'APP_USR-abc123-refresh-token-xyz'
+      const encrypted = encryptToken(plaintext)
+      const decrypted = decryptToken(encrypted)
+
+      expect(decrypted).toBe(plaintext)
+    })
+
+    test('should handle empty string', () => {
+      const encrypted = encryptToken('')
+      expect(decryptToken(encrypted)).toBe('')
+    })
+
+    test('should handle unicode characters', () => {
+      const plaintext = 'token-with-unicode-\u00e9\u00e8\u00ea'
+      const encrypted = encryptToken(plaintext)
+      expect(decryptToken(encrypted)).toBe(plaintext)
+    })
+
+    test('should throw on tampered ciphertext', () => {
+      const encrypted = encryptToken('my-secret-token')
+      const parts = encrypted.split(':')
+      // Tamper with the ciphertext portion
+      const tampered = `${parts[0]}:${parts[1]}:${'ff'.repeat(parts[2].length / 2)}`
+
+      expect(() => decryptToken(tampered)).toThrow()
+    })
+
+    test('should throw on invalid format (missing parts)', () => {
+      expect(() => decryptToken('only-one-part')).toThrow(
+        'Invalid encrypted token format'
+      )
+      expect(() => decryptToken('two:parts')).toThrow(
+        'Invalid encrypted token format'
+      )
+      expect(() => decryptToken('too:many:parts:here')).toThrow(
+        'Invalid encrypted token format'
+      )
+    })
+  })
+
+  describe('encryptTokens', () => {
+    test('should only encrypt accessToken and refreshToken, leave expiresAt and publicKey unchanged', () => {
+      const tokens = {
+        accessToken: 'APP_USR-access-123',
+        refreshToken: 'TG-refresh-456',
+        expiresAt: '2025-12-31T23:59:59Z',
+        publicKey: 'APP_USR-public-789',
+      }
+
+      const encrypted = encryptTokens(tokens)
+
+      // Sensitive fields should be encrypted (different from original)
+      expect(encrypted.accessToken).not.toBe(tokens.accessToken)
+      expect(encrypted.refreshToken).not.toBe(tokens.refreshToken)
+
+      // Encrypted fields should have the iv:authTag:ciphertext format
+      expect(encrypted.accessToken.split(':')).toHaveLength(3)
+      expect(encrypted.refreshToken.split(':')).toHaveLength(3)
+
+      // Non-sensitive fields should be unchanged
+      expect(encrypted.expiresAt).toBe(tokens.expiresAt)
+      expect(encrypted.publicKey).toBe(tokens.publicKey)
+    })
+  })
+
+  describe('decryptTokens', () => {
+    test('should reverse encryptTokens correctly', () => {
+      const tokens = {
+        accessToken: 'APP_USR-access-123',
+        refreshToken: 'TG-refresh-456',
+        expiresAt: '2025-12-31T23:59:59Z',
+        publicKey: 'APP_USR-public-789',
+      }
+
+      const encrypted = encryptTokens(tokens)
+      const decrypted = decryptTokens(encrypted)
+
+      expect(decrypted).toEqual(tokens)
+    })
+  })
+
+  describe('encryption key validation', () => {
+    test('should throw if MARKETPLACE_TOKEN_ENCRYPTION_KEY is not set', () => {
+      delete process.env.MARKETPLACE_TOKEN_ENCRYPTION_KEY
+
+      expect(() => encryptToken('test')).toThrow(
+        'MARKETPLACE_TOKEN_ENCRYPTION_KEY is not configured'
+      )
+    })
+
+    test('should throw if encryption key is invalid length', () => {
+      // 16 hex chars = 8 bytes, too short for AES-256 which needs 32 bytes
+      process.env.MARKETPLACE_TOKEN_ENCRYPTION_KEY = 'a'.repeat(16)
+
+      expect(() => encryptToken('test')).toThrow()
+    })
+  })
+})

--- a/packages/core/tests/jest/services/subscription.service.test.ts
+++ b/packages/core/tests/jest/services/subscription.service.test.ts
@@ -6,7 +6,7 @@
  */
 
 import { SubscriptionService } from '@/core/lib/services/subscription.service'
-import { queryOneWithRLS, queryWithRLS, mutateWithRLS } from '@/core/lib/db'
+import { queryOneWithRLS, queryWithRLS, mutateWithRLS, getTransactionClient } from '@/core/lib/db'
 import type { Subscription, Plan, SubscriptionWithPlan } from '@/core/lib/billing/types'
 
 // Mock database functions
@@ -14,6 +14,7 @@ jest.mock('@/core/lib/db', () => ({
   queryOneWithRLS: jest.fn(),
   queryWithRLS: jest.fn(),
   mutateWithRLS: jest.fn(),
+  getTransactionClient: jest.fn(),
 }))
 
 // Mock PlanService
@@ -79,6 +80,19 @@ jest.mock('@/core/lib/billing/gateways/stripe', () => ({
   updateSubscriptionPlan: jest.fn(),
 }))
 
+// Mock billing gateway factory
+const mockUpdateSubscriptionPlan = jest.fn()
+jest.mock('@/core/lib/billing/gateways/factory', () => ({
+  getBillingGateway: jest.fn(() => ({
+    updateSubscriptionPlan: mockUpdateSubscriptionPlan,
+  })),
+}))
+
+// Mock hook system
+jest.mock('@/core/lib/plugins/hook-system', () => ({
+  doAction: jest.fn().mockResolvedValue(undefined),
+}))
+
 // Mock enforcement module
 jest.mock('@/core/lib/billing/enforcement', () => ({
   checkDowngrade: jest.fn().mockResolvedValue({ canDowngrade: true, warnings: [] }),
@@ -91,6 +105,7 @@ import { TeamMemberService } from '@/core/lib/services/team-member.service'
 const mockQueryOneWithRLS = queryOneWithRLS as jest.MockedFunction<typeof queryOneWithRLS>
 const mockQueryWithRLS = queryWithRLS as jest.MockedFunction<typeof queryWithRLS>
 const mockMutateWithRLS = mutateWithRLS as jest.MockedFunction<typeof mutateWithRLS>
+const mockGetTransactionClient = getTransactionClient as jest.MockedFunction<typeof getTransactionClient>
 const mockPlanService = PlanService as jest.Mocked<typeof PlanService>
 const mockUsageService = UsageService as jest.Mocked<typeof UsageService>
 const mockTeamMemberService = TeamMemberService as jest.Mocked<typeof TeamMemberService>
@@ -573,6 +588,124 @@ describe('SubscriptionService', () => {
 
       expect(result.success).toBe(false)
       expect(result.error).toContain('No price ID configured')
+    })
+
+    // Happy path shared setup
+    const targetPlanDb = { id: 'plan-enterprise', slug: 'enterprise' }
+    const mockTx = {
+      query: jest.fn().mockResolvedValue({ rows: [], rowCount: 1 }),
+      commit: jest.fn().mockResolvedValue(undefined),
+      rollback: jest.fn().mockResolvedValue(undefined),
+    }
+
+    function setupChangePlanHappyPath(overrides?: { isUpgrade?: boolean }) {
+      const isUpgrade = overrides?.isUpgrade ?? true
+
+      // getActive (step 1) — returns current sub with plan slug 'pro'
+      mockQueryOneWithRLS
+        .mockResolvedValueOnce({
+          ...mockSubscriptionWithPlan,
+          externalSubscriptionId: 'stripe_sub_123',
+        })
+
+      // PlanService registry lookups (steps 2-3)
+      mockPlanService.getConfig.mockReturnValue({ slug: 'enterprise', features: ['all'], limits: {} })
+      mockPlanService.getPriceId.mockReturnValue('price_enterprise_monthly')
+      mockPlanService.isUpgrade.mockReturnValue(isUpgrade)
+
+      // Provider update (step 5)
+      mockUpdateSubscriptionPlan.mockResolvedValue(undefined)
+
+      // PlanService.getBySlug for local plan ID (step 6)
+      mockPlanService.getBySlug.mockResolvedValue(targetPlanDb as any)
+
+      // Transaction client (steps 7-8)
+      mockGetTransactionClient.mockResolvedValue(mockTx as any)
+
+      // getActive again for updated subscription (step 9)
+      const updatedSub = {
+        ...mockSubscriptionWithPlan,
+        planId: 'plan-enterprise',
+        plan: { ...mockPlan, slug: 'enterprise', id: 'plan-enterprise' },
+        externalSubscriptionId: 'stripe_sub_123',
+      }
+      mockQueryOneWithRLS.mockResolvedValueOnce(updatedSub)
+
+      return { updatedSub }
+    }
+
+    it('successfully upgrades plan via billing gateway and updates DB', async () => {
+      const { updatedSub } = setupChangePlanHappyPath({ isUpgrade: true })
+
+      const result = await SubscriptionService.changePlan('team-456', 'enterprise')
+
+      expect(result.success).toBe(true)
+      expect(result.subscription).toBeDefined()
+      expect(result.downgradeWarnings).toBeUndefined()
+
+      // Verify gateway was called with correct params
+      expect(mockUpdateSubscriptionPlan).toHaveBeenCalledWith({
+        subscriptionId: 'stripe_sub_123',
+        newPriceId: 'price_enterprise_monthly',
+      })
+
+      // Verify DB transaction was committed
+      expect(mockTx.query).toHaveBeenCalledTimes(2) // UPDATE subscription + INSERT billing_event
+      expect(mockTx.commit).toHaveBeenCalled()
+      expect(mockTx.rollback).not.toHaveBeenCalled()
+    })
+
+    it('successfully downgrades plan and returns enforcement warnings', async () => {
+      setupChangePlanHappyPath({ isUpgrade: false })
+
+      // Override the enforcement mock for this test to return warnings
+      const { checkDowngrade } = await import('@/core/lib/billing/enforcement')
+      const mockCheckDowngrade = checkDowngrade as jest.MockedFunction<typeof checkDowngrade>
+      mockCheckDowngrade.mockResolvedValueOnce({
+        canDowngrade: true,
+        warnings: ['You will lose access to advanced analytics', 'Team member limit will decrease'],
+      })
+
+      const result = await SubscriptionService.changePlan('team-456', 'enterprise')
+
+      expect(result.success).toBe(true)
+      expect(result.downgradeWarnings).toEqual([
+        'You will lose access to advanced analytics',
+        'Team member limit will decrease',
+      ])
+
+      // Gateway should still be called even on downgrade
+      expect(mockUpdateSubscriptionPlan).toHaveBeenCalledWith({
+        subscriptionId: 'stripe_sub_123',
+        newPriceId: 'price_enterprise_monthly',
+      })
+      expect(mockTx.commit).toHaveBeenCalled()
+    })
+
+    it('returns error when DB transaction fails after provider update succeeds', async () => {
+      setupChangePlanHappyPath({ isUpgrade: true })
+
+      // Override: make the DB transaction throw
+      mockTx.query.mockRejectedValueOnce(new Error('Connection lost'))
+
+      const result = await SubscriptionService.changePlan('team-456', 'enterprise')
+
+      expect(result.success).toBe(false)
+      expect(result.error).toContain('Plan changed in payment provider but local DB update failed')
+
+      // Provider was called successfully
+      expect(mockUpdateSubscriptionPlan).toHaveBeenCalled()
+      // Transaction was rolled back
+      expect(mockTx.rollback).toHaveBeenCalled()
+      expect(mockTx.commit).not.toHaveBeenCalled()
+    })
+
+    it('passes billingInterval correctly to getPriceId', async () => {
+      setupChangePlanHappyPath({ isUpgrade: true })
+
+      await SubscriptionService.changePlan('team-456', 'enterprise', 'yearly')
+
+      expect(mockPlanService.getPriceId).toHaveBeenCalledWith('enterprise', 'yearly')
     })
   })
 

--- a/packages/core/tests/jest/services/team.service.test.ts
+++ b/packages/core/tests/jest/services/team.service.test.ts
@@ -9,6 +9,13 @@ import { TeamService } from '@/core/lib/services/team.service'
 import { queryOneWithRLS, queryWithRLS, getTransactionClient } from '@/core/lib/db'
 import type { Team } from '@/core/lib/teams/types'
 
+// Mock config
+jest.mock('@/core/lib/config', () => ({
+  TEAMS_CONFIG: {
+    mode: 'single-tenant',
+  },
+}))
+
 // Mock database functions
 jest.mock('@/core/lib/db', () => ({
   queryOneWithRLS: jest.fn(),
@@ -96,7 +103,7 @@ describe('TeamService', () => {
 
       expect(result).toEqual(mockTeam)
       expect(mockQueryOneWithRLS).toHaveBeenCalledWith(
-        expect.stringContaining('ORDER BY "createdAt" ASC'),
+        expect.stringContaining('"isGlobal" = TRUE'),
         []
       )
     })

--- a/themes/default/migrations/093_marketplace_sample_data.sql
+++ b/themes/default/migrations/093_marketplace_sample_data.sql
@@ -1,0 +1,1107 @@
+-- Migration: 093_marketplace_sample_data.sql
+-- Description: Sample marketplace data - connected accounts, payments, and webhook events
+-- Date: 2026-03-20
+-- Theme: default
+-- Phase: Theme sample data - runs AFTER 092_billing_sample_data.sql
+--
+-- This file contains marketplace sample data for:
+-- - 7 connected accounts (Stripe Connect + MercadoPago, various statuses)
+-- - 25 marketplace payments (various statuses, currencies, amounts)
+-- - 12 webhook events (Stripe Connect + MercadoPago)
+--
+-- Uses teams from 090_demo_users_teams.sql and 091_greek_teams_billing.sql
+
+-- ============================================
+-- CONNECTED ACCOUNTS (7 accounts)
+-- ============================================
+-- 4 Stripe Connect accounts (active, in_progress, restricted, disconnected)
+-- 3 MercadoPago accounts (active in AR, BR, MX)
+
+INSERT INTO public."connectedAccounts" (
+  id,
+  "teamId",
+  provider,
+  "externalAccountId",
+  email,
+  "businessName",
+  country,
+  currency,
+  "onboardingStatus",
+  "chargesEnabled",
+  "payoutsEnabled",
+  "commissionRate",
+  "fixedFee",
+  "payoutSchedule",
+  metadata,
+  "createdAt",
+  "updatedAt"
+) VALUES
+  -- ========================================
+  -- STRIPE CONNECT ACCOUNTS
+  -- ========================================
+
+  -- Everpoint Labs → Stripe Connect (active, 15% commission)
+  (
+    'mkt-acct-everpoint-001',
+    'team-everpoint-001',
+    'stripe_connect',
+    'acct_everpoint_stripe_001',
+    'billing@everpointlabs.com',
+    'Everpoint Labs LLC',
+    'US',
+    'usd',
+    'active',
+    TRUE,
+    TRUE,
+    0.1500,
+    30,
+    'weekly',
+    '{"stripeAccountType": "express", "businessType": "company", "mcc": "5734"}'::jsonb,
+    NOW() - INTERVAL '90 days',
+    NOW() - INTERVAL '2 days'
+  ),
+
+  -- Alpha Tech → Stripe Connect (active, 10% commission)
+  (
+    'mkt-acct-alpha-001',
+    'team-alpha-001',
+    'stripe_connect',
+    'acct_alpha_stripe_001',
+    'finance@alphatech.io',
+    'Alpha Tech Inc.',
+    'US',
+    'usd',
+    'active',
+    TRUE,
+    TRUE,
+    0.1000,
+    25,
+    'daily',
+    '{"stripeAccountType": "express", "businessType": "company", "mcc": "7372"}'::jsonb,
+    NOW() - INTERVAL '120 days',
+    NOW() - INTERVAL '5 days'
+  ),
+
+  -- Beta Solutions → Stripe Connect (in_progress, 15% commission)
+  (
+    'mkt-acct-beta-001',
+    'team-beta-002',
+    'stripe_connect',
+    'acct_beta_stripe_001',
+    'admin@betasolutions.com',
+    'Beta Solutions Corp.',
+    'US',
+    'usd',
+    'in_progress',
+    FALSE,
+    FALSE,
+    0.1500,
+    30,
+    'weekly',
+    '{"stripeAccountType": "express", "businessType": "company", "pendingVerification": ["external_account", "identity_document"]}'::jsonb,
+    NOW() - INTERVAL '7 days',
+    NOW() - INTERVAL '1 day'
+  ),
+
+  -- Gamma Industries → Stripe Connect (restricted, 20% commission)
+  (
+    'mkt-acct-gamma-001',
+    'team-gamma-003',
+    'stripe_connect',
+    'acct_gamma_stripe_001',
+    'ops@gammaindustries.net',
+    'Gamma Industries Ltd.',
+    'GB',
+    'gbp',
+    'restricted',
+    TRUE,
+    FALSE,
+    0.2000,
+    50,
+    'monthly',
+    '{"stripeAccountType": "express", "businessType": "company", "restrictionReason": "past_due_requirements", "currentDeadline": "2026-04-15"}'::jsonb,
+    NOW() - INTERVAL '60 days',
+    NOW() - INTERVAL '3 days'
+  ),
+
+  -- ========================================
+  -- MERCADOPAGO ACCOUNTS
+  -- ========================================
+
+  -- Ironvale Global → MercadoPago Argentina (active, 15% commission)
+  (
+    'mkt-acct-ironvale-001',
+    'team-ironvale-002',
+    'mercadopago_split',
+    'mp_user_ironvale_ar_001',
+    'pagos@ironvaleglobal.com.ar',
+    'Ironvale Global SRL',
+    'AR',
+    'ars',
+    'active',
+    TRUE,
+    TRUE,
+    0.1500,
+    0,
+    'weekly',
+    '{"mpUserId": "123456789", "mpAccessToken": "APP_USR-xxxx-redacted", "mpRefreshToken": "TG-xxxx-redacted", "mpTokenExpiresAt": "2026-06-20T00:00:00Z", "cuit": "30-71234567-8"}'::jsonb,
+    NOW() - INTERVAL '75 days',
+    NOW() - INTERVAL '1 day'
+  ),
+
+  -- Riverstone Ventures → MercadoPago Brazil (active, 10% commission)
+  (
+    'mkt-acct-riverstone-001',
+    'team-riverstone-003',
+    'mercadopago_split',
+    'mp_user_riverstone_br_001',
+    'financeiro@riverstonebr.com.br',
+    'Riverstone Ventures Ltda.',
+    'BR',
+    'brl',
+    'active',
+    TRUE,
+    TRUE,
+    0.1000,
+    0,
+    'daily',
+    '{"mpUserId": "987654321", "mpAccessToken": "APP_USR-yyyy-redacted", "mpRefreshToken": "TG-yyyy-redacted", "mpTokenExpiresAt": "2026-07-10T00:00:00Z", "cnpj": "12.345.678/0001-90"}'::jsonb,
+    NOW() - INTERVAL '45 days',
+    NOW() - INTERVAL '4 days'
+  ),
+
+  -- Delta Dynamics → MercadoPago Mexico (active, 20% commission)
+  (
+    'mkt-acct-delta-001',
+    'team-delta-004',
+    'mercadopago_split',
+    'mp_user_delta_mx_001',
+    'cobranza@deltadynamics.mx',
+    'Delta Dynamics SA de CV',
+    'MX',
+    'mxn',
+    'active',
+    TRUE,
+    TRUE,
+    0.2000,
+    0,
+    'weekly',
+    '{"mpUserId": "456789123", "mpAccessToken": "APP_USR-zzzz-redacted", "mpRefreshToken": "TG-zzzz-redacted", "mpTokenExpiresAt": "2026-05-30T00:00:00Z", "rfc": "DDY201501ABC"}'::jsonb,
+    NOW() - INTERVAL '30 days',
+    NOW() - INTERVAL '2 days'
+  )
+ON CONFLICT (id) DO NOTHING;
+
+-- ============================================
+-- MARKETPLACE PAYMENTS (25 payments)
+-- ============================================
+-- Mix of statuses, currencies, amounts, and commission rates
+
+INSERT INTO public."marketplacePayments" (
+  id,
+  "connectedAccountId",
+  "teamId",
+  "referenceId",
+  "referenceType",
+  "externalPaymentId",
+  "externalChargeId",
+  "externalTransferId",
+  "totalAmount",
+  "applicationFee",
+  "businessAmount",
+  "providerFee",
+  currency,
+  "commissionRate",
+  status,
+  "statusDetail",
+  "paymentMethod",
+  "paymentType",
+  "refundedAmount",
+  metadata,
+  "paidAt",
+  "createdAt",
+  "updatedAt"
+) VALUES
+  -- ========================================
+  -- EVERPOINT LABS (Stripe Connect, USD, 15%)
+  -- ========================================
+
+  -- Succeeded payments
+  (
+    'mkt-pay-ever-001',
+    'mkt-acct-everpoint-001',
+    'team-everpoint-001',
+    'booking-001',
+    'booking',
+    'pi_ever_mkt_001',
+    'ch_ever_mkt_001',
+    'tr_ever_mkt_001',
+    25000,    -- $250.00
+    3750,     -- $37.50 (15%)
+    21250,    -- $212.50
+    725,      -- Stripe fee ~2.9%
+    'usd',
+    0.1500,
+    'succeeded',
+    'Payment completed successfully',
+    'card',
+    'one_time',
+    0,
+    '{"customerEmail": "john.doe@example.com", "bookingDate": "2026-03-01"}'::jsonb,
+    NOW() - INTERVAL '60 days',
+    NOW() - INTERVAL '60 days',
+    NOW() - INTERVAL '60 days'
+  ),
+  (
+    'mkt-pay-ever-002',
+    'mkt-acct-everpoint-001',
+    'team-everpoint-001',
+    'booking-002',
+    'booking',
+    'pi_ever_mkt_002',
+    'ch_ever_mkt_002',
+    'tr_ever_mkt_002',
+    15000,    -- $150.00
+    2250,     -- $22.50 (15%)
+    12750,    -- $127.50
+    435,
+    'usd',
+    0.1500,
+    'succeeded',
+    'Payment completed successfully',
+    'card',
+    'one_time',
+    0,
+    '{"customerEmail": "jane.smith@example.com", "bookingDate": "2026-03-05"}'::jsonb,
+    NOW() - INTERVAL '45 days',
+    NOW() - INTERVAL '45 days',
+    NOW() - INTERVAL '45 days'
+  ),
+  (
+    'mkt-pay-ever-003',
+    'mkt-acct-everpoint-001',
+    'team-everpoint-001',
+    'booking-003',
+    'booking',
+    'pi_ever_mkt_003',
+    'ch_ever_mkt_003',
+    'tr_ever_mkt_003',
+    50000,    -- $500.00
+    7500,     -- $75.00 (15%)
+    42500,    -- $425.00
+    1450,
+    'usd',
+    0.1500,
+    'succeeded',
+    'Payment completed successfully',
+    'card',
+    'one_time',
+    0,
+    '{"customerEmail": "bob.williams@example.com", "bookingDate": "2026-03-10"}'::jsonb,
+    NOW() - INTERVAL '30 days',
+    NOW() - INTERVAL '30 days',
+    NOW() - INTERVAL '30 days'
+  ),
+
+  -- Refunded payment
+  (
+    'mkt-pay-ever-004',
+    'mkt-acct-everpoint-001',
+    'team-everpoint-001',
+    'booking-004',
+    'booking',
+    'pi_ever_mkt_004',
+    'ch_ever_mkt_004',
+    'tr_ever_mkt_004',
+    35000,    -- $350.00
+    5250,     -- $52.50 (15%)
+    29750,    -- $297.50
+    1015,
+    'usd',
+    0.1500,
+    'refunded',
+    'Customer requested full refund - event canceled',
+    'card',
+    'one_time',
+    35000,    -- Full refund
+    '{"customerEmail": "carol.taylor@example.com", "bookingDate": "2026-03-08", "refundReason": "event_canceled"}'::jsonb,
+    NOW() - INTERVAL '40 days',
+    NOW() - INTERVAL '40 days',
+    NOW() - INTERVAL '35 days'
+  ),
+
+  -- Partially refunded
+  (
+    'mkt-pay-ever-005',
+    'mkt-acct-everpoint-001',
+    'team-everpoint-001',
+    'booking-005',
+    'booking',
+    'pi_ever_mkt_005',
+    'ch_ever_mkt_005',
+    'tr_ever_mkt_005',
+    18000,    -- $180.00
+    2700,     -- $27.00 (15%)
+    15300,    -- $153.00
+    522,
+    'usd',
+    0.1500,
+    'partially_refunded',
+    'Partial refund for late check-in',
+    'card',
+    'one_time',
+    5000,     -- $50 partial refund
+    '{"customerEmail": "dave.johnson@example.com", "bookingDate": "2026-03-12", "refundReason": "late_checkin"}'::jsonb,
+    NOW() - INTERVAL '25 days',
+    NOW() - INTERVAL '25 days',
+    NOW() - INTERVAL '20 days'
+  ),
+
+  -- Pending payment
+  (
+    'mkt-pay-ever-006',
+    'mkt-acct-everpoint-001',
+    'team-everpoint-001',
+    'booking-006',
+    'booking',
+    'pi_ever_mkt_006',
+    NULL,
+    NULL,
+    22000,    -- $220.00
+    3300,     -- $33.00 (15%)
+    18700,    -- $187.00
+    NULL,
+    'usd',
+    0.1500,
+    'pending',
+    'Awaiting payment confirmation',
+    'card',
+    'one_time',
+    0,
+    '{"customerEmail": "emma.white@example.com", "bookingDate": "2026-03-25"}'::jsonb,
+    NULL,
+    NOW() - INTERVAL '1 day',
+    NOW() - INTERVAL '1 day'
+  ),
+
+  -- ========================================
+  -- ALPHA TECH (Stripe Connect, USD, 10%)
+  -- ========================================
+
+  (
+    'mkt-pay-alpha-001',
+    'mkt-acct-alpha-001',
+    'team-alpha-001',
+    'order-001',
+    'order',
+    'pi_alpha_mkt_001',
+    'ch_alpha_mkt_001',
+    'tr_alpha_mkt_001',
+    9900,     -- $99.00
+    990,      -- $9.90 (10%)
+    8910,     -- $89.10
+    287,
+    'usd',
+    0.1000,
+    'succeeded',
+    'Payment completed successfully',
+    'card',
+    'one_time',
+    0,
+    '{"customerEmail": "alice.brown@example.com", "productId": "prod-saas-001"}'::jsonb,
+    NOW() - INTERVAL '50 days',
+    NOW() - INTERVAL '50 days',
+    NOW() - INTERVAL '50 days'
+  ),
+  (
+    'mkt-pay-alpha-002',
+    'mkt-acct-alpha-001',
+    'team-alpha-001',
+    'order-002',
+    'order',
+    'pi_alpha_mkt_002',
+    'ch_alpha_mkt_002',
+    'tr_alpha_mkt_002',
+    29900,    -- $299.00
+    2990,     -- $29.90 (10%)
+    26910,    -- $269.10
+    867,
+    'usd',
+    0.1000,
+    'succeeded',
+    'Payment completed successfully',
+    'card',
+    'one_time',
+    0,
+    '{"customerEmail": "frank.miller@example.com", "productId": "prod-saas-002"}'::jsonb,
+    NOW() - INTERVAL '35 days',
+    NOW() - INTERVAL '35 days',
+    NOW() - INTERVAL '35 days'
+  ),
+  (
+    'mkt-pay-alpha-003',
+    'mkt-acct-alpha-001',
+    'team-alpha-001',
+    'order-003',
+    'order',
+    'pi_alpha_mkt_003',
+    'ch_alpha_mkt_003',
+    'tr_alpha_mkt_003',
+    4900,     -- $49.00
+    490,      -- $4.90 (10%)
+    4410,     -- $44.10
+    142,
+    'usd',
+    0.1000,
+    'succeeded',
+    'Payment completed successfully',
+    'card',
+    'one_time',
+    0,
+    '{"customerEmail": "grace.lee@example.com", "productId": "prod-saas-003"}'::jsonb,
+    NOW() - INTERVAL '20 days',
+    NOW() - INTERVAL '20 days',
+    NOW() - INTERVAL '20 days'
+  ),
+
+  -- Failed payment
+  (
+    'mkt-pay-alpha-004',
+    'mkt-acct-alpha-001',
+    'team-alpha-001',
+    'order-004',
+    'order',
+    'pi_alpha_mkt_004',
+    NULL,
+    NULL,
+    19900,    -- $199.00
+    1990,     -- $19.90 (10%)
+    17910,    -- $179.10
+    NULL,
+    'usd',
+    0.1000,
+    'failed',
+    'Card declined: insufficient funds',
+    'card',
+    'one_time',
+    0,
+    '{"customerEmail": "henry.clark@example.com", "productId": "prod-saas-004", "failureCode": "card_declined"}'::jsonb,
+    NULL,
+    NOW() - INTERVAL '10 days',
+    NOW() - INTERVAL '10 days'
+  ),
+
+  -- Disputed payment
+  (
+    'mkt-pay-alpha-005',
+    'mkt-acct-alpha-001',
+    'team-alpha-001',
+    'order-005',
+    'order',
+    'pi_alpha_mkt_005',
+    'ch_alpha_mkt_005',
+    'tr_alpha_mkt_005',
+    14900,    -- $149.00
+    1490,     -- $14.90 (10%)
+    13410,    -- $134.10
+    432,
+    'usd',
+    0.1000,
+    'disputed',
+    'Customer dispute: product not as described',
+    'card',
+    'one_time',
+    0,
+    '{"customerEmail": "iris.wang@example.com", "productId": "prod-saas-005", "disputeId": "dp_alpha_001", "disputeReason": "product_not_received"}'::jsonb,
+    NOW() - INTERVAL '15 days',
+    NOW() - INTERVAL '15 days',
+    NOW() - INTERVAL '8 days'
+  ),
+
+  -- ========================================
+  -- IRONVALE GLOBAL (MercadoPago AR, ARS, 15%)
+  -- ========================================
+
+  (
+    'mkt-pay-iron-001',
+    'mkt-acct-ironvale-001',
+    'team-ironvale-002',
+    'booking-101',
+    'booking',
+    'mp_pay_iron_001',
+    NULL,
+    NULL,
+    150000,   -- ARS 150,000
+    22500,    -- ARS 22,500 (15%)
+    127500,   -- ARS 127,500
+    7500,
+    'ars',
+    0.1500,
+    'succeeded',
+    'Pago aprobado',
+    'credit_card',
+    'one_time',
+    0,
+    '{"customerEmail": "martin.perez@gmail.com", "mpPaymentId": "67890123", "installments": 1}'::jsonb,
+    NOW() - INTERVAL '55 days',
+    NOW() - INTERVAL '55 days',
+    NOW() - INTERVAL '55 days'
+  ),
+  (
+    'mkt-pay-iron-002',
+    'mkt-acct-ironvale-001',
+    'team-ironvale-002',
+    'booking-102',
+    'booking',
+    'mp_pay_iron_002',
+    NULL,
+    NULL,
+    250000,   -- ARS 250,000
+    37500,    -- ARS 37,500 (15%)
+    212500,   -- ARS 212,500
+    12500,
+    'ars',
+    0.1500,
+    'succeeded',
+    'Pago aprobado',
+    'debit_card',
+    'one_time',
+    0,
+    '{"customerEmail": "lucia.gomez@yahoo.com.ar", "mpPaymentId": "67890124", "installments": 1}'::jsonb,
+    NOW() - INTERVAL '40 days',
+    NOW() - INTERVAL '40 days',
+    NOW() - INTERVAL '40 days'
+  ),
+  (
+    'mkt-pay-iron-003',
+    'mkt-acct-ironvale-001',
+    'team-ironvale-002',
+    'booking-103',
+    'booking',
+    'mp_pay_iron_003',
+    NULL,
+    NULL,
+    480000,   -- ARS 480,000
+    72000,    -- ARS 72,000 (15%)
+    408000,   -- ARS 408,000
+    24000,
+    'ars',
+    0.1500,
+    'succeeded',
+    'Pago aprobado - 6 cuotas',
+    'credit_card',
+    'one_time',
+    0,
+    '{"customerEmail": "nicolas.silva@hotmail.com", "mpPaymentId": "67890125", "installments": 6}'::jsonb,
+    NOW() - INTERVAL '22 days',
+    NOW() - INTERVAL '22 days',
+    NOW() - INTERVAL '22 days'
+  ),
+
+  -- Pending in MercadoPago (waiting for payment)
+  (
+    'mkt-pay-iron-004',
+    'mkt-acct-ironvale-001',
+    'team-ironvale-002',
+    'booking-104',
+    'booking',
+    'mp_pay_iron_004',
+    NULL,
+    NULL,
+    95000,    -- ARS 95,000
+    14250,    -- ARS 14,250 (15%)
+    80750,    -- ARS 80,750
+    NULL,
+    'ars',
+    0.1500,
+    'pending',
+    'Esperando pago en efectivo (Rapipago)',
+    'ticket',
+    'one_time',
+    0,
+    '{"customerEmail": "ana.martinez@gmail.com", "mpPaymentId": "67890126", "paymentPointName": "Rapipago"}'::jsonb,
+    NULL,
+    NOW() - INTERVAL '2 days',
+    NOW() - INTERVAL '2 days'
+  ),
+
+  -- ========================================
+  -- RIVERSTONE VENTURES (MercadoPago BR, BRL, 10%)
+  -- ========================================
+
+  (
+    'mkt-pay-river-001',
+    'mkt-acct-riverstone-001',
+    'team-riverstone-003',
+    'booking-201',
+    'booking',
+    'mp_pay_river_001',
+    NULL,
+    NULL,
+    35000,    -- BRL 350.00
+    3500,     -- BRL 35.00 (10%)
+    31500,    -- BRL 315.00
+    1750,
+    'brl',
+    0.1000,
+    'succeeded',
+    'Pagamento aprovado',
+    'credit_card',
+    'one_time',
+    0,
+    '{"customerEmail": "pedro.santos@gmail.com.br", "mpPaymentId": "11223344", "installments": 1}'::jsonb,
+    NOW() - INTERVAL '38 days',
+    NOW() - INTERVAL '38 days',
+    NOW() - INTERVAL '38 days'
+  ),
+  (
+    'mkt-pay-river-002',
+    'mkt-acct-riverstone-001',
+    'team-riverstone-003',
+    'booking-202',
+    'booking',
+    'mp_pay_river_002',
+    NULL,
+    NULL,
+    89000,    -- BRL 890.00
+    8900,     -- BRL 89.00 (10%)
+    80100,    -- BRL 801.00
+    4450,
+    'brl',
+    0.1000,
+    'succeeded',
+    'Pagamento aprovado via Pix',
+    'pix',
+    'one_time',
+    0,
+    '{"customerEmail": "maria.oliveira@outlook.com.br", "mpPaymentId": "11223345", "pixKey": "email"}'::jsonb,
+    NOW() - INTERVAL '18 days',
+    NOW() - INTERVAL '18 days',
+    NOW() - INTERVAL '18 days'
+  ),
+  (
+    'mkt-pay-river-003',
+    'mkt-acct-riverstone-001',
+    'team-riverstone-003',
+    'booking-203',
+    'booking',
+    'mp_pay_river_003',
+    NULL,
+    NULL,
+    125000,   -- BRL 1,250.00
+    12500,    -- BRL 125.00 (10%)
+    112500,   -- BRL 1,125.00
+    6250,
+    'brl',
+    0.1000,
+    'succeeded',
+    'Pagamento aprovado - 3 parcelas',
+    'credit_card',
+    'one_time',
+    0,
+    '{"customerEmail": "joao.costa@gmail.com.br", "mpPaymentId": "11223346", "installments": 3}'::jsonb,
+    NOW() - INTERVAL '5 days',
+    NOW() - INTERVAL '5 days',
+    NOW() - INTERVAL '5 days'
+  ),
+
+  -- Refunded BRL payment
+  (
+    'mkt-pay-river-004',
+    'mkt-acct-riverstone-001',
+    'team-riverstone-003',
+    'booking-204',
+    'booking',
+    'mp_pay_river_004',
+    NULL,
+    NULL,
+    45000,    -- BRL 450.00
+    4500,     -- BRL 45.00 (10%)
+    40500,    -- BRL 405.00
+    2250,
+    'brl',
+    0.1000,
+    'refunded',
+    'Reembolso total - servico nao prestado',
+    'credit_card',
+    'one_time',
+    45000,    -- Full refund
+    '{"customerEmail": "rafael.lima@yahoo.com.br", "mpPaymentId": "11223347", "refundReason": "service_not_provided"}'::jsonb,
+    NOW() - INTERVAL '28 days',
+    NOW() - INTERVAL '28 days',
+    NOW() - INTERVAL '24 days'
+  ),
+
+  -- ========================================
+  -- DELTA DYNAMICS (MercadoPago MX, MXN, 20%)
+  -- ========================================
+
+  (
+    'mkt-pay-delta-001',
+    'mkt-acct-delta-001',
+    'team-delta-004',
+    'booking-301',
+    'booking',
+    'mp_pay_delta_001',
+    NULL,
+    NULL,
+    350000,   -- MXN 3,500.00
+    70000,    -- MXN 700.00 (20%)
+    280000,   -- MXN 2,800.00
+    17500,
+    'mxn',
+    0.2000,
+    'succeeded',
+    'Pago aprobado',
+    'credit_card',
+    'one_time',
+    0,
+    '{"customerEmail": "carlos.hernandez@gmail.com.mx", "mpPaymentId": "55667788", "installments": 1}'::jsonb,
+    NOW() - INTERVAL '20 days',
+    NOW() - INTERVAL '20 days',
+    NOW() - INTERVAL '20 days'
+  ),
+  (
+    'mkt-pay-delta-002',
+    'mkt-acct-delta-001',
+    'team-delta-004',
+    'booking-302',
+    'booking',
+    'mp_pay_delta_002',
+    NULL,
+    NULL,
+    180000,   -- MXN 1,800.00
+    36000,    -- MXN 360.00 (20%)
+    144000,   -- MXN 1,440.00
+    9000,
+    'mxn',
+    0.2000,
+    'succeeded',
+    'Pago aprobado',
+    'debit_card',
+    'one_time',
+    0,
+    '{"customerEmail": "rosa.morales@outlook.com.mx", "mpPaymentId": "55667789", "installments": 1}'::jsonb,
+    NOW() - INTERVAL '12 days',
+    NOW() - INTERVAL '12 days',
+    NOW() - INTERVAL '12 days'
+  ),
+
+  -- Failed MXN payment
+  (
+    'mkt-pay-delta-003',
+    'mkt-acct-delta-001',
+    'team-delta-004',
+    'booking-303',
+    'booking',
+    'mp_pay_delta_003',
+    NULL,
+    NULL,
+    520000,   -- MXN 5,200.00
+    104000,   -- MXN 1,040.00 (20%)
+    416000,   -- MXN 4,160.00
+    NULL,
+    'mxn',
+    0.2000,
+    'failed',
+    'Tarjeta rechazada: fondos insuficientes',
+    'credit_card',
+    'one_time',
+    0,
+    '{"customerEmail": "jorge.lopez@gmail.com.mx", "mpPaymentId": "55667790", "failureCode": "cc_rejected_insufficient_amount"}'::jsonb,
+    NULL,
+    NOW() - INTERVAL '6 days',
+    NOW() - INTERVAL '6 days'
+  ),
+
+  -- ========================================
+  -- GAMMA INDUSTRIES (Stripe Connect, GBP, 20% - restricted account)
+  -- ========================================
+
+  (
+    'mkt-pay-gamma-001',
+    'mkt-acct-gamma-001',
+    'team-gamma-003',
+    'booking-401',
+    'booking',
+    'pi_gamma_mkt_001',
+    'ch_gamma_mkt_001',
+    'tr_gamma_mkt_001',
+    12000,    -- GBP 120.00
+    2400,     -- GBP 24.00 (20%)
+    9600,     -- GBP 96.00
+    348,
+    'gbp',
+    0.2000,
+    'succeeded',
+    'Payment completed successfully',
+    'card',
+    'one_time',
+    0,
+    '{"customerEmail": "oliver.jones@example.co.uk", "bookingDate": "2026-02-20"}'::jsonb,
+    NOW() - INTERVAL '42 days',
+    NOW() - INTERVAL '42 days',
+    NOW() - INTERVAL '42 days'
+  )
+ON CONFLICT (id) DO NOTHING;
+
+-- ============================================
+-- MARKETPLACE WEBHOOK EVENTS (12 events)
+-- ============================================
+
+INSERT INTO public."marketplaceWebhookEvents" (
+  id,
+  provider,
+  "externalEventId",
+  "eventType",
+  action,
+  "resourceId",
+  processed,
+  "processedAt",
+  error,
+  "rawPayload",
+  "createdAt"
+) VALUES
+  -- ========================================
+  -- STRIPE CONNECT WEBHOOK EVENTS
+  -- ========================================
+
+  -- Account onboarding completed
+  (
+    'mkt-wh-001',
+    'stripe_connect',
+    'evt_stripe_acct_updated_001',
+    'account.updated',
+    'onboarding_complete',
+    'acct_everpoint_stripe_001',
+    TRUE,
+    NOW() - INTERVAL '89 days',
+    NULL,
+    '{"id": "evt_stripe_acct_updated_001", "type": "account.updated", "data": {"object": {"id": "acct_everpoint_stripe_001", "charges_enabled": true, "payouts_enabled": true}}}'::jsonb,
+    NOW() - INTERVAL '89 days'
+  ),
+
+  -- Payment intent succeeded
+  (
+    'mkt-wh-002',
+    'stripe_connect',
+    'evt_stripe_pi_succeeded_001',
+    'payment_intent.succeeded',
+    'payment_captured',
+    'pi_ever_mkt_001',
+    TRUE,
+    NOW() - INTERVAL '60 days',
+    NULL,
+    '{"id": "evt_stripe_pi_succeeded_001", "type": "payment_intent.succeeded", "data": {"object": {"id": "pi_ever_mkt_001", "amount": 25000, "currency": "usd"}}}'::jsonb,
+    NOW() - INTERVAL '60 days'
+  ),
+
+  -- Charge refunded
+  (
+    'mkt-wh-003',
+    'stripe_connect',
+    'evt_stripe_charge_refund_001',
+    'charge.refunded',
+    'refund_processed',
+    'ch_ever_mkt_004',
+    TRUE,
+    NOW() - INTERVAL '35 days',
+    NULL,
+    '{"id": "evt_stripe_charge_refund_001", "type": "charge.refunded", "data": {"object": {"id": "ch_ever_mkt_004", "amount_refunded": 35000}}}'::jsonb,
+    NOW() - INTERVAL '35 days'
+  ),
+
+  -- Charge disputed
+  (
+    'mkt-wh-004',
+    'stripe_connect',
+    'evt_stripe_dispute_001',
+    'charge.dispute.created',
+    'dispute_opened',
+    'ch_alpha_mkt_005',
+    TRUE,
+    NOW() - INTERVAL '8 days',
+    NULL,
+    '{"id": "evt_stripe_dispute_001", "type": "charge.dispute.created", "data": {"object": {"id": "dp_alpha_001", "charge": "ch_alpha_mkt_005", "amount": 14900, "reason": "product_not_received"}}}'::jsonb,
+    NOW() - INTERVAL '8 days'
+  ),
+
+  -- Account restricted notification
+  (
+    'mkt-wh-005',
+    'stripe_connect',
+    'evt_stripe_acct_restricted_001',
+    'account.updated',
+    'requirements_past_due',
+    'acct_gamma_stripe_001',
+    TRUE,
+    NOW() - INTERVAL '3 days',
+    NULL,
+    '{"id": "evt_stripe_acct_restricted_001", "type": "account.updated", "data": {"object": {"id": "acct_gamma_stripe_001", "requirements": {"past_due": ["individual.verification.document"]}}}}'::jsonb,
+    NOW() - INTERVAL '3 days'
+  ),
+
+  -- Payment failed (unprocessed - simulates retry scenario)
+  (
+    'mkt-wh-006',
+    'stripe_connect',
+    'evt_stripe_pi_failed_001',
+    'payment_intent.payment_failed',
+    'payment_failed',
+    'pi_alpha_mkt_004',
+    FALSE,
+    NULL,
+    'Retry scheduled: webhook handler timeout',
+    '{"id": "evt_stripe_pi_failed_001", "type": "payment_intent.payment_failed", "data": {"object": {"id": "pi_alpha_mkt_004", "last_payment_error": {"code": "card_declined"}}}}'::jsonb,
+    NOW() - INTERVAL '10 days'
+  ),
+
+  -- ========================================
+  -- MERCADOPAGO WEBHOOK EVENTS
+  -- ========================================
+
+  -- Payment approved (AR)
+  (
+    'mkt-wh-007',
+    'mercadopago_split',
+    'mp_evt_payment_001',
+    'payment',
+    'payment.created',
+    'mp_pay_iron_001',
+    TRUE,
+    NOW() - INTERVAL '55 days',
+    NULL,
+    '{"id": "mp_evt_payment_001", "type": "payment", "action": "payment.created", "data": {"id": "67890123"}}'::jsonb,
+    NOW() - INTERVAL '55 days'
+  ),
+
+  -- Payment approved (BR - Pix)
+  (
+    'mkt-wh-008',
+    'mercadopago_split',
+    'mp_evt_payment_002',
+    'payment',
+    'payment.created',
+    'mp_pay_river_002',
+    TRUE,
+    NOW() - INTERVAL '18 days',
+    NULL,
+    '{"id": "mp_evt_payment_002", "type": "payment", "action": "payment.created", "data": {"id": "11223345"}}'::jsonb,
+    NOW() - INTERVAL '18 days'
+  ),
+
+  -- Payment refunded (BR)
+  (
+    'mkt-wh-009',
+    'mercadopago_split',
+    'mp_evt_refund_001',
+    'payment',
+    'payment.updated',
+    'mp_pay_river_004',
+    TRUE,
+    NOW() - INTERVAL '24 days',
+    NULL,
+    '{"id": "mp_evt_refund_001", "type": "payment", "action": "payment.updated", "data": {"id": "11223347", "status": "refunded"}}'::jsonb,
+    NOW() - INTERVAL '24 days'
+  ),
+
+  -- Payment approved (MX)
+  (
+    'mkt-wh-010',
+    'mercadopago_split',
+    'mp_evt_payment_003',
+    'payment',
+    'payment.created',
+    'mp_pay_delta_001',
+    TRUE,
+    NOW() - INTERVAL '20 days',
+    NULL,
+    '{"id": "mp_evt_payment_003", "type": "payment", "action": "payment.created", "data": {"id": "55667788"}}'::jsonb,
+    NOW() - INTERVAL '20 days'
+  ),
+
+  -- Payment failed (MX - unprocessed)
+  (
+    'mkt-wh-011',
+    'mercadopago_split',
+    'mp_evt_payment_fail_001',
+    'payment',
+    'payment.updated',
+    'mp_pay_delta_003',
+    FALSE,
+    NULL,
+    NULL,
+    '{"id": "mp_evt_payment_fail_001", "type": "payment", "action": "payment.updated", "data": {"id": "55667790", "status": "rejected"}}'::jsonb,
+    NOW() - INTERVAL '6 days'
+  ),
+
+  -- Pending ticket payment (AR - not yet processed)
+  (
+    'mkt-wh-012',
+    'mercadopago_split',
+    'mp_evt_payment_pending_001',
+    'payment',
+    'payment.created',
+    'mp_pay_iron_004',
+    TRUE,
+    NOW() - INTERVAL '2 days',
+    NULL,
+    '{"id": "mp_evt_payment_pending_001", "type": "payment", "action": "payment.created", "data": {"id": "67890126", "status": "pending", "status_detail": "pending_waiting_payment"}}'::jsonb,
+    NOW() - INTERVAL '2 days'
+  )
+ON CONFLICT (id) DO NOTHING;
+
+-- ============================================
+-- SUCCESS SUMMARY
+-- ============================================
+
+DO $$
+DECLARE
+  account_count INTEGER;
+  payment_count INTEGER;
+  webhook_count INTEGER;
+  total_usd NUMERIC;
+  total_ars NUMERIC;
+  total_brl NUMERIC;
+  total_mxn NUMERIC;
+BEGIN
+  SELECT COUNT(*) INTO account_count FROM "connectedAccounts" WHERE id LIKE 'mkt-acct-%';
+  SELECT COUNT(*) INTO payment_count FROM "marketplacePayments" WHERE id LIKE 'mkt-pay-%';
+  SELECT COUNT(*) INTO webhook_count FROM "marketplaceWebhookEvents" WHERE id LIKE 'mkt-wh-%';
+
+  SELECT COALESCE(SUM("totalAmount"), 0) INTO total_usd FROM "marketplacePayments" WHERE id LIKE 'mkt-pay-%' AND currency = 'usd';
+  SELECT COALESCE(SUM("totalAmount"), 0) INTO total_ars FROM "marketplacePayments" WHERE id LIKE 'mkt-pay-%' AND currency = 'ars';
+  SELECT COALESCE(SUM("totalAmount"), 0) INTO total_brl FROM "marketplacePayments" WHERE id LIKE 'mkt-pay-%' AND currency = 'brl';
+  SELECT COALESCE(SUM("totalAmount"), 0) INTO total_mxn FROM "marketplacePayments" WHERE id LIKE 'mkt-pay-%' AND currency = 'mxn';
+
+  RAISE NOTICE '';
+  RAISE NOTICE '════════════════════════════════════════════════════════════';
+  RAISE NOTICE '  Theme Migration 093_marketplace_sample_data.sql completed!';
+  RAISE NOTICE '════════════════════════════════════════════════════════════';
+  RAISE NOTICE '';
+  RAISE NOTICE '  MARKETPLACE DATA STATISTICS:';
+  RAISE NOTICE '     Connected Accounts:  %', account_count;
+  RAISE NOTICE '     Marketplace Payments: %', payment_count;
+  RAISE NOTICE '     Webhook Events:       %', webhook_count;
+  RAISE NOTICE '';
+  RAISE NOTICE '  CONNECTED ACCOUNTS:';
+  RAISE NOTICE '     Everpoint Labs    - Stripe Connect (active, 15%%, USD)';
+  RAISE NOTICE '     Alpha Tech        - Stripe Connect (active, 10%%, USD)';
+  RAISE NOTICE '     Beta Solutions    - Stripe Connect (in_progress, 15%%)';
+  RAISE NOTICE '     Gamma Industries  - Stripe Connect (restricted, 20%%, GBP)';
+  RAISE NOTICE '     Ironvale Global   - MercadoPago AR (active, 15%%, ARS)';
+  RAISE NOTICE '     Riverstone Ventures - MercadoPago BR (active, 10%%, BRL)';
+  RAISE NOTICE '     Delta Dynamics    - MercadoPago MX (active, 20%%, MXN)';
+  RAISE NOTICE '';
+  RAISE NOTICE '  PAYMENT VOLUME:';
+  RAISE NOTICE '     USD: $% (% cents)', (total_usd / 100.0), total_usd;
+  RAISE NOTICE '     ARS: $%', total_ars;
+  RAISE NOTICE '     BRL: R$% (% centavos)', (total_brl / 100.0), total_brl;
+  RAISE NOTICE '     MXN: $%', total_mxn;
+  RAISE NOTICE '';
+  RAISE NOTICE '  PAYMENT STATUSES:';
+  RAISE NOTICE '     succeeded, pending, failed, refunded,';
+  RAISE NOTICE '     partially_refunded, disputed';
+  RAISE NOTICE '';
+  RAISE NOTICE '════════════════════════════════════════════════════════════';
+END $$;


### PR DESCRIPTION
## Summary

Adds a complete marketplace payment splitting module, enabling platforms to collect payments on behalf of connected businesses (e.g., hair salons, booking platforms) and retain a configurable commission.

- **7 commits**, +3,940 lines across 17 new files
- Parallel to `billing/` (SaaS subscriptions): `marketplace/` handles customer → business payments with platform commission
- Two providers: Stripe Connect (Express + Destination Charges) and MercadoPago Split (OAuth + marketplace_fee)
- 38 unit tests, all passing

## Architecture

```
billing/   = Business pays the PLATFORM (SaaS subscription)
marketplace/ = Customer pays, PLATFORM takes commission, business gets the rest
```

### Core Module (`packages/core/src/lib/marketplace/`)

| File | Purpose |
|------|---------|
| `types.ts` | ConnectedAccount, MarketplacePayment, Payout, CommissionConfig |
| `interface.ts` | MarketplaceGateway (14 methods: accounts, payments, refunds, payouts, webhooks) |
| `gateways/stripe-connect.ts` | Express accounts + Destination charges with application_fee |
| `gateways/mercadopago-split.ts` | OAuth marketplace + marketplace_fee + token refresh helpers |
| `gateways/factory.ts` | Singleton factory (MARKETPLACE_PROVIDER env var) |
| `commission.ts` | Fee calculator: percentage, fixed, hybrid, tiered with min/max |
| `stripe-connect-webhook.ts` | account.updated, payment lifecycle, disputes, payouts |
| `mercadopago-webhook.ts` | x-signature HMAC verification, fetch-full-resource pattern |
| `token-encryption.ts` | AES-256-GCM encryption for OAuth tokens at rest |
| `index.ts` | Barrel exports |

### API Routes (`apps/dev/app/api/v1/marketplace/`)

| Route | Method | Purpose |
|-------|--------|---------|
| `/connect` | POST | Create connected account + onboarding link |
| `/checkout` | POST | Create split payment checkout session |
| `/account` | GET | Connected account status + balance |
| `/oauth/callback` | GET | MercadoPago OAuth code exchange (with CSRF protection) |
| `/webhooks/stripe-connect` | POST | Stripe Connect webhook handler |
| `/webhooks/mercadopago` | POST | MercadoPago webhook handler |

### Database (`022_marketplace.sql`)

- `connectedAccounts` — Merchant accounts (Stripe/MP) with commission config
- `marketplacePayments` — Split payments with fee tracking
- `marketplaceWebhookEvents` — Idempotency for provider webhooks

## Security

Two HIGH severity vulnerabilities were identified via security review and fixed:

1. **OAuth CSRF** — `state` parameter now uses `crypto.randomUUID()` with DB lookup + one-time use + auth check (was raw teamId)
2. **Plaintext tokens** — OAuth tokens encrypted with AES-256-GCM before DB storage (requires `MARKETPLACE_TOKEN_ENCRYPTION_KEY`)

## Example Flow (Hair Salon)

1. Salon onboards: `POST /marketplace/connect` → redirects to Stripe/MP
2. Customer books: `POST /marketplace/checkout` → checkout with 15% commission
3. Customer pays $100 → Platform gets $15, salon gets ~$82 (after provider fees)
4. Webhook confirms → booking marked as "paid"

## Environment Variables

```bash
# Stripe Connect
STRIPE_CONNECT_WEBHOOK_SECRET=whsec_...

# MercadoPago Split
MARKETPLACE_PROVIDER=stripe_connect  # or mercadopago_split
MP_APP_ID=...
MP_CLIENT_SECRET=...
MP_ACCESS_TOKEN=TEST-...
MP_WEBHOOK_SECRET=...

# Token Encryption (required)
MARKETPLACE_TOKEN_ENCRYPTION_KEY=<64-char hex>  # node -e "console.log(require('crypto').randomBytes(32).toString('hex'))"
```

## Tests

- 38 unit tests (commission calculator, factory, Stripe Connect gateway)
- All passing, no regressions in existing billing tests (169 pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)