### PR TITLE
fix(core): sendOnSignUp + export getStripeInstance (unblocks Synap)

### DIFF
--- a/packages/core/src/lib/auth.ts
+++ b/packages/core/src/lib/auth.ts
@@ -117,6 +117,7 @@ export const auth = betterAuth({
     },
   },
   emailVerification: {
+    sendOnSignUp: false,
     sendVerificationEmail: async ({ user, token }: { user: UserWithEmail; url: string; token: string }) => {
       try {
         const verifyUrl = `${baseUrl}/api/auth/verify-email?token=${token}`;

--- a/packages/core/src/lib/billing/gateways/stripe.ts
+++ b/packages/core/src/lib/billing/gateways/stripe.ts
@@ -27,7 +27,16 @@ import type {
 // Lazy-load Stripe client to avoid initialization during build time
 let stripeInstance: Stripe | null = null
 
-function getStripe(): Stripe {
+/**
+ * Lazy accessor for the shared Stripe SDK client. Returns the same instance on
+ * every call. Throws if STRIPE_SECRET_KEY is not configured.
+ *
+ * Exported so theme code can reach the SDK directly for the few cases the
+ * BillingGateway interface does not cover (e.g. updating subscription
+ * `quantity`, which is not part of UpdateSubscriptionParams). Prefer the
+ * BillingGateway interface for everything it already exposes.
+ */
+export function getStripeInstance(): Stripe {
   if (!stripeInstance) {
     if (!process.env.STRIPE_SECRET_KEY) {
       throw new Error('STRIPE_SECRET_KEY is not configured')
@@ -84,7 +93,7 @@ export class StripeGateway implements BillingGateway {
       }
     }
 
-    const session = await getStripe().checkout.sessions.create(sessionParams)
+    const session = await getStripeInstance().checkout.sessions.create(sessionParams)
     return { id: session.id, url: session.url }
   }
 
@@ -107,12 +116,12 @@ export class StripeGateway implements BillingGateway {
       sessionParams.customer_email = customerEmail
     }
 
-    const session = await getStripe().checkout.sessions.create(sessionParams)
+    const session = await getStripeInstance().checkout.sessions.create(sessionParams)
     return { id: session.id, url: session.url }
   }
 
   async createPortalSession(params: CreatePortalParams): Promise<PortalSessionResult> {
-    const session = await getStripe().billingPortal.sessions.create({
+    const session = await getStripeInstance().billingPortal.sessions.create({
       customer: params.customerId,
       return_url: params.returnUrl
     })
@@ -128,7 +137,7 @@ export class StripeGateway implements BillingGateway {
     const signature = typeof signatureOrHeaders === 'string'
       ? signatureOrHeaders
       : signatureOrHeaders['stripe-signature'] || ''
-    const event = getStripe().webhooks.constructEvent(payload, signature, webhookSecret)
+    const event = getStripeInstance().webhooks.constructEvent(payload, signature, webhookSecret)
     return {
       id: event.id,
       type: event.type,
@@ -137,7 +146,7 @@ export class StripeGateway implements BillingGateway {
   }
 
   async getCustomer(customerId: string): Promise<CustomerResult> {
-    const customer = await getStripe().customers.retrieve(customerId)
+    const customer = await getStripeInstance().customers.retrieve(customerId)
     if ('deleted' in customer && customer.deleted) {
       throw new Error(`Customer ${customerId} has been deleted`)
     }
@@ -149,7 +158,7 @@ export class StripeGateway implements BillingGateway {
   }
 
   async createCustomer(params: CreateCustomerParams): Promise<CustomerResult> {
-    const customer = await getStripe().customers.create(params)
+    const customer = await getStripeInstance().customers.create(params)
     return {
       id: customer.id,
       email: customer.email ?? null,
@@ -159,7 +168,7 @@ export class StripeGateway implements BillingGateway {
 
   async updateSubscriptionPlan(params: UpdateSubscriptionParams): Promise<SubscriptionResult> {
     const { subscriptionId, newPriceId, prorationBehavior = 'create_prorations' } = params
-    const stripe = getStripe()
+    const stripe = getStripeInstance()
 
     // Get current subscription to find the item ID
     const subscription = await stripe.subscriptions.retrieve(subscriptionId)
@@ -185,7 +194,7 @@ export class StripeGateway implements BillingGateway {
   }
 
   async cancelSubscriptionAtPeriodEnd(subscriptionId: string): Promise<SubscriptionResult> {
-    const updated = await getStripe().subscriptions.update(subscriptionId, {
+    const updated = await getStripeInstance().subscriptions.update(subscriptionId, {
       cancel_at_period_end: true
     })
     return {
@@ -196,7 +205,7 @@ export class StripeGateway implements BillingGateway {
   }
 
   async cancelSubscriptionImmediately(subscriptionId: string): Promise<SubscriptionResult> {
-    const canceled = await getStripe().subscriptions.cancel(subscriptionId)
+    const canceled = await getStripeInstance().subscriptions.cancel(subscriptionId)
     return {
       id: canceled.id,
       status: canceled.status,
@@ -225,7 +234,7 @@ export class StripeGateway implements BillingGateway {
   }
 
   async reactivateSubscription(subscriptionId: string): Promise<SubscriptionResult> {
-    const updated = await getStripe().subscriptions.update(subscriptionId, {
+    const updated = await getStripeInstance().subscriptions.update(subscriptionId, {
       cancel_at_period_end: false
     })
     return {


### PR DESCRIPTION
## Summary

Two small, additive fixes reported by an external consumer (Synap project) that were verified against the latest published core (`0.1.0-beta.147`) and confirmed to still exist on `main`.

- **`fix(core/auth)`** — Add `sendOnSignUp: false` to `emailVerification` config in `packages/core/src/lib/auth.ts`. Better Auth was firing the verification email automatically on `/sign-up/email` even when the consumer project verifies email ownership through other means (OTP code, invitation token). The verification email caused user confusion. `requireEmailVerification: true` is preserved (sign-in gate unchanged) and `sendVerificationEmail` is still exported for explicit use.
- **`fix(core/billing)`** — Rename internal `getStripe()` helper to `getStripeInstance()` and export it from `packages/core/src/lib/billing/gateways/stripe.ts`. Backward-compatible: `StripeGateway` class export is unchanged. Unblocks themes that need raw Stripe SDK access for cases the `BillingGateway` interface does not cover (e.g. updating subscription `quantity`, not part of `UpdateSubscriptionParams`).

Both fixes are minimal, non-breaking, and additive. See referenced tickets in `.claude/sessions/tasks/` for full root-cause and reproduction context.

## Tickets

- `.claude/sessions/tasks/2026-04-24-suppress-verification-email-on-signup/requirements.md`
- `.claude/sessions/tasks/2026-05-04-export-getStripeInstance-from-stripe-gateway/requirements.md`

## Test plan

- [x] `pnpm build` in `packages/core` — completes; pre-existing TS errors in unrelated files (theme/usage/teams), confirmed to also exist on clean `main` (verified via `git stash`)
- [x] `pnpm jest tests/jest/lib/billing/ tests/jest/services/subscription.service.test.ts` — 5/6 suites pass (213 tests). The only failing suite (`stripe.test.ts`) fails identically on clean `main` (Jest ESM/`rou3` config issue, pre-existing)
- [x] Verified `dist/lib/billing/gateways/stripe.d.ts` exports `getStripeInstance` after build
- [x] Verified `dist/lib/auth.js` contains `sendOnSignUp: false` after build
- [x] Verified zero remaining `getStripe()` (without `Instance`) call sites in `stripe.ts`
- [ ] After merge: bump to `0.1.0-beta.148` and publish so Synap can `pnpm install`

## Out of scope

- Pre-existing Jest config issue with `rou3` ESM resolution (separate task).
- Pre-existing TS errors in `theme.service.ts`, `usage.service.ts`, `teams/schema.ts`, `static-intl-provider.tsx` (separate task).
- Extending `BillingGateway.UpdateSubscriptionParams` to expose `quantity` (would obviate the need for raw Stripe access; larger API change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)