### PR TITLE
fix(teams): add missing deletedAt column (fixes #81)

### DIFF
--- a/packages/core/migrations/024_teams_soft_delete.sql
+++ b/packages/core/migrations/024_teams_soft_delete.sql
@@ -1,0 +1,36 @@
+-- Migration: 024_teams_soft_delete.sql
+-- Description: Add `deletedAt` column to teams for soft-delete support.
+-- Date: 2026-07-18
+--
+-- Why this is needed:
+--   Commit 11f62e17 ("enhance team retrieval logic to exclude soft-deleted
+--   teams") added `t."deletedAt" IS NULL` predicates to TeamService.switchActive
+--   (team.service.ts) and GET /api/v1/teams (templates/app/api/v1/teams/route.ts),
+--   on the assumption that a soft-delete marker already existed on `teams`. It
+--   never did — 007_teams_table.sql's CREATE TABLE has no such column, and no
+--   migration since has added one. Both call sites throw a real Postgres
+--   "column deletedAt does not exist" error against a database built purely
+--   from this package's own migrations.
+--
+--   A team is never hard-deleted (TeamService.delete() does perform a real
+--   DELETE today, but a consuming app implementing its own "delete team"
+--   feature is expected to soft-delete instead, to preserve history) — this
+--   column is what the two call sites above already assume is available.
+--
+--   100% additive: NULL = active team (unchanged prior behavior for every
+--   existing row).
+
+ALTER TABLE public."teams"
+  ADD COLUMN IF NOT EXISTS "deletedAt" TIMESTAMPTZ;
+
+COMMENT ON COLUMN public."teams"."deletedAt"
+  IS 'Soft-delete marker. NULL = team active. NOT NULL = team soft-deleted; '
+     'the row is preserved for historical/audit purposes. '
+     'TeamService.switchActive() and GET /api/v1/teams exclude non-NULL rows '
+     'from active-team resolution.';
+
+-- Partial index for active-team lookups (deletedAt IS NULL) — keeps the two
+-- call sites above fast without a sequential scan as `teams` grows.
+CREATE INDEX IF NOT EXISTS idx_teams_active
+  ON public."teams" (id)
+  WHERE "deletedAt" IS NULL;


### PR DESCRIPTION
## Summary

Fixes #81. `TeamService.switchActive` and `GET /api/v1/teams` both query `t."deletedAt" IS NULL`, but no migration ever added that column — `007_teams_table.sql`'s `CREATE TABLE` doesn't have it, and nothing since alters it in. Against a database built purely from this package's own migrations, both call sites throw `column deletedAt does not exist`.

## Fix

Adds `packages/core/migrations/024_teams_soft_delete.sql`:
- `ALTER TABLE teams ADD COLUMN IF NOT EXISTS "deletedAt" TIMESTAMPTZ` — additive, `NULL` = active (matches existing behavior for every row)
- Partial index (`WHERE "deletedAt" IS NULL`) supporting both call sites' lookup pattern

## Verification

Empirically verified end-to-end against a real throwaway Postgres database, using a fresh `create-nextspark-app` scaffold built from packed local tarballs (not just static analysis):

- `nextspark db:migrate` — migration 024 applies cleanly alongside all other core migrations
- Signed up a user, verified email, signed in
- `GET /api/v1/teams` → `200`, with `"deletedAt":null` present in the returned team object
- `POST /api/v1/teams/switch` → `200`, `{"success":true,...}`

Both call sites that previously threw a 500 now work cleanly on a database that only has this package's own schema.

## Test plan

- [x] Migration applies cleanly on a fresh database
- [x] `GET /api/v1/teams` returns 200 with the new column present
- [x] `POST /api/v1/teams/switch` returns 200