### PR TITLE
fix(teams): re-entrant active-team self-heal (fixes #78)

### DIFF
--- a/packages/core/jest.config.cjs
+++ b/packages/core/jest.config.cjs
@@ -48,6 +48,7 @@ module.exports = {
     // Mock ESM modules that cause import issues
     '^better-auth$': '<rootDir>/tests/jest/__mocks__/better-auth.js',
     '^better-auth/next-js$': '<rootDir>/tests/jest/__mocks__/better-auth-next.js',
+    '^better-auth/plugins$': '<rootDir>/tests/jest/__mocks__/better-auth-plugins.js',
     '^next-intl/server$': '<rootDir>/tests/jest/__mocks__/next-intl-server.js',
   },
   setupFilesAfterEnv: ['<rootDir>/tests/jest/setup.ts'],

--- a/packages/core/migrations/023_team_invitations_pending_email_index.sql
+++ b/packages/core/migrations/023_team_invitations_pending_email_index.sql
@@ -1,0 +1,7 @@
+-- Migration: 023_team_invitations_pending_email_index.sql
+-- Description: Partial functional index supporting the pending-invitation-by-email lookup added for nextspark#78 (hasPendingInvitationForEmail in lib/auth.ts)
+-- Date: 2026-07-17
+
+CREATE INDEX IF NOT EXISTS idx_invitations_pending_email_lower
+  ON public."team_invitations" (lower(email))
+  WHERE status = 'pending';

--- a/packages/core/src/contexts/TeamContext.tsx
+++ b/packages/core/src/contexts/TeamContext.tsx
@@ -57,7 +57,6 @@ export function TeamProvider({ children }: { children: ReactNode }) {
   const queryClient = useQueryClient()
   const [currentTeam, setCurrentTeam] = useState<Team | null>(null)
   const [isSwitching, setIsSwitching] = useState(false)
-  const [initialSyncDone, setInitialSyncDone] = useState(false)
 
   // Modal state for team switching animation
   const [switchModalOpen, setSwitchModalOpen] = useState(false)
@@ -75,7 +74,11 @@ export function TeamProvider({ children }: { children: ReactNode }) {
     enabled: !!user && !authLoading,
     staleTime: 1000 * 60 * 5, // Cache for 5 minutes - prevents refetch on navigation
     gcTime: 1000 * 60 * 60, // Keep in cache for 1 hour
-    refetchOnWindowFocus: false, // Don't refetch when window regains focus
+    // Automatic safety net for the self-heal above: if a membership change
+    // happened while this tab was unfocused (removed from a team, a team
+    // soft-deleted elsewhere), returning focus re-fetches userTeams without
+    // depending on whatever mutated it remembering to call refreshTeams().
+    refetchOnWindowFocus: true,
     refetchOnMount: false, // Don't refetch if data exists and is not stale
   })
 
@@ -93,7 +96,20 @@ export function TeamProvider({ children }: { children: ReactNode }) {
   // Initialize current team when teams data loads
   useEffect(() => {
     // Guard: don't run during logout (user null but stale TanStack cache)
-    if (!user || !userTeams.length || initialSyncDone) return
+    if (!user || !userTeams.length) return
+
+    // Nothing to heal if the team we're already tracking is still a real,
+    // current membership. Re-evaluated every time userTeams changes (not
+    // just once) — this is what makes the self-heal re-entrant instead of
+    // one-shot: a later out-of-band membership change (someone removed from
+    // a team, a team soft-deleted) that updates userTeams triggers this
+    // effect again and gets corrected, instead of being silently ignored
+    // for the rest of the session. Deliberately keyed off `currentTeam`
+    // (the state we've actually synced), not the raw localStorage value —
+    // on the very first run currentTeam is still null even when a stored
+    // id already resolves to a valid membership, so gating on the stored
+    // id here would skip the initial sync entirely.
+    if (currentTeam && userTeams.some(t => t.team.id === currentTeam.id)) return
 
     // Determine active team (priority: localStorage > user's teams)
     const storedTeamId = typeof window !== 'undefined' ? localStorage.getItem('activeTeamId') : null
@@ -109,7 +125,7 @@ export function TeamProvider({ children }: { children: ReactNode }) {
         localStorage.setItem('activeTeamId', activeTeam.team.id)
       }
 
-      // Sync cookie via API for server-side access (only once on initial load)
+      // Sync cookie via API for server-side access
       if (typeof window !== 'undefined') {
         fetch('/api/v1/teams/switch', {
           method: 'POST',
@@ -117,12 +133,10 @@ export function TeamProvider({ children }: { children: ReactNode }) {
           body: JSON.stringify({ teamId: activeTeam.team.id })
         }).catch(err => console.error('Failed to sync team cookie:', err))
       }
-
-      setInitialSyncDone(true)
     }
-  }, [user, userTeams, initialSyncDone])
+  }, [user, userTeams, currentTeam])
 
