### PR TITLE
feat(core/auth): make sendOnSignUp verification email configurable per theme

### DIFF
--- a/packages/core/src/lib/auth.ts
+++ b/packages/core/src/lib/auth.ts
@@ -117,7 +117,11 @@ export const auth = betterAuth({
     },
   },
   emailVerification: {
-    sendOnSignUp: false,
+    // Controlled by AUTH_CONFIG.sendVerificationEmailOnSignup (default: true).
+    // Themes opt out by setting `auth.sendVerificationEmailOnSignup: false`
+    // in their app.config.ts when they verify email ownership through other
+    // means (OTP, invitation token, claim-account flow, etc.).
+    sendOnSignUp: AUTH_CONFIG.sendVerificationEmailOnSignup ?? true,
     sendVerificationEmail: async ({ user, token }: { user: UserWithEmail; url: string; token: string }) => {
       try {
         const verifyUrl = `${baseUrl}/api/auth/verify-email?token=${token}`;

--- a/packages/core/src/lib/config/app.config.ts
+++ b/packages/core/src/lib/config/app.config.ts
@@ -391,6 +391,20 @@ export const DEFAULT_APP_CONFIG: AppConfig = {
         enabled: true,
       },
     },
+
+    /**
+     * Whether Better Auth automatically sends the verification email on signup.
+     *
+     * Default: `true` — matches Better Auth's standard behavior. Users get a
+     * "Verify Your Email Address" link email when they sign up via
+     * `/api/auth/sign-up/email`.
+     *
+     * Set this to `false` in your theme's `app.config.ts` if your project
+     * verifies email ownership through other means (OTP code, invitation
+     * token, claim-account flow). The `sendVerificationEmail` function
+     * remains exported and can still be called explicitly when needed.
+     */
+    sendVerificationEmailOnSignup: true,
   },
 
   // =============================================================================

--- a/packages/core/src/lib/config/types.ts
+++ b/packages/core/src/lib/config/types.ts
@@ -432,6 +432,23 @@ export interface AuthConfig {
 
   /** OAuth provider settings */
   providers?: AuthProvidersConfig
+
+  /**
+   * Whether Better Auth should automatically send the built-in
+   * verification email when a user signs up via `/api/auth/sign-up/email`.
+   *
+   * - `true` (default): preserves Better Auth's standard behavior — users
+   *   receive a "Verify Your Email Address" link email immediately on signup.
+   * - `false`: suppresses the automatic email. Use this when the project
+   *   verifies email ownership through other means (OTP code, invitation
+   *   token, claim-account flow, etc.) before or after signup.
+   *
+   * Note: this only controls the AUTOMATIC dispatch on signup.
+   * `requireEmailVerification: true` and the `sendVerificationEmail`
+   * function remain available regardless — projects can still trigger
+   * link-based verification explicitly when they need to.
+   */
+  sendVerificationEmailOnSignup?: boolean
 }
 
 /**


### PR DESCRIPTION
## Summary

Replaces the hardcoded `sendOnSignUp: false` shipped in `0.1.0-beta.148` with a proper config flag exposed in `AuthConfig`, so themes choose per-project. Default preserves Better Auth's standard behavior (auto-send verification email on signup); themes opt out with one line.

## Why

`0.1.0-beta.148` made a global, undocumented decision: every theme that uses core lost the auto-verification email. The original ticket explicitly marked configurability as out-of-scope; this PR is that follow-up. **It was the wrong architectural call to leave it hardcoded** — themes should be in control of behavior that affects their end users' inbox.

## Changes

- `packages/core/src/lib/config/types.ts` — add optional `sendVerificationEmailOnSignup?: boolean` to `AuthConfig`
- `packages/core/src/lib/config/app.config.ts` — set core default to `true` (matches Better Auth's standard)
- `packages/core/src/lib/auth.ts` — read `AUTH_CONFIG.sendVerificationEmailOnSignup` (with `?? true` fallback) instead of hardcoded `false`

## Theme usage

```ts
// themes/<theme>/config/app.config.ts — opt out for custom flows
auth: {
  registration: { mode: 'open' },
  providers: { google: { enabled: true } },
  sendVerificationEmailOnSignup: false,   // ← opt out
}
```

## ⚠️ Behavior change vs beta.148

Themes that started using `beta.148` and upgrade past this PR will get the auto-email back **unless they add `sendVerificationEmailOnSignup: false`** to their config. Synap (reported the original bug) must add this line before upgrading.

## Test plan

- [x] `pnpm build` in `packages/core` — succeeds; pre-existing TS errors in unrelated files persist (verified identical on clean `main` via `git stash`)
- [x] Verified `dist/lib/config/types.d.ts` exports the new field
- [x] Verified `dist/lib/config/app.config.js` contains default `true`
- [x] Verified `dist/lib/auth.js` reads from `AUTH_CONFIG.sendVerificationEmailOnSignup`
- [ ] After release: ship as `0.1.0-beta.149`. Notify Synap to add the opt-out line.

## Out of scope (separate ticket)

Email template customization per theme (i18n, branding overrides). Discussed in conversation; will follow the same pattern as blocks/messages — a `themes/<theme>/emails/` directory with build-time discovery into a registry. Tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)