### PR TITLE
fix(core): add rich-text case to ArrayField renderItemField

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nextsparkjs/core",
-  "version": "0.1.0-beta.137",
+  "version": "0.1.0-beta.138",
   "description": "NextSpark - The complete SaaS framework for Next.js",
   "license": "MIT",
   "author": "NextSpark <hello@nextspark.dev>",

--- a/packages/core/src/components/dashboard/block-editor/array-field.tsx
+++ b/packages/core/src/components/dashboard/block-editor/array-field.tsx
@@ -14,6 +14,7 @@ import {
   SelectValue,
 } from '../../ui/select'
 import { ImageUpload } from '../../ui/image-upload'
+import { RichTextEditor } from '../../ui/rich-text-editor'
 import { MediaLibrary } from '../../media/MediaLibrary'
 import { Card, CardContent, CardHeader } from '../../ui/card'
 import { ChevronUp, ChevronDown, Trash2, Plus, ImageIcon, X } from 'lucide-react'
@@ -226,6 +227,16 @@ export function ArrayField({ field, value, onChange }: ArrayFieldProps) {
             value={String(fieldValue || '')}
             onChange={(url) => handleItemFieldChange(itemIndex, itemField.name, url)}
             fieldName={`${field.name}-${itemIndex}-${itemField.name}`}
+          />
+        )
+
+      case 'rich-text':
+        return (
+          <RichTextEditor
+            value={String(fieldValue)}
+            onChange={(newValue) => handleItemFieldChange(itemIndex, itemField.name, newValue)}
+            placeholder={itemField.placeholder}
+            data-cy={sel('blockEditor.blockPropertiesPanel.form.arrayField.itemField', { name: field.name, index: itemIndex, field: itemField.name })}
           />
         )
 


### PR DESCRIPTION
ArrayField supported rich-text as a valid FieldType in the type definitions, but the renderItemField switch statement was missing the case, causing it to fall through to the default plain text input.

Affects any block using rich-text inside itemFields (e.g. FAQ accordion).

Bumps @nextsparkjs/core to 0.1.0-beta.138.