-  // Reset sync flag, clear localStorage and TanStack Query cache when user logs out
+  // Clear localStorage and TanStack Query cache when user logs out
   // IMPORTANT: Only run when auth has finished loading (!authLoading) to distinguish
   // actual logout (user=null, authLoading=false) from initial page load (user=null, authLoading=true).
   // Without the authLoading guard, this effect fires on every page reload/navigation,
@@ -131,7 +145,6 @@ export function TeamProvider({ children }: { children: ReactNode }) {
   useEffect(() => {
     if (!user && !authLoading) {
       setCurrentTeam(null)
-      setInitialSyncDone(false)
       // Clear team context to prevent leaking to next user session
       if (typeof window !== 'undefined') {
         localStorage.removeItem('activeTeamId')
@@ -199,7 +212,16 @@ export function TeamProvider({ children }: { children: ReactNode }) {
     }
   }, [userTeams, currentTeam])
 
-  // Refresh teams list - invalidate and refetch
+  // Refresh teams list - invalidate and refetch.
+  //
+  // Convention: any endpoint that mutates a team_members row or a team's
+  // deletedAt outside the standard switchTeam() flow (removing a member,
+  // soft-deleting a team, etc.) should call this — or force a hard
+  // navigation — immediately after, so any open tab with that team active
+  // doesn't wait out the query's staleTime or a window-focus event to
+  // notice. Not the only mechanism: the self-heal effect above and
+  // refetchOnWindowFocus on the userTeams query both self-correct on their
+  // own even if a call-site forgets this.
   const refreshTeams = useCallback(async () => {
     await queryClient.invalidateQueries({ queryKey: TEAMS_QUERY_KEY })
     await refetchTeams()

--- a/packages/core/src/contexts/TeamContext.tsx
+++ b/packages/core/src/contexts/TeamContext.tsx
@@ -96,7 +96,25 @@ export function TeamProvider({ children }: { children: ReactNode }) {
   // Initialize current team when teams data loads
   useEffect(() => {
     // Guard: don't run during logout (user null but stale TanStack cache)
-    if (!user || !userTeams.length) return
+    if (!user) return
+
+    // User has genuinely zero team memberships (query resolved, not just
+    // still loading) — clear any stale currentTeam/localStorage instead of
+    // leaving them pointing at a team the user no longer belongs to. Without
+    // this, a user removed from EVERY team (not just their active one) never
+    // self-heals: getCurrentTeamId() keeps returning a dead team forever.
+    if (!teamsLoading && userTeams.length === 0) {
+      if (currentTeam) {
+        setCurrentTeam(null)
+        if (typeof window !== 'undefined') {
+          localStorage.removeItem('activeTeamId')
+        }
+      }
+      return
+    }
+
+    // Still loading (or genuinely nothing to do yet) — nothing to heal.
+    if (!userTeams.length) return
 
     // Nothing to heal if the team we're already tracking is still a real,
     // current membership. Re-evaluated every time userTeams changes (not
@@ -134,7 +152,7 @@ export function TeamProvider({ children }: { children: ReactNode }) {
         }).catch(err => console.error('Failed to sync team cookie:', err))
       }
     }
-  }, [user, userTeams, currentTeam])
+  }, [user, userTeams, currentTeam, teamsLoading])
 
   // Clear localStorage and TanStack Query cache when user logs out
   // IMPORTANT: Only run when auth has finished loading (!authLoading) to distinguish

--- a/packages/core/src/lib/api/auth/dual-auth.ts
+++ b/packages/core/src/lib/api/auth/dual-auth.ts
@@ -10,6 +10,7 @@ import { auth } from '../../auth'
 import { validateApiKey } from '../auth'
 import { queryOne } from '../../db'
 import { TeamMemberService } from '../../services/team-member.service'
+import { TeamService } from '../../services/team.service'
 
 // ==========================================
 // ADMIN BYPASS CONSTANTS
@@ -314,10 +315,27 @@ export async function resolveTeamContext(
     )
   }
 
