### PR TITLE
chore(themes): document sendVerificationEmailOnSignup in default and starter app.config

### DIFF
--- a/packages/core/templates/contents/themes/starter/config/app.config.ts
+++ b/packages/core/templates/contents/themes/starter/config/app.config.ts
@@ -115,6 +115,21 @@ export const APP_CONFIG_OVERRIDES = {
         enabled: false,
       },
     },
+    /**
+     * Whether Better Auth automatically sends the verification email on signup.
+     *
+     * - `true` (default): users get a "Verify Your Email Address" link email
+     *   immediately when they sign up via `/api/auth/sign-up/email`.
+     * - `false`: suppress the automatic email. Use this when your project
+     *   verifies email ownership through other means (OTP code, invitation
+     *   token, claim-account flow). The `sendVerificationEmail` function
+     *   remains available — you can still trigger link-based verification
+     *   explicitly when you need to.
+     *
+     * `requireEmailVerification: true` is enforced regardless: users with
+     * `emailVerified: false` cannot sign in.
+     */
+    sendVerificationEmailOnSignup: true,
   },
 
   // =============================================================================

--- a/themes/default/config/app.config.ts
+++ b/themes/default/config/app.config.ts
@@ -53,6 +53,21 @@ export const APP_CONFIG_OVERRIDES = {
         enabled: true,
       },
     },
+    /**
+     * Whether Better Auth automatically sends the verification email on signup.
+     *
+     * - `true` (default): users get a "Verify Your Email Address" link email
+     *   immediately when they sign up via `/api/auth/sign-up/email`.
+     * - `false`: suppress the automatic email. Use this when your project
+     *   verifies email ownership through other means (OTP code, invitation
+     *   token, claim-account flow). The `sendVerificationEmail` function
+     *   remains available — you can still trigger link-based verification
+     *   explicitly when you need to.
+     *
+     * `requireEmailVerification: true` is enforced regardless: users with
+     * `emailVerified: false` cannot sign in.
+     */
+    sendVerificationEmailOnSignup: true,
   },
 
   // =============================================================================


### PR DESCRIPTION
## Summary

Follow-up to #69. Makes the `auth.sendVerificationEmailOnSignup` flag **self-documenting** in the two theme configs developers actually read:

- `themes/default/config/app.config.ts` — showcase theme
- `packages/core/templates/contents/themes/starter/config/app.config.ts` — starter copied by `create-nextspark-app`

Both keep the default value (`true`) so runtime behaviour is unchanged. The point is *discoverability*: a developer scrolling their `app.config.ts` now sees the flag, knows what it does, and how to flip it for custom verification flows.

## Why this is needed

#69 added the flag to `AuthConfig` and to core's internal default config — runtime works correctly. But developers don't read `packages/core/src/lib/config/app.config.ts`; they read their own theme's config. Without this PR, the option would be invisible unless they:
- Read core's source code, or
- Read the type definition in `types.ts`, or
- See it mentioned in docs/release notes

None of those are reliable. Putting the flag — with its docstring — in the theme config makes it self-evident.

## Out of scope

`themes/blog`, `themes/crm`, `themes/productivity` don't have an `auth:` block at all (they inherit core defaults entirely). Whether to add a stub `auth:` block in each just for documentation is a separate question. Not addressed here.

## Test plan

- [x] `git diff` confirms only doc + identity-default fields added (no behaviour change)
- [x] No build implications (these are theme TS sources, not compiled separately)
- [ ] Will ship together with #69 in `0.1.0-beta.149`

🤖 Generated with [Claude Code](https://claude.com/claude-code)