+  // Deliberately NO userId arg: TeamService.getById(teamId, userId) is
+  // queryOneWithRLS-scoped, and the "teams" RLS policy only lets a user see
+  // teams they're a member of — passing the current user's id here would
+  // make a real, active team they're just not a member of look IDENTICAL
+  // to a deleted/nonexistent one (both resolve to null), which is exactly
+  // the ambiguity this check exists to remove. Omitting userId routes
+  // through the service (RLS-bypass) pool — safe here because we only ever
+  // branch on existence/deletedAt to pick an error CODE, never return the
+  // row's contents to the client.
+  const team = await TeamService.getById(teamId)
+  if (!team || team.deletedAt) {
+    return NextResponse.json(
+      { success: false, error: 'Team not found', code: 'TEAM_NOT_FOUND' },
+      { status: 403 },
+    )
+  }
+
   const isMember = await TeamMemberService.isMember(teamId, authResult.user!.id)
   if (!isMember) {
     return NextResponse.json(
-      { success: false, error: 'Access denied: You are not a member of this team' },
+      { success: false, error: 'Access denied: You are not a member of this team', code: 'NOT_A_MEMBER' },
       { status: 403 }
     )
   }

--- a/packages/core/src/lib/auth.ts
+++ b/packages/core/src/lib/auth.ts
@@ -2,7 +2,7 @@ import { betterAuth } from "better-auth";
 import { Pool } from "pg";
 import { nextCookies } from "better-auth/next-js";
 import { emailOTP } from "better-auth/plugins";
-import { parseSSLConfig, stripSSLParams } from './db';
+import { parseSSLConfig, stripSSLParams, queryOne } from './db';
 import { EmailFactory } from './email';
 import {
   sendVerifyEmail,
@@ -21,6 +21,30 @@ import {
 import { isDomainAllowed } from './auth/registration-helpers';
 import { registrationGuardPlugin } from './auth/registration-guard-plugin';
 import { getCorsOrigins } from './utils/cors';
+
+/**
+ * Does this email have a pending, unexpired team invitation waiting?
+ *
+ * Used by the signup `after` hook to skip auto-creating a personal team —
+ * closes the gap where skipTeamCreation (auth-context.ts) is only set by
+ * the dedicated signup-with-invite route: a person who signs up on their
+ * own, unaware they already have a pending invitation, would otherwise
+ * still get an orphan personal team created first.
+ *
+ * No userId passed to queryOne → runs on the service (RLS-bypass) pool,
+ * same reasoning as the TEAM_NOT_FOUND check in dual-auth.ts: this has to
+ * see invitations regardless of whether anyone is "logged in" yet during
+ * signup, not a user-scoped read.
+ */
+export async function hasPendingInvitationForEmail(email: string): Promise<boolean> {
+  const row = await queryOne<{ id: string }>(
+    `SELECT id FROM "team_invitations"
+      WHERE lower(email) = lower($1) AND status = 'pending' AND "expiresAt" > now()
+      LIMIT 1`,
+    [email],
+  )
+  return !!row
+}
 
 interface UserWithEmail {
   email: string;
@@ -331,9 +355,11 @@ export const auth = betterAuth({
         // Team type depends on configured teams mode
         after: async (user: { id: string; name?: string; [key: string]: unknown }) => {
           try {
-            // Check if we should skip team creation (e.g., user created via invite)
-            if (shouldSkipTeamCreation()) {
-              console.log(`[Teams] Skipping team creation for user ${user.id} (invite flow)`);
+            // Check if we should skip team creation (e.g., user created via
+            // invite, or this email already has a pending invitation from
+            // any other signup path)
+            if (shouldSkipTeamCreation() || (await hasPendingInvitationForEmail(user.email as string))) {
+              console.log(`[Teams] Skipping team creation for user ${user.id} (invite flow or pending invitation)`);
               return;
             }
 

--- a/packages/core/src/lib/auth.ts
+++ b/packages/core/src/lib/auth.ts
@@ -46,6 +46,20 @@ export async function hasPendingInvitationForEmail(email: string): Promise<boole
   return !!row
 }
 
+/**
+ * Should this signup skip automatic team creation?
+ *
+ * True if either the request came through the dedicated invite-flow context
+ * (shouldSkipTeamCreation(), set by signup-with-invite), OR this email
+ * already has a pending, unexpired invitation waiting from any other signup
+ * path (hasPendingInvitationForEmail — see its own doc comment for why this
+ * second check exists). Short-circuits on the first true so a signup that's
+ * already known to be invite-flow never pays for the extra query.
+ */
+export async function shouldSkipTeamCreationForUser(email: string): Promise<boolean> {
+  return shouldSkipTeamCreation() || (await hasPendingInvitationForEmail(email))
+}
+
 interface UserWithEmail {
   email: string;
   id?: string;
@@ -358,7 +372,7 @@ export const auth = betterAuth({
             // Check if we should skip team creation (e.g., user created via
             // invite, or this email already has a pending invitation from
             // any other signup path)
-            if (shouldSkipTeamCreation() || (await hasPendingInvitationForEmail(user.email as string))) {
+            if (await shouldSkipTeamCreationForUser(user.email as string)) {
               console.log(`[Teams] Skipping team creation for user ${user.id} (invite flow or pending invitation)`);
               return;
             }

--- a/packages/core/src/lib/teams/types.ts
+++ b/packages/core/src/lib/teams/types.ts
@@ -83,6 +83,7 @@ export interface Team {
   settings: Record<string, any>
   createdAt: string
   updatedAt: string
+  deletedAt?: string | null
 }
 
 // Team Member interface

--- a/packages/core/tests/jest/__mocks__/better-auth-plugins.js
+++ b/packages/core/tests/jest/__mocks__/better-auth-plugins.js
@@ -1,0 +1,8 @@
+/**
+ * Mock for better-auth/plugins package
+ * Resolves ES module import issues in Jest tests
+ */
+
+module.exports = {
+  emailOTP: jest.fn(() => ({})),
+}

--- a/packages/core/tests/jest/contexts/TeamContext.test.tsx
+++ b/packages/core/tests/jest/contexts/TeamContext.test.tsx
@@ -1,0 +1,151 @@
+/**
+ * TeamContext — self-heal re-entrancy tests.
+ *
+ * The self-heal effect used to gate itself shut after the first successful
+ * run (`initialSyncDone`), even though membership can change later. These
+ * tests drive the provider through a membership change (simulated via a
+ * refetch that resolves to a different team list) and assert it corrects
+ * `currentTeam`/`localStorage`/the switch-cookie call every time the cached
+ * active team stops being valid — not just once.
+ */
+import { render, screen, waitFor, act } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { TeamProvider, useTeamContext, TEAMS_QUERY_KEY } from '@/core/contexts/TeamContext'
+
+jest.mock('@/core/hooks/useAuth', () => ({
+  useAuth: () => ({ user: { id: 'user-1' }, isLoading: false }),
+}))
+
+jest.mock('next/navigation', () => ({
+  useRouter: () => ({ push: jest.fn(), refresh: jest.fn() }),
+}))
+
+// TeamProvider renders TeamSwitchModal, which uses next-intl.
+jest.mock('next-intl', () => ({
+  useTranslations: () => (key: string) => key,
+}))
+
+const TEAM_A = { id: 'team-a', name: 'Team A', slug: 'team-a', description: null, owner_id: 'user-1', avatar_url: null, settings: {}, created_at: '2026-01-01', updated_at: '2026-01-01' }
+const TEAM_B = { id: 'team-b', name: 'Team B', slug: 'team-b', description: null, owner_id: 'user-2', avatar_url: null, settings: {}, created_at: '2026-01-01', updated_at: '2026-01-01' }
+
+function membershipRow(team: typeof TEAM_A, role = 'owner') {
+  return { ...team, userRole: role }
+}
+
+function Probe() {
+  const { currentTeam } = useTeamContext()
+  return <div data-testid="current-team">{currentTeam?.id ?? 'none'}</div>
+}
+
+function renderWithProviders() {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  render(
+    <QueryClientProvider client={queryClient}>
+      <TeamProvider>
+        <Probe />
+      </TeamProvider>
+    </QueryClientProvider>
+  )
+  return queryClient
+}
+
+describe('TeamProvider self-heal', () => {
+  beforeEach(() => {
+    localStorage.clear()
+    global.fetch = jest.fn()
+  })
+
+  it('picks the stored active team on initial load', async () => {
+    localStorage.setItem('activeTeamId', 'team-b')
+    ;(global.fetch as jest.Mock).mockImplementation((url: string) => {
+      if (url === '/api/v1/teams') {
+        return Promise.resolve({ ok: true, json: async () => ({ data: [membershipRow(TEAM_A), membershipRow(TEAM_B)] }) })
+      }
+      return Promise.resolve({ ok: true, json: async () => ({}) })
+    })
+
+    renderWithProviders()
+
+    await waitFor(() => expect(screen.getByTestId('current-team').textContent).toBe('team-b'))
+  })
+
+  it('re-heals when the active team drops out of userTeams after a later refetch — not just once', async () => {
+    localStorage.setItem('activeTeamId', 'team-a')
+    let call = 0
+    ;(global.fetch as jest.Mock).mockImplementation((url: string) => {
+      if (url === '/api/v1/teams') {
+        call += 1
+        // First resolution: team-a is a valid member. Second (simulated
+        // post-membership-change refetch): team-a is gone, only team-b left.
+        const rows = call === 1 ? [membershipRow(TEAM_A), membershipRow(TEAM_B)] : [membershipRow(TEAM_B)]
+        return Promise.resolve({ ok: true, json: async () => ({ data: rows }) })
+      }
+      return Promise.resolve({ ok: true, json: async () => ({}) })
+    })
+
+    const queryClient = renderWithProviders()
+    await waitFor(() => expect(screen.getByTestId('current-team').textContent).toBe('team-a'))
+
+    // Simulate whatever revalidation trigger fires later (window focus refetch,
+    // an explicit refreshTeams() call, or staleTime expiring) by invalidating
+    // the query directly — this is the "userTeams changed after the first
+    // sync" case the one-shot `initialSyncDone` gate used to ignore entirely.
+    await act(async () => {
+      await queryClient.invalidateQueries({ queryKey: TEAMS_QUERY_KEY })
+    })
+
+    await waitFor(() => expect(screen.getByTestId('current-team').textContent).toBe('team-b'))
+  })
+
+  it('does not re-fetch the switch-cookie endpoint on a stable re-render with a still-valid active team', async () => {
+    localStorage.setItem('activeTeamId', 'team-a')
+    const switchCalls: string[] = []
+    ;(global.fetch as jest.Mock).mockImplementation((url: string, init?: RequestInit) => {
+      if (url === '/api/v1/teams') {
+        return Promise.resolve({ ok: true, json: async () => ({ data: [membershipRow(TEAM_A), membershipRow(TEAM_B)] }) })
+      }
+      if (url === '/api/v1/teams/switch') {
+        switchCalls.push(String(init?.body))
+      }
+      return Promise.resolve({ ok: true, json: async () => ({}) })
+    })
+
+    renderWithProviders()
+    await waitFor(() => expect(screen.getByTestId('current-team').textContent).toBe('team-a'))
+    const callsAfterFirstSync = switchCalls.length
+
+    // Force a couple of re-renders with the exact same data.
+    await act(async () => {})
+    await act(async () => {})
+
+    expect(switchCalls.length).toBe(callsAfterFirstSync)
+  })
+
+  it('refetches userTeams when the window regains focus', async () => {
+    // Two layers of unreliability rule out a behavioral assertion here:
+    // (1) real `focus`/`visibilitychange` DOM events don't reach TanStack
+    // Query in jsdom — its focus manager gates on `document.hasFocus()`,
+    // which jsdom never wires up to synthetic events; (2) even driving focus
+    // via the library's own `focusManager.setFocused()` API, a refetch is
+    // only triggered when the query is stale (or `refetchOnWindowFocus ===
+    // 'always'`) — and this query's 5-minute staleTime means it's still
+    // fresh immediately after mount, so no refetch would fire either way,
+    // in a real browser or in this test. So instead of asserting behavior,
+    // assert the wiring directly: the mounted query's merged options carry
+    // `refetchOnWindowFocus: true`, which is what makes the real-browser
+    // behavior possible once the data does go stale.
+    localStorage.setItem('activeTeamId', 'team-a')
+    ;(global.fetch as jest.Mock).mockImplementation((url: string) => {
+      if (url === '/api/v1/teams') {
+        return Promise.resolve({ ok: true, json: async () => ({ data: [membershipRow(TEAM_A)] }) })
+      }
+      return Promise.resolve({ ok: true, json: async () => ({}) })
+    })
+
+    const queryClient = renderWithProviders()
+    await waitFor(() => expect(screen.getByTestId('current-team').textContent).toBe('team-a'))
+
+    const query = queryClient.getQueryCache().find({ queryKey: TEAMS_QUERY_KEY })
+    expect(query?.options.refetchOnWindowFocus).toBe(true)
+  })
+})

--- a/packages/core/tests/jest/contexts/TeamContext.test.tsx
+++ b/packages/core/tests/jest/contexts/TeamContext.test.tsx
@@ -148,4 +148,30 @@ describe('TeamProvider self-heal', () => {
     const query = queryClient.getQueryCache().find({ queryKey: TEAMS_QUERY_KEY })
     expect(query?.options.refetchOnWindowFocus).toBe(true)
   })
+
+  it('clears currentTeam and localStorage when the user has zero team memberships', async () => {
+    localStorage.setItem('activeTeamId', 'team-a')
+    let call = 0
+    ;(global.fetch as jest.Mock).mockImplementation((url: string) => {
+      if (url === '/api/v1/teams') {
+        call += 1
+        // First resolution: team-a is a valid member. Second (simulated
+        // post-membership-change refetch): the user has been removed from
+        // every team — the query resolves to an empty list.
+        const rows = call === 1 ? [membershipRow(TEAM_A)] : []
+        return Promise.resolve({ ok: true, json: async () => ({ data: rows }) })
+      }
+      return Promise.resolve({ ok: true, json: async () => ({}) })
+    })
+
+    const queryClient = renderWithProviders()
+    await waitFor(() => expect(screen.getByTestId('current-team').textContent).toBe('team-a'))
+
+    await act(async () => {
+      await queryClient.invalidateQueries({ queryKey: TEAMS_QUERY_KEY })
+    })
+
+    await waitFor(() => expect(screen.getByTestId('current-team').textContent).toBe('none'))
+    expect(localStorage.getItem('activeTeamId')).toBeNull()
+  })
 })

--- a/packages/core/tests/jest/lib/api/auth/resolveTeamContext.test.ts
+++ b/packages/core/tests/jest/lib/api/auth/resolveTeamContext.test.ts
@@ -1,0 +1,79 @@
+/**
+ * resolveTeamContext — 403 error-code tests.
+ *
+ * Previously returned a flat 403 for both "the team doesn't exist / was
+ * soft-deleted" and "the team exists but this user was never a member" —
+ * indistinguishable from the outside. This distinguishes them via a `code`
+ * field, so a caller can eventually tell "your cached team went stale" from
+ * "you don't have access to this."
+ */
+jest.mock('@/core/lib/services/team.service', () => ({
+  TeamService: { getById: jest.fn() },
+}))
+jest.mock('@/core/lib/services/team-member.service', () => ({
+  TeamMemberService: { isMember: jest.fn() },
+}))
+
+import { NextRequest } from 'next/server'
+import { resolveTeamContext } from '@/core/lib/api/auth/dual-auth'
+import { TeamService } from '@/core/lib/services/team.service'
+import { TeamMemberService } from '@/core/lib/services/team-member.service'
+
+const mockGetById = TeamService.getById as jest.MockedFunction<typeof TeamService.getById>
+const mockIsMember = TeamMemberService.isMember as jest.MockedFunction<typeof TeamMemberService.isMember>
+
+function makeRequest(teamId: string): NextRequest {
+  return new (NextRequest as unknown as { new (url: string, init?: RequestInit): NextRequest })(
+    'http://localhost/api/v1/some-entity',
+    { headers: { 'x-team-id': teamId } },
+  )
+}
+
+const authResult = { user: { id: 'user-1' } } as Parameters<typeof resolveTeamContext>[1]
+
+describe('resolveTeamContext', () => {
+  beforeEach(() => jest.clearAllMocks())
+
+  it('returns TEAM_NOT_FOUND when the team row does not exist at all', async () => {
+    mockGetById.mockResolvedValueOnce(null)
+
+    const result = await resolveTeamContext(makeRequest('team-gone'), authResult)
+
+    expect(mockGetById).toHaveBeenCalledWith('team-gone') // no userId arg — service pool, bypasses RLS
+    expect(mockIsMember).not.toHaveBeenCalled()
+    const body = await (result as Response).json()
+    expect((result as Response).status).toBe(403)
+    expect(body.code).toBe('TEAM_NOT_FOUND')
+  })
+
+  it('returns TEAM_NOT_FOUND when the team exists but is soft-deleted', async () => {
+    mockGetById.mockResolvedValueOnce({ id: 'team-deleted', deletedAt: '2026-07-01T00:00:00Z' } as never)
+
+    const result = await resolveTeamContext(makeRequest('team-deleted'), authResult)
+
+    const body = await (result as Response).json()
+    expect((result as Response).status).toBe(403)
+    expect(body.code).toBe('TEAM_NOT_FOUND')
+  })
+
+  it('returns NOT_A_MEMBER when the team is real and active but this user never joined it', async () => {
+    mockGetById.mockResolvedValueOnce({ id: 'team-real', deletedAt: null } as never)
+    mockIsMember.mockResolvedValueOnce(false)
+
+    const result = await resolveTeamContext(makeRequest('team-real'), authResult)
+
+    expect(mockIsMember).toHaveBeenCalledWith('team-real', 'user-1')
+    const body = await (result as Response).json()
+    expect((result as Response).status).toBe(403)
+    expect(body.code).toBe('NOT_A_MEMBER')
+  })
+
+  it('returns the teamId (not a Response) when the team is real, active, and the user is a member', async () => {
+    mockGetById.mockResolvedValueOnce({ id: 'team-real', deletedAt: null } as never)
+    mockIsMember.mockResolvedValueOnce(true)
+
+    const result = await resolveTeamContext(makeRequest('team-real'), authResult)
+
+    expect(result).toBe('team-real')
+  })
+})

--- a/packages/core/tests/jest/lib/hasPendingInvitationForEmail.test.ts
+++ b/packages/core/tests/jest/lib/hasPendingInvitationForEmail.test.ts
@@ -26,8 +26,15 @@ jest.mock('better-auth/next-js', () => ({
   nextCookies: jest.fn(),
 }))
 
+jest.mock('@/core/lib/auth-context', () => ({
+  shouldSkipTeamCreation: jest.fn(),
+}))
+
 // Import after all mocks are set up
-import { hasPendingInvitationForEmail } from '@/core/lib/auth'
+import { hasPendingInvitationForEmail, shouldSkipTeamCreationForUser } from '@/core/lib/auth'
+import { shouldSkipTeamCreation } from '@/core/lib/auth-context'
+
+const mockShouldSkipTeamCreation = shouldSkipTeamCreation as jest.MockedFunction<typeof shouldSkipTeamCreation>
 
 describe('hasPendingInvitationForEmail', () => {
   beforeEach(() => jest.clearAllMocks())
@@ -46,5 +53,30 @@ describe('hasPendingInvitationForEmail', () => {
     mockQueryOne.mockResolvedValueOnce(null)
 
     await expect(hasPendingInvitationForEmail('nobody@example.com')).resolves.toBe(false)
+  })
+})
+
+describe('shouldSkipTeamCreationForUser', () => {
+  beforeEach(() => jest.clearAllMocks())
+
+  it('returns true when shouldSkipTeamCreation() is true, without querying invitations', async () => {
+    mockShouldSkipTeamCreation.mockReturnValueOnce(true)
+
+    await expect(shouldSkipTeamCreationForUser('invitee@example.com')).resolves.toBe(true)
+    expect(mockQueryOne).not.toHaveBeenCalled()
+  })
+
+  it('returns true when shouldSkipTeamCreation() is false but the email has a pending invitation', async () => {
+    mockShouldSkipTeamCreation.mockReturnValueOnce(false)
+    mockQueryOne.mockResolvedValueOnce({ id: 'inv-1' })
+
+    await expect(shouldSkipTeamCreationForUser('person@example.com')).resolves.toBe(true)
+  })
+
+  it('returns false when shouldSkipTeamCreation() is false and there is no pending invitation (normal signup still gets a team)', async () => {
+    mockShouldSkipTeamCreation.mockReturnValueOnce(false)
+    mockQueryOne.mockResolvedValueOnce(null)
+
+    await expect(shouldSkipTeamCreationForUser('newuser@example.com')).resolves.toBe(false)
   })
 })

--- a/packages/core/tests/jest/lib/hasPendingInvitationForEmail.test.ts
+++ b/packages/core/tests/jest/lib/hasPendingInvitationForEmail.test.ts
@@ -1,0 +1,50 @@
+/**
+ * hasPendingInvitationForEmail — used by the signup `after` hook to skip
+ * auto-creating a personal team for an email that already has a pending
+ * team invitation waiting (regardless of which signup route was used).
+ */
+
+// Mock db module BEFORE importing auth
+const mockQueryOne = jest.fn();
+
+jest.mock('@/core/lib/db', () => ({
+  queryOne: mockQueryOne,
+  parseSSLConfig: jest.fn(),
+  stripSSLParams: jest.fn(),
+}))
+
+// Mock better-auth and its dependencies to avoid ESM parsing issues
+jest.mock('better-auth', () => ({
+  betterAuth: jest.fn(),
+}))
+
+jest.mock('better-auth/plugins', () => ({
+  emailOTP: jest.fn(),
+}))
+
+jest.mock('better-auth/next-js', () => ({
+  nextCookies: jest.fn(),
+}))
+
+// Import after all mocks are set up
+import { hasPendingInvitationForEmail } from '@/core/lib/auth'
+
+describe('hasPendingInvitationForEmail', () => {
+  beforeEach(() => jest.clearAllMocks())
+
+  it('returns true when a pending, unexpired invitation matches the email', async () => {
+    mockQueryOne.mockResolvedValueOnce({ id: 'inv-1' })
+
+    await expect(hasPendingInvitationForEmail('person@example.com')).resolves.toBe(true)
+    expect(mockQueryOne).toHaveBeenCalledWith(
+      expect.stringContaining('team_invitations'),
+      ['person@example.com'],
+    )
+  })
+
+  it('returns false when no matching row exists (expired, wrong status, or no invitation at all)', async () => {
+    mockQueryOne.mockResolvedValueOnce(null)
+
+    await expect(hasPendingInvitationForEmail('nobody@example.com')).resolves.toBe(false)
+  })
+})


### PR DESCRIPTION
## Summary

Fixes #78. `TeamContext`'s active-team self-heal only ran once per session (a `useState` flag `initialSyncDone` set `true` on first sync and never reset). If a user's team membership changed later in the same session via any path other than the `switchTeam()` UI action (removed from their active team by another admin, a team soft-deleted elsewhere), the client kept sending a stale team ID forever — no automatic recovery without a full page reload.

## Changes

1. **`packages/core/src/contexts/TeamContext.tsx`** — removed `initialSyncDone`; the self-heal effect is now a derived check re-evaluated on every render of `userTeams` (`if (currentTeam && userTeams.some(t => t.team.id === currentTeam.id)) return`, else re-sync). Added `refetchOnWindowFocus: true` to the `userTeams` query so a backgrounded tab re-checks membership on refocus. Also handles the edge case where a user is removed from *every* team (clears `currentTeam`/`localStorage.activeTeamId` instead of leaving them stale).
2. **`packages/core/src/lib/auth.ts`** + migration `023_team_invitations_pending_email_index.sql` — a signup with a pending team invitation no longer also gets an unwanted default team auto-created (`hasPendingInvitationForEmail`/`shouldSkipTeamCreationForUser`).
3. **`packages/core/src/lib/api/auth/dual-auth.ts`** — `resolveTeamContext` now distinguishes `TEAM_NOT_FOUND` (team missing or soft-deleted) from `NOT_A_MEMBER` (team exists, user isn't in it), instead of collapsing both into one generic 403.

Depends on #82 (already merged) for the `teams.deletedAt` column Task 3 and the regular `GET /api/v1/teams` path both need.

## Verification

- All 3 tasks built via fresh-subagent implement + review cycles (Task 2 needed one fix round for a missing index + a hook-level test; all others passed cleanly).
- Final whole-branch review (opus): 13/13 tests green, no Critical findings; one Important finding (empty-`userTeams` self-heal gap) fixed and re-verified (5/5 tests) before this PR.
- Empirically verified live, not just unit tests: fresh `create-nextspark-app` scaffold + throwaway Postgres DB + real browser session. Set up a user with 2 team memberships (one via out-of-band DB insert, simulating a membership grant outside `switchTeam()`), then deleted their membership in the *active* team directly in the DB (simulating an out-of-band removal) and triggered a refetch with **no page reload** — `currentTeam` correctly self-healed to the one remaining real membership.

## Test plan

- [x] `packages/core/tests/jest/contexts/TeamContext.test.tsx` — 5/5 passing
- [x] `packages/core/tests/jest/lib/hasPendingInvitationForEmail.test.ts` — passing
- [x] `packages/core/tests/jest/lib/api/auth/resolveTeamContext.test.ts` — passing
- [x] Live browser verification of the re-entrant self-heal against a real DB (see above)