### PR TITLE
[94,95] Fix API-key scope minting/enforcement and authorization bypass

### DIFF
--- a/apps/dev/app/api/v1/api-keys/route.ts
+++ b/apps/dev/app/api/v1/api-keys/route.ts
@@ -7,7 +7,7 @@ import {
   handleCorsPreflightRequest,
   addCorsHeaders
 } from '@nextsparkjs/core/lib/api/helpers';
-import { authenticateRequest, hasRequiredScope } from '@nextsparkjs/core/lib/api/auth/dual-auth';
+import { authenticateRequest, hasRequiredScope, resolveTeamContext } from '@nextsparkjs/core/lib/api/auth/dual-auth';
 import { ApiKeyManager, API_SCOPES, API_KEY_LIMITS } from '@nextsparkjs/core/lib/api/keys';
 import { validateScopesForUser } from '@nextsparkjs/core/lib/api/auth';
 import { withRateLimitTier } from '@nextsparkjs/core/lib/api/rate-limit';
@@ -177,8 +177,20 @@ export const POST = withRateLimitTier(withApiLogging(async (req: NextRequest): P
       return addCorsHeaders(response);
     }
 
-    // Validar que el usuario pueda crear API keys con estos scopes
-    const userScopeValidation = await validateScopesForUser(authResult.user!.id, validatedData.scopes);
+    // Validar que el usuario pueda crear API keys con estos scopes.
+    // Scope minting is TEAM-role based (see validateScopesForUser) — resolve
+    // the team this key is being minted for, unless the caller is a global
+    // superadmin, which validateScopesForUser bypasses regardless of team.
+    let teamId: string | null = null;
+    if (authResult.user!.role !== 'superadmin') {
+      const teamResult = await resolveTeamContext(req, authResult);
+      if (teamResult instanceof NextResponse) {
+        return teamResult;
+      }
+      teamId = teamResult;
+    }
+
+    const userScopeValidation = await validateScopesForUser(authResult.user!.id, teamId, validatedData.scopes);
     if (!userScopeValidation.valid) {
       const response = createApiError(
         'You do not have permission to create API keys with these scopes', 

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -7,6 +7,53 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Security
+
+- **API-key scope minting now matches scope enforcement (#94).** `validateScopesForUser`
+  — the gate deciding which scopes a user may mint into an API key — previously checked
+  a hardcoded map keyed by the caller's **global** `users.role`, referencing a
+  nonexistent role (`colaborator`) and missing `owner`/`viewer` entirely. Independently,
+  the scope-registry generator that was supposed to back this was dead code: it read
+  entity properties (`entity.api.endpoints`, `entity.features`) that don't exist on the
+  real entity-discovery shape, so `SCOPE_CONFIG.roles` was 100% hardcoded, wrong JSON
+  referencing a nonexistent `products` entity. Net effect: **no non-superadmin user
+  could ever mint a working API key for their own theme's entities.**
+  - The scope-registry generator (`scope-registry.mjs`) now emits a file that computes
+    `SCOPE_CONFIG.roles` at import time, deriving `<slug>:read/write/delete` per
+    API-exposed entity from the same team-role permission matrix
+    (`PERMISSIONS_BY_ROLE`) the request-time authorization check uses — scope minting
+    and scope enforcement can no longer drift apart.
+  - `validateScopesForUser(userId, teamId, requestedScopes)` now takes an explicit
+    `teamId` and resolves the caller's real **team** role via `TeamMemberService`,
+    with an explicit bypass for the global `superadmin` role (which is not a team role
+    and never appears in `AVAILABLE_ROLES`).
+  - `POST /api/v1/api-keys` now resolves team context (`x-team-id` header / cookie /
+    default team) before validating requested scopes, for any non-superadmin caller.
+  - Fixed a satellite bug: `handleGenericDelete` checked the entity's `:write` scope
+    instead of `:delete` — a write-scoped key could delete, and the `:delete` scope was
+    pure decoration.
+  - Removed the undocumented, unmintable `admin:all` scope from `hasRequiredScope` —
+    dead code (nothing could mint it) and a latent, undocumented full-access string.
+    Use `*` instead.
+
+- **API-key authentication no longer bypasses team-role permission checks, field
+  guards, or ownership-based row filtering on the generic entity routes (#95).**
+  `/api/v1/[entity]` previously ran three authorization layers — a team-role
+  permission check, per-role field write guards, and ownership-scoped row
+  filtering — only for session-authenticated requests, explicitly skipping all
+  three for API-key auth on the stated assumption that scopes alone governed
+  API-key requests. Scopes only ever expressed entity+operation granularity, so a
+  scoped key could read/write outside its owner's team role, ownership scope, or
+  field restrictions — broader access than the same user's own session. All three
+  checks now run identically for both auth types.
+
+### Known Limitations
+
+- Requests against the generic entity routes (`/api/v1/[entity]`) — session or
+  API-key — are still not written to `api_audit_log`; that table's `apiKeyId`
+  column is `NOT NULL`, so closing this gap needs a migration and a new logging
+  path, tracked separately from the fixes above.
+
 ## [0.1.0-beta.167]
 
 ### Security — RLS Enforcement Layer

--- a/packages/core/docs/05-api/02-authentication.md
+++ b/packages/core/docs/05-api/02-authentication.md
@@ -441,7 +441,6 @@ export function hasRequiredScope(authResult: DualAuthResult, requiredScope: stri
   // API Keys check scopes
   if (authResult.type === 'api-key' && authResult.scopes) {
     return authResult.scopes.includes(requiredScope) ||
-           authResult.scopes.includes('admin:all') ||
            authResult.scopes.includes('*')
   }
 
@@ -820,7 +819,7 @@ function hasAllScopes(authResult: DualAuthResult, scopes: string[]): boolean {
 }
 
 // Usage:
-if (!hasAnyScope(authResult, ['products:read', 'admin:all'])) {
+if (!hasAnyScope(authResult, ['products:read', '*'])) {
   return createAuthError('Insufficient permissions', 403)
 }
 

--- a/packages/core/jest.config.cjs
+++ b/packages/core/jest.config.cjs
@@ -19,7 +19,6 @@ module.exports = {
     'tests/jest/services/membership.service.test.ts',
     'tests/jest/services/namespace.service.test.ts',
     'tests/jest/services/permission.service.test.ts',
-    'tests/jest/services/scope.service.test.ts',
     'tests/jest/services/theme.service.test.ts',
     'tests/jest/services/translation.service.test.ts',
     // Billing tests that expect specific registry configuration

--- a/packages/core/scripts/build/registry/__tests__/scope-registry.test.mjs
+++ b/packages/core/scripts/build/registry/__tests__/scope-registry.test.mjs
@@ -1,0 +1,88 @@
+/**
+ * Tests for the scope-registry generator.
+ *
+ * The role→scope computation no longer happens at generation time (see the
+ * rationale comment at the top of `generators/scope-registry.mjs`) — it's
+ * emitted as TypeScript that computes `SCOPE_CONFIG.roles` at IMPORT time,
+ * from the sibling generated `entity-registry.ts`/`permissions-registry.ts`.
+ * So this generator-level test can only assert on the EMITTED source: the
+ * correct static imports, the defensive entity-registry guard, the
+ * role/permission-derived scope logic, and the untouched flag/restriction
+ * literals. The actual `SCOPE_CONFIG.roles` VALUES for a real role are
+ * covered by `packages/core/tests/jest/services/scope.service.test.ts`
+ * (against a realistic mock) and by manual inspection of the real generated
+ * output after `node packages/core/scripts/build/registry.mjs`.
+ *
+ * Run: node --test packages/core/scripts/build/registry/__tests__/scope-registry.test.mjs
+ */
+
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+
+import { generateScopeRegistry } from '../generators/scope-registry.mjs'
+
+test('imports ENTITY_REGISTRY and AVAILABLE_ROLES/PERMISSIONS_BY_ROLE from sibling generated registries', () => {
+  const out = generateScopeRegistry([], {})
+  assert.match(out, /import \{ ENTITY_REGISTRY \} from '\.\/entity-registry'/)
+  assert.match(out, /import \{ AVAILABLE_ROLES, PERMISSIONS_BY_ROLE \} from '\.\/permissions-registry'/)
+})
+
+test('does not reintroduce the old generation-time entities/config computation', () => {
+  const out = generateScopeRegistry([{ name: 'ignored', api: { endpoints: { create: true } } }], { some: 'config' })
+  // The old bug read entity.api.endpoints/entity.features/entity.fields directly —
+  // none of those property paths should appear in the emitted output at all,
+  // since the real computation now reads ENTITY_REGISTRY's real EntityConfig.
+  assert.doesNotMatch(out, /entity\.api\.endpoints/)
+  assert.doesNotMatch(out, /entity\.features/)
+})
+
+test('base scopes are empty — nothing granted irrespective of role', () => {
+  const out = generateScopeRegistry([], {})
+  assert.match(out, /base:\s*\[\]/)
+})
+
+test('role scopes are computed from PERMISSIONS_BY_ROLE per AVAILABLE_ROLES, not hardcoded role names', () => {
+  const out = generateScopeRegistry([], {})
+  assert.match(out, /for \(const role of AVAILABLE_ROLES\)/)
+  assert.match(out, /const perms = PERMISSIONS_BY_ROLE\[role\]/)
+  // The old hardcoded roleScopes literal (superadmin/admin/manager/member keys,
+  // referencing a nonexistent "products" entity) must be gone.
+  assert.doesNotMatch(out, /'manager'/)
+  assert.doesNotMatch(out, /products:write/)
+  assert.doesNotMatch(out, /products:delete/)
+})
+
+test('read/write/delete scopes are derived from list|read / create|update / delete permissions', () => {
+  const out = generateScopeRegistry([], {})
+  assert.match(out, /\$\{slug\}\.list.*Permission.*\|\|.*perms\?\.has\(`\$\{slug\}\.read`/)
+  assert.match(out, /\$\{slug\}\.create.*Permission.*\|\|.*perms\?\.has\(`\$\{slug\}\.update`/)
+  assert.match(out, /\$\{slug\}\.delete.*Permission/)
+  assert.match(out, /scopes\.push\(`\$\{slug\}:read`\)/)
+  assert.match(out, /scopes\.push\(`\$\{slug\}:write`\)/)
+  assert.match(out, /scopes\.push\(`\$\{slug\}:delete`\)/)
+})
+
+test('guards against ChildEntityDefinition entries (no access/slug) in ENTITY_REGISTRY', () => {
+  const out = generateScopeRegistry([], {})
+  assert.match(out, /if \(!cfg\?\.access\?\.api \|\| !cfg\.slug\) return null/)
+})
+
+test('flag scopes and restrictions are preserved unchanged', () => {
+  const out = generateScopeRegistry([], {})
+  assert.match(out, /beta_tester/)
+  assert.match(out, /vip:features/)
+  assert.match(out, /"remove": \[\s*"delete",\s*"admin"\s*\]/)
+  assert.match(out, /"allow_only": \[\s*"read",\s*"tasks:write"\s*\]/)
+})
+
+test('superadmin is not hardcoded into SCOPE_CONFIG.roles — handled as a global-role bypass elsewhere', () => {
+  const out = generateScopeRegistry([], {})
+  assert.doesNotMatch(out, /'superadmin':\s*\[/)
+  assert.match(out, /Superadmin is a GLOBAL role/)
+})
+
+test('is a pure function of its output shape — always emits both SCOPE_CONFIG and API_CONFIG exports', () => {
+  const out = generateScopeRegistry([], {})
+  assert.match(out, /export const SCOPE_CONFIG: ScopeConfig = \{/)
+  assert.match(out, /export const API_CONFIG: ApiConfig = \{/)
+})

--- a/packages/core/scripts/build/registry/generators/scope-registry.mjs
+++ b/packages/core/scripts/build/registry/generators/scope-registry.mjs
@@ -3,111 +3,81 @@
  *
  * Generates scope-registry.ts
  *
+ * IMPORTANT: unlike most registry generators, the role→scope computation does
+ * NOT happen here at generation time. It happens at IMPORT TIME inside the
+ * emitted TypeScript, by statically importing the sibling generated
+ * `entity-registry.ts` (for which entities are API-exposed, via
+ * `access.api`) and `permissions-registry.ts` (for which team roles can
+ * perform which action on each entity, via `PERMISSIONS_BY_ROLE`).
+ *
+ * Why: this generator previously computed scopes from the raw `entities`
+ * discovery array (filesystem-scan metadata only — `{name, exportName,
+ * configPath, ...}`), which never carried `.api`/`.features`/`.fields`
+ * properties. Those properties don't exist on that shape, nor on the real
+ * `EntityConfig` type, so the computation silently produced `base: []` and a
+ * hardcoded, wrong `roles` object every time. Reading the REAL entity config
+ * (`access.api`, `slug`, `fields`) and the REAL per-role permission matrix
+ * requires resolving imports, which can only happen once the generated files
+ * are imported by app code — not synchronously inside this generation
+ * script. Doing the computation at import time also guarantees scope
+ * minting and scope enforcement can never diverge again: both read the same
+ * `PERMISSIONS_BY_ROLE` source of truth `checkPermission()` uses at request
+ * time.
+ *
  * @module core/scripts/build/registry/generators/scope-registry
  */
+
+// Flag-based scopes and restriction rules are orthogonal to team roles/entity
+// permissions (they're driven by user flags like `beta_tester`/`vip`, not by
+// what a role can do to which entity) — kept as static literals, unrelated to
+// the role/entity computation this generator used to get wrong.
+const FLAG_SCOPES = {
+  'beta_tester': ['beta:features'],
+  'vip': ['vip:features', 'advanced:export'],
+  'early_adopter': ['early:features'],
+  'power_user': ['advanced:features', 'bulk:operations']
+}
+
+const SCOPE_RESTRICTIONS = {
+  'restricted': {
+    remove: ['delete', 'admin']
+  },
+  'limited_access': {
+    allow_only: ['read', 'tasks:write']
+  }
+}
 
 /**
  * Generate the scope registry file
  *
- * @param {Array} entities - Discovered entities
+ * @param {Array} entities - Discovered entities (unused for scope computation
+ *   today — kept in the signature for call-site consistency with the other
+ *   generators; the real per-entity data used below comes from the generated
+ *   `entity-registry.ts` this file imports, not from this parameter)
  * @param {object} config - Configuration object from getConfig()
  * @returns {string} Generated TypeScript content
  */
 export function generateScopeRegistry(entities, config) {
-  // Generate base scopes from entities
-  const baseScopes = []
-  const entityPaths = []
-
-  for (const entity of entities) {
-    if (entity.api && entity.features?.enabled) {
-      const entityName = entity.name
-      baseScopes.push(`${entityName}:read`)
-
-      // Add write scope if entity supports creation
-      if (entity.api.endpoints && entity.api.endpoints.create) {
-        baseScopes.push(`${entityName}:write`)
-      }
-
-      // Add delete scope for entities that support deletion
-      if (entity.api.endpoints && entity.api.endpoints.delete) {
-        baseScopes.push(`${entityName}:delete`)
-      }
-
-      // Collect entity paths for routing
-      if (entity.api.apiPath) {
-        entityPaths.push(entity.api.apiPath)
-      }
-    }
-  }
-
-  // Define role-based scopes
-  const roleScopes = {
-    'superadmin': ['admin:users', 'tasks:delete', 'products:write', 'products:delete', ...baseScopes.filter(s => s.includes(':delete'))],
-    'admin': ['admin:users', 'tasks:delete', 'products:write', 'products:delete', ...baseScopes.filter(s => s.includes(':delete'))],
-    'manager': baseScopes.filter(s => s.includes(':write') || s.includes(':read')),
-    'member': baseScopes.filter(s => s.includes(':read') || s === 'tasks:write')
-  }
-
-  // Define flag-based scopes
-  const flagScopes = {
-    'beta_tester': ['beta:features'],
-    'vip': ['vip:features', 'advanced:export'],
-    'early_adopter': ['early:features'],
-    'power_user': ['advanced:features', 'bulk:operations']
-  }
-
-  // Define allowed filters based on entities
-  const allowedFilters = ['status', 'role', 'completed', 'userId']
-
-  // Add entity-specific filters
-  for (const entity of entities) {
-    if (entity.api && entity.features?.enabled) {
-      allowedFilters.push(`${entity.name}Id`)
-
-      // Add common entity filters
-      if (entity.fields) {
-        const fields = Object.keys(entity.fields)
-        if (fields.includes('status')) allowedFilters.push(`${entity.name}Status`)
-        if (fields.includes('type')) allowedFilters.push(`${entity.name}Type`)
-        if (fields.includes('category')) allowedFilters.push(`${entity.name}Category`)
-      }
-    }
-  }
-
-  const scopeConfig = {
-    base: [...new Set(baseScopes)],
-    roles: roleScopes,
-    flags: flagScopes,
-    restrictions: {
-      'restricted': {
-        remove: ['delete', 'admin']
-      },
-      'limited_access': {
-        allow_only: ['read', 'tasks:write']
-      }
-    }
-  }
-
-  const apiConfig = {
-    filters: {
-      allowed: [...new Set(allowedFilters)]
-    },
-    entityPaths: [...new Set(entityPaths)]
-  }
-
   return `/**
  * Auto-generated API Scope Registry
  *
  * Generated at: ${new Date().toISOString()}
- * Base scopes: ${scopeConfig.base.length}
- * Role configurations: ${Object.keys(scopeConfig.roles).length}
- * Flag configurations: ${Object.keys(scopeConfig.flags).length}
- * Allowed filters: ${apiConfig.filters.allowed.length}
+ *
+ * Role→scope mapping is computed below at import time from
+ * \`entity-registry.ts\` (which entities are API-exposed) and
+ * \`permissions-registry.ts\` (which team roles can do what to each entity),
+ * so scope MINTING (this file) and scope ENFORCEMENT
+ * (\`checkPermission\`/\`hasRequiredScope\`) can never drift apart.
  *
  * This file replaces hardcoded scope configurations in helpers.ts
  *
  * DO NOT EDIT - This file is auto-generated by scripts/build-registry.mjs
  */
+
+import { ENTITY_REGISTRY } from './entity-registry'
+import { AVAILABLE_ROLES, PERMISSIONS_BY_ROLE } from './permissions-registry'
+import type { Permission } from '@/core/lib/permissions/types'
+import type { EntityConfig } from '@/core/lib/entities/types'
 
 export interface ScopeConfig {
   base: string[]
@@ -123,9 +93,84 @@ export interface ApiConfig {
   entityPaths: string[]
 }
 
-export const SCOPE_CONFIG: ScopeConfig = ${JSON.stringify(scopeConfig, null, 2)}
+interface ScopeApiEntity {
+  slug: string
+  apiPath: string
+  fieldNames: string[]
+}
 
-export const API_CONFIG: ApiConfig = ${JSON.stringify(apiConfig, null, 2)}
+// Entities exposed via the external API (access.api === true). ENTITY_REGISTRY
+// entries can be a full EntityConfig or a ChildEntityDefinition (which has no
+// \`access\`/\`slug\` at all) — guard defensively rather than assume every
+// registry entry is a root entity.
+const SCOPE_API_ENTITIES: ScopeApiEntity[] = Object.values(ENTITY_REGISTRY)
+  .map((entry) => {
+    const cfg = entry.config as Partial<EntityConfig>
+    if (!cfg?.access?.api || !cfg.slug) return null
+    return {
+      slug: cfg.slug,
+      apiPath: cfg.access.basePath || \`/api/v1/\${cfg.slug}\`,
+      fieldNames: Array.isArray(cfg.fields) ? cfg.fields.map((field) => field.name) : []
+    }
+  })
+  .filter((entity): entity is ScopeApiEntity => entity !== null)
+
+// For each API-exposed entity, grant \`<slug>:read/write/delete\` to any team
+// role whose PERMISSIONS_BY_ROLE set includes the corresponding
+// \`<slug>.<action>\` permission — the SAME set checkAuthPermission() consults
+// at request time. Superadmin is a GLOBAL role (never in AVAILABLE_ROLES) and
+// is intentionally NOT represented here; it's handled as an explicit bypass
+// in validateScopesForUser().
+function computeRoleScopes(): Record<string, string[]> {
+  const roleScopes: Record<string, string[]> = {}
+  for (const role of AVAILABLE_ROLES) {
+    const perms = PERMISSIONS_BY_ROLE[role]
+    const scopes: string[] = []
+    for (const { slug } of SCOPE_API_ENTITIES) {
+      if (perms?.has(\`\${slug}.list\` as Permission) || perms?.has(\`\${slug}.read\` as Permission)) {
+        scopes.push(\`\${slug}:read\`)
+      }
+      if (perms?.has(\`\${slug}.create\` as Permission) || perms?.has(\`\${slug}.update\` as Permission)) {
+        scopes.push(\`\${slug}:write\`)
+      }
+      if (perms?.has(\`\${slug}.delete\` as Permission)) {
+        scopes.push(\`\${slug}:delete\`)
+      }
+    }
+    roleScopes[role] = [...new Set(scopes)]
+  }
+  return roleScopes
+}
+
+function computeAllowedFilters(): string[] {
+  const allowedFilters = new Set<string>(['status', 'role', 'completed', 'userId'])
+  for (const { slug, fieldNames } of SCOPE_API_ENTITIES) {
+    allowedFilters.add(\`\${slug}Id\`)
+    if (fieldNames.includes('status')) allowedFilters.add(\`\${slug}Status\`)
+    if (fieldNames.includes('type')) allowedFilters.add(\`\${slug}Type\`)
+    if (fieldNames.includes('category')) allowedFilters.add(\`\${slug}Category\`)
+  }
+  return [...allowedFilters]
+}
+
+export const SCOPE_CONFIG: ScopeConfig = {
+  // Nothing is granted irrespective of role — every entity scope flows
+  // through computeRoleScopes() above, sourced from the real permission
+  // matrix. Kept as an empty array (rather than removed) so a future,
+  // deliberate "these scopes belong to every authenticated key" need has a
+  // place to live without re-deriving this decision.
+  base: [],
+  roles: computeRoleScopes(),
+  flags: ${JSON.stringify(FLAG_SCOPES, null, 2).split('\n').join('\n  ')},
+  restrictions: ${JSON.stringify(SCOPE_RESTRICTIONS, null, 2).split('\n').join('\n  ')}
+}
+
+export const API_CONFIG: ApiConfig = {
+  filters: {
+    allowed: computeAllowedFilters()
+  },
+  entityPaths: SCOPE_API_ENTITIES.map((entity) => entity.apiPath)
+}
 
 // ==================== Service Layer ====================
 // Query functions have been moved to: @nextsparkjs/core/lib/services/scope.service

--- a/packages/core/src/lib/api/auth.ts
+++ b/packages/core/src/lib/api/auth.ts
@@ -2,6 +2,8 @@ import { NextRequest } from 'next/server';
 import { queryOne } from '../db';
 import { ApiKeyManager } from './keys';
 import { apiKeyCache, getCacheKey } from './cache';
+import { TeamMemberService } from '../services/team-member.service';
+import { ScopeService } from '../services/scope.service';
 
 /**
  * Información de autenticación de API Key
@@ -257,7 +259,13 @@ export async function getApiKeyUser(auth: ApiKeyAuth) {
 }
 
 /**
- * Verifica si un usuario puede crear API keys
+ * Verifica si un usuario puede crear API keys.
+ *
+ * Superadmin is a GLOBAL role (`users.role`) and is always allowed. Any
+ * other user is allowed only if they hold a team role that itself grants
+ * `admin:api-keys`/`admin:users`-equivalent scopes for at least one team —
+ * i.e. the same source of truth `validateScopesForUser` uses, checked
+ * without a specific team in mind (any qualifying membership is enough).
  */
 export async function canCreateApiKeys(userId: string): Promise<boolean> {
   try {
@@ -265,13 +273,20 @@ export async function canCreateApiKeys(userId: string): Promise<boolean> {
       'SELECT role FROM "users" WHERE id = $1',
       [userId]
     );
-    
+
     if (!user) {
       return false;
     }
-    
-    // Solo admins y superadmins pueden crear API keys
-    return ['admin', 'superadmin'].includes(user.role);
+
+    if (user.role === 'superadmin') {
+      return true;
+    }
+
+    const memberships = await TeamMemberService.listByUser(userId);
+    return memberships.some(({ role }) => {
+      const scopes = ScopeService.getRoleScopes(role);
+      return scopes.includes('*') || scopes.includes('admin:api-keys');
+    });
   } catch (error) {
     console.error('Error checking API key creation permissions:', error);
     return false;
@@ -279,9 +294,24 @@ export async function canCreateApiKeys(userId: string): Promise<boolean> {
 }
 
 /**
- * Valida que los scopes solicitados sean permitidos para el usuario
+ * Valida que los scopes solicitados sean permitidos para el usuario, en el
+ * contexto de un team específico.
+ *
+ * Superadmin is a GLOBAL role (`users.role`) — it never appears in
+ * `AVAILABLE_ROLES` (team roles), so it's special-cased here rather than
+ * inside the scope registry. Every other user is resolved through their
+ * TEAM role for `teamId` (not their global `users.role` — NextSpark's
+ * entity authorization model is team-scoped, see `app.config.ts`), and the
+ * allowed-scope set comes from the same registry-backed
+ * `ScopeService.getRoleScopes()` that session auth's implicit scopes
+ * (`generateScopesForRole` in `helpers.ts`) and `checkPermission()` both
+ * ultimately derive from — so minting and enforcement can't diverge again.
  */
-export async function validateScopesForUser(userId: string, requestedScopes: string[]): Promise<{
+export async function validateScopesForUser(
+  userId: string,
+  teamId: string | null,
+  requestedScopes: string[]
+): Promise<{
   valid: boolean;
   allowedScopes: string[];
   deniedScopes: string[];
@@ -291,7 +321,7 @@ export async function validateScopesForUser(userId: string, requestedScopes: str
       'SELECT role FROM "users" WHERE id = $1',
       [userId]
     );
-    
+
     if (!user) {
       return {
         valid: false,
@@ -299,21 +329,39 @@ export async function validateScopesForUser(userId: string, requestedScopes: str
         deniedScopes: requestedScopes
       };
     }
-    
-    // Definir scopes permitidos por rol
-    const scopesByRole: Record<string, string[]> = {
-      member: ['tasks:read', 'tasks:write'],
-      colaborator: ['tasks:read', 'tasks:write', 'tasks:delete', 'users:read'],
-      admin: [
-        'users:read', 'users:write', 'users:delete',
-        'tasks:read', 'tasks:write', 'tasks:delete',
-        'admin:api-keys', 'admin:users'
-      ],
-      superadmin: ['*'] // Acceso completo
-    };
-    
-    const allowedScopes = scopesByRole[user.role] || [];
-    
+
+    if (user.role === 'superadmin') {
+      return {
+        valid: true,
+        allowedScopes: requestedScopes,
+        deniedScopes: []
+      };
+    }
+
+    if (!teamId) {
+      // Non-superadmin with no resolvable team context cannot mint any
+      // team-scoped API key — there is no role to check scopes against.
+      return {
+        valid: false,
+        allowedScopes: [],
+        deniedScopes: requestedScopes
+      };
+    }
+
+    const teamRole = await TeamMemberService.getRole(teamId, userId);
+    if (!teamRole) {
+      return {
+        valid: false,
+        allowedScopes: [],
+        deniedScopes: requestedScopes
+      };
+    }
+
+    const allowedScopes = [
+      ...ScopeService.getBaseScopes(),
+      ...ScopeService.getRoleScopes(teamRole)
+    ];
+
     // Si tiene acceso completo, permitir todo
     if (allowedScopes.includes('*')) {
       return {
@@ -322,11 +370,11 @@ export async function validateScopesForUser(userId: string, requestedScopes: str
         deniedScopes: []
       };
     }
-    
+
     // Filtrar scopes permitidos y denegados
     const validScopes = requestedScopes.filter(scope => allowedScopes.includes(scope));
     const deniedScopes = requestedScopes.filter(scope => !allowedScopes.includes(scope));
-    
+
     return {
       valid: deniedScopes.length === 0,
       allowedScopes: validScopes,

--- a/packages/core/src/lib/api/auth/dual-auth.ts
+++ b/packages/core/src/lib/api/auth/dual-auth.ts
@@ -267,6 +267,13 @@ async function trySessionAuth(request: NextRequest): Promise<DualAuthResult> {
 
 /**
  * Check if user has required scope (for API Key auth)
+ *
+ * `admin:all` was previously accepted as an implicit full-access scope here,
+ * but it was never in `API_SCOPES`, never mintable via `validateScopesForUser`,
+ * and undocumented — a full-access string nothing legitimately produced.
+ * Removed rather than formalized: the wildcard `*` (mintable only by a real
+ * superadmin, see `validateScopesForUser`) already covers the "this key has
+ * full access" case in a documented, auditable way.
  */
 export function hasRequiredScope(authResult: DualAuthResult, requiredScope: string): boolean {
   if (authResult.type === 'session') {
@@ -274,8 +281,7 @@ export function hasRequiredScope(authResult: DualAuthResult, requiredScope: stri
   }
 
   if (authResult.type === 'api-key' && authResult.scopes) {
-    return authResult.scopes.includes(requiredScope) || 
-           authResult.scopes.includes('admin:all') || 
+    return authResult.scopes.includes(requiredScope) ||
            authResult.scopes.includes('*')
   }
 

--- a/packages/core/src/lib/api/entity/generic-handler.ts
+++ b/packages/core/src/lib/api/entity/generic-handler.ts
@@ -391,26 +391,28 @@ type OwnershipFilterResult =
 /**
  * Resolve the ownership filter for the current request.
  *
- * Checks whether the authenticated user's team role is one of the roles listed
- * in `entityConfig.access.ownershipFilter.roles`.  If so, looks up the linked
- * record (resolved via `linkedBy` config where `userField = userId`) and
- * returns the filter value to append to the query.
+ * Checks whether the authenticated identity's team role is one of the roles
+ * listed in `entityConfig.access.ownershipFilter.roles`.  If so, looks up the
+ * linked record (resolved via `linkedBy` config where `userField = userId`)
+ * and returns the filter value to append to the query.
  *
- * Only runs for session-authenticated users with a real teamId.  API-key auth
- * and admin-bypass paths are deliberately left unrestricted.
+ * Runs identically for session and API-key auth — both resolve to a real
+ * `team_members` role for `userId`/`teamId`, and there is nothing
+ * auth-type-specific about the ownership check itself. Only an admin bypass
+ * skips it (a superadmin/service-context request is not scoped by any single
+ * team role).
  */
 async function resolveOwnershipFilter(
   entityConfig: EntityConfig,
   userId: string,
   teamId: string,
-  isBypass: boolean,
-  authType: 'session' | 'api-key' | 'none'
+  isBypass: boolean
 ): Promise<OwnershipFilterResult> {
   const ownershipFilter = entityConfig.access?.ownershipFilter
   if (!ownershipFilter) return { applies: false }
 
-  // Admin bypass or API-key auth: no role-based restriction
-  if (isBypass || authType === 'api-key') return { applies: false }
+  // Admin bypass: no role-based restriction.
+  if (isBypass) return { applies: false }
 
   // Get the user's team role
   const memberRow = await queryOneWithRLS<{ role: string }>(
@@ -454,19 +456,22 @@ async function resolveOwnershipFilter(
  * Returns true if user is a member, false otherwise
  */
 /**
- * Check entity-level permissions for session-authenticated users.
- * API key auth uses scopes; session auth needs role-based permission checks.
+ * Check entity-level, team-role-based permissions for the authenticated
+ * identity — session user, or API-key owner (API keys carry the same real
+ * `users.id` a session would, resolved to a `team_members` role the same
+ * way). This runs IN ADDITION to the coarse `<slug>:read/write/delete` scope
+ * check `hasRequiredScope` already performs earlier in each handler — API-key
+ * auth now gets both layers, matching what session auth always had.
  * Returns null if allowed, or a NextResponse with 403 if denied.
  */
-async function checkSessionPermission(
+async function checkAuthPermission(
   authResult: DualAuthResult,
   entitySlug: string,
   action: string,
   teamId: string,
   request: NextRequest
 ): Promise<NextResponse | null> {
-  // Only check for session auth — API key auth uses scopes
-  if (authResult.type !== 'session' || !authResult.user?.id) return null
+  if (!authResult.user?.id) return null
 
   const permission = `${entitySlug}.${action}` as Permission
   try {
@@ -625,11 +630,13 @@ export async function handleGenericList(request: NextRequest): Promise<NextRespo
       teamId = teamValidation.teamId
       isBypass = teamValidation.isBypass
 
-      // Entity-level permission check for session users (api-key uses scopes
-      // above). Skipped for admin bypass (superadmin/developer), who are
-      // authorized at the platform level. A member without `entity.list` → 403.
+      // Entity-level, team-role-based permission check — runs for both
+      // session and API-key auth, in addition to the coarse `:read` scope
+      // check above. Skipped for admin bypass (superadmin/developer), who
+      // are authorized at the platform level. A member without `entity.list`
+      // → 403.
       if (!isBypass && teamId) {
-        const permDenied = await checkSessionPermission(authResult, resolution.entityConfig.slug, 'list', teamId, request)
+        const permDenied = await checkAuthPermission(authResult, resolution.entityConfig.slug, 'list', teamId, request)
         if (permDenied) return permDenied
       }
     }
@@ -777,8 +784,7 @@ export async function handleGenericList(request: NextRequest): Promise<NextRespo
         entityConfig,
         userId,
         teamId,
-        isBypass,
-        authResult.type
+        isBypass
       )
     }
 
@@ -1230,8 +1236,9 @@ export async function handleGenericCreate(request: NextRequest): Promise<NextRes
       return addCorsHeaders(response, request)
     }
 
-    // Check entity-level permissions for session auth
-    const permDenied = await checkSessionPermission(authResult, entityConfig.slug, 'create', teamId, request)
+    // Entity-level, team-role-based permission check — runs for both session
+    // and API-key auth, in addition to the coarse `:write` scope check above.
+    const permDenied = await checkAuthPermission(authResult, entityConfig.slug, 'create', teamId, request)
     if (permDenied) return permDenied
 
     if (idStrategy === 'serial') {
@@ -1559,10 +1566,11 @@ export async function handleGenericRead(request: NextRequest, { params }: { para
       teamId = teamValidation.teamId
       isBypass = teamValidation.isBypass
 
-      // Entity-level permission check for session users (api-key uses scopes).
-      // Skipped for admin bypass; a member without `entity.read` → 403.
+      // Entity-level, team-role-based permission check — runs for both
+      // session and API-key auth, in addition to the coarse `:read` scope check
+      // above. Skipped for admin bypass; a member without `entity.read` → 403.
       if (!isBypass && teamId) {
-        const permDenied = await checkSessionPermission(authResult, resolution.entityConfig.slug, 'read', teamId, request)
+        const permDenied = await checkAuthPermission(authResult, resolution.entityConfig.slug, 'read', teamId, request)
         if (permDenied) return permDenied
       }
     }
@@ -1629,8 +1637,7 @@ export async function handleGenericRead(request: NextRequest, { params }: { para
         entityConfig,
         userId,
         teamId,
-        isBypass,
-        authResult.type
+        isBypass
       )
       if (readOwnershipFilter.applies) {
         if (readOwnershipFilter.value === null) {
@@ -1762,8 +1769,9 @@ export async function handleGenericUpdate(request: NextRequest, { params }: { pa
       return addCorsHeaders(response, request)
     }
 
-    // Check entity-level permissions for session auth
-    const permDenied = await checkSessionPermission(authResult, resolution.entityConfig.slug, 'update', teamId, request)
+    // Entity-level, team-role-based permission check — runs for both session
+    // and API-key auth, in addition to the coarse `:write` scope check above.
+    const permDenied = await checkAuthPermission(authResult, resolution.entityConfig.slug, 'update', teamId, request)
     if (permDenied) return permDenied
 
     // Parse request body
@@ -1781,9 +1789,11 @@ export async function handleGenericUpdate(request: NextRequest, { params }: { pa
     // Generate validation schema from entity configuration
     const entityConfig = resolution.entityConfig
 
-    // Apply field guards based on team role if configured
+    // Apply field guards based on team role if configured. Runs for both
+    // session and API-key auth — the guard is keyed on the identity's real
+    // team role, same as checkAuthPermission/resolveOwnershipFilter above.
     const fieldGuards = entityConfig.access?.ownershipFilter?.fieldGuards
-    if (fieldGuards && fieldGuards.length > 0 && authResult.type === 'session') {
+    if (fieldGuards && fieldGuards.length > 0 && authResult.user?.id) {
       const guardMemberRow = await queryOneWithRLS<{ role: string }>(
         'SELECT role FROM "team_members" WHERE "teamId" = $1 AND "userId" = $2',
         [teamId, authResult.user!.id],
@@ -1975,8 +1985,7 @@ export async function handleGenericUpdate(request: NextRequest, { params }: { pa
         entityConfig,
         authResult.user!.id,
         teamId,
-        teamValidation.isBypass,
-        authResult.type
+        teamValidation.isBypass
       )
       if (updateOwnershipFilter.applies) {
         if (updateOwnershipFilter.value === null) {
@@ -2125,8 +2134,12 @@ export async function handleGenericDelete(request: NextRequest, { params }: { pa
       return authResult.rateLimitResponse as NextResponse
     }
 
-    // Check required permissions for all auth types
-    if (!hasRequiredScope(authResult, `${resolution.entityConfig.slug}:write`)) {
+    // Check required permissions for all auth types. Delete is its own
+    // scope (`<slug>:delete`, distinct from `:write`) — API_SCOPES already
+    // defines it per entity; this previously checked `:write` instead, which
+    // made a write-scoped key able to delete and made the `:delete` scope
+    // itself pure decoration.
+    if (!hasRequiredScope(authResult, `${resolution.entityConfig.slug}:delete`)) {
       const response = createApiError('Insufficient permissions', 403)
       return addCorsHeaders(response, request)
     }
@@ -2144,8 +2157,9 @@ export async function handleGenericDelete(request: NextRequest, { params }: { pa
       return addCorsHeaders(response, request)
     }
 
-    // Check entity-level permissions for session auth
-    const permDenied = await checkSessionPermission(authResult, resolution.entityConfig.slug, 'delete', teamId, request)
+    // Entity-level, team-role-based permission check — runs for both session
+    // and API-key auth, in addition to the coarse `:delete` scope check above.
+    const permDenied = await checkAuthPermission(authResult, resolution.entityConfig.slug, 'delete', teamId, request)
     if (permDenied) return permDenied
 
     // Delete the item

--- a/packages/core/tests/jest/__mocks__/@nextsparkjs/registries/scope-registry.ts
+++ b/packages/core/tests/jest/__mocks__/@nextsparkjs/registries/scope-registry.ts
@@ -1,15 +1,65 @@
 /**
  * Mock Scope Registry for Jest tests
+ *
+ * Shape MUST match the real generated `scope-registry.ts`
+ * (`ScopeConfig`/`ApiConfig`, see
+ * packages/core/scripts/build/registry/generators/scope-registry.mjs) — the
+ * previous version of this mock only exported an empty `SCOPE_REGISTRY` with
+ * unrelated `{name, description}`/`{basePath, version}` interfaces, which
+ * meant `scope.service.test.ts` failed on every assertion the moment it was
+ * force-run and had to be excluded from the suite.
+ *
+ * The role names below (superadmin/admin/manager/member) are an arbitrary
+ * fixture for exercising ScopeService's lookup/immutability/edge-case
+ * behavior — they are NOT meant to represent real `AVAILABLE_ROLES` (which
+ * are `owner/admin/member/viewer` + theme customs). ScopeService itself is
+ * agnostic to what role names exist; it's a pure Record lookup.
  */
 
-export const SCOPE_REGISTRY: Record<string, any> = {}
-
 export interface ScopeConfig {
-  name: string
-  description: string
+  base: string[]
+  roles: Record<string, string[]>
+  flags: Record<string, string[]>
+  restrictions: Record<string, { remove?: string[]; allow_only?: string[] }>
 }
 
 export interface ApiConfig {
-  basePath: string
-  version: string
+  filters: {
+    allowed: string[]
+  }
+  entityPaths: string[]
 }
+
+export const SCOPE_CONFIG: ScopeConfig = {
+  base: ['tasks:read'],
+  roles: {
+    superadmin: ['admin:users', 'admin:api-keys', 'tasks:delete'],
+    admin: ['admin:users', 'tasks:read', 'tasks:write', 'tasks:delete'],
+    manager: ['tasks:read', 'tasks:write'],
+    member: ['tasks:read'],
+  },
+  flags: {
+    beta_tester: ['beta:features'],
+    vip: ['vip:features', 'advanced:export'],
+    early_adopter: ['early:features'],
+    power_user: ['advanced:features', 'bulk:operations'],
+  },
+  restrictions: {
+    restricted: {
+      remove: ['delete', 'admin'],
+    },
+    limited_access: {
+      allow_only: ['read', 'tasks:write'],
+    },
+  },
+}
+
+export const API_CONFIG: ApiConfig = {
+  filters: {
+    allowed: ['status', 'role', 'completed', 'userId'],
+  },
+  entityPaths: ['/api/v1/tasks'],
+}
+
+// Kept for any legacy import still expecting SCOPE_REGISTRY to exist.
+export const SCOPE_REGISTRY: Record<string, unknown> = {}

--- a/packages/core/tests/jest/api/admin-auth.test.ts
+++ b/packages/core/tests/jest/api/admin-auth.test.ts
@@ -4,7 +4,6 @@ jest.mock('@/core/lib/api/auth/dual-auth', () => ({
     if (authResult.type === 'session') return true
     if (authResult.scopes?.includes(requiredScope)) return true
     if (authResult.scopes?.includes('*')) return true
-    if (authResult.scopes?.includes('admin:all')) return true
     return false
   })
 }))
@@ -138,14 +137,14 @@ describe('Admin API Authentication', () => {
       expect(hasAdminPermission(authResult, 'users:read')).toBe(true)
     })
 
-    it('should allow superadmin API key with admin:all scope', () => {
+    it('should deny an API key carrying the removed admin:all scope (not a real scope — #94/#95)', () => {
       const authResult: DualAuthResult = {
         success: true,
         type: 'api-key',
         user: { id: '1', role: 'superadmin', email: 'admin@test.com' },
         scopes: ['admin:all']
       }
-      expect(hasAdminPermission(authResult, 'users:read')).toBe(true)
+      expect(hasAdminPermission(authResult, 'users:read')).toBe(false)
     })
 
     it('should reject failed authentication', () => {

--- a/packages/core/tests/jest/api/auth.test.ts
+++ b/packages/core/tests/jest/api/auth.test.ts
@@ -1,0 +1,183 @@
+/**
+ * Unit Tests - validateScopesForUser / canCreateApiKeys
+ *
+ * Regression coverage for #94: these two functions previously checked a
+ * hardcoded `scopesByRole` map keyed by the user's GLOBAL role (`users.role`),
+ * referencing a nonexistent role (`colaborator`) and missing `owner`/`viewer`
+ * entirely. They now resolve the caller's real TEAM role (for the team the
+ * request targets) and check it against the registry-backed
+ * `ScopeService.getRoleScopes()` — the same source of truth session auth's
+ * implicit scopes and `checkPermission()` both use.
+ */
+
+const mockQueryOne = jest.fn();
+jest.mock('@/core/lib/db', () => ({
+  queryOne: (...args: unknown[]) => mockQueryOne(...args),
+}));
+
+const mockGetRole = jest.fn();
+const mockListByUser = jest.fn();
+jest.mock('@/core/lib/services/team-member.service', () => ({
+  TeamMemberService: {
+    getRole: (...args: unknown[]) => mockGetRole(...args),
+    listByUser: (...args: unknown[]) => mockListByUser(...args),
+  },
+}));
+
+const mockGetBaseScopes = jest.fn();
+const mockGetRoleScopes = jest.fn();
+jest.mock('@/core/lib/services/scope.service', () => ({
+  ScopeService: {
+    getBaseScopes: (...args: unknown[]) => mockGetBaseScopes(...args),
+    getRoleScopes: (...args: unknown[]) => mockGetRoleScopes(...args),
+  },
+}));
+
+import { validateScopesForUser, canCreateApiKeys } from '@/core/lib/api/auth';
+
+describe('validateScopesForUser', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGetBaseScopes.mockReturnValue([]);
+  });
+
+  it('grants everything to a superadmin regardless of team context', async () => {
+    mockQueryOne.mockResolvedValue({ role: 'superadmin' });
+
+    const result = await validateScopesForUser('user-1', null, ['pets:read', 'pets:delete']);
+
+    expect(result).toEqual({
+      valid: true,
+      allowedScopes: ['pets:read', 'pets:delete'],
+      deniedScopes: [],
+    });
+    expect(mockGetRole).not.toHaveBeenCalled();
+  });
+
+  it('denies a non-superadmin with no resolvable team context', async () => {
+    mockQueryOne.mockResolvedValue({ role: 'user' });
+
+    const result = await validateScopesForUser('user-1', null, ['pets:read']);
+
+    expect(result).toEqual({
+      valid: false,
+      allowedScopes: [],
+      deniedScopes: ['pets:read'],
+    });
+    expect(mockGetRole).not.toHaveBeenCalled();
+  });
+
+  it('denies a non-superadmin who is not a member of the target team', async () => {
+    mockQueryOne.mockResolvedValue({ role: 'user' });
+    mockGetRole.mockResolvedValue(null);
+
+    const result = await validateScopesForUser('user-1', 'team-1', ['pets:read']);
+
+    expect(result).toEqual({
+      valid: false,
+      allowedScopes: [],
+      deniedScopes: ['pets:read'],
+    });
+    expect(mockGetRole).toHaveBeenCalledWith('team-1', 'user-1');
+  });
+
+  it('grants scopes covered by the caller real team role, denies the rest', async () => {
+    mockQueryOne.mockResolvedValue({ role: 'user' });
+    mockGetRole.mockResolvedValue('member');
+    mockGetRoleScopes.mockReturnValue(['pets:read']);
+
+    const result = await validateScopesForUser('user-1', 'team-1', ['pets:read', 'pets:delete']);
+
+    expect(result).toEqual({
+      valid: false,
+      allowedScopes: ['pets:read'],
+      deniedScopes: ['pets:delete'],
+    });
+    expect(mockGetRoleScopes).toHaveBeenCalledWith('member');
+  });
+
+  it('grants everything to a team role whose scopes include the wildcard', async () => {
+    mockQueryOne.mockResolvedValue({ role: 'user' });
+    mockGetRole.mockResolvedValue('owner');
+    mockGetRoleScopes.mockReturnValue(['*']);
+
+    const result = await validateScopesForUser('user-1', 'team-1', ['pets:read', 'pets:delete']);
+
+    expect(result).toEqual({
+      valid: true,
+      allowedScopes: ['pets:read', 'pets:delete'],
+      deniedScopes: [],
+    });
+  });
+
+  it('includes base scopes in the allowed set for any real team role', async () => {
+    mockQueryOne.mockResolvedValue({ role: 'user' });
+    mockGetRole.mockResolvedValue('viewer');
+    mockGetBaseScopes.mockReturnValue(['tasks:read']);
+    mockGetRoleScopes.mockReturnValue([]);
+
+    const result = await validateScopesForUser('user-1', 'team-1', ['tasks:read']);
+
+    expect(result.valid).toBe(true);
+    expect(result.allowedScopes).toEqual(['tasks:read']);
+  });
+
+  it('denies for a nonexistent userId', async () => {
+    mockQueryOne.mockResolvedValue(null);
+
+    const result = await validateScopesForUser('ghost', 'team-1', ['pets:read']);
+
+    expect(result).toEqual({
+      valid: false,
+      allowedScopes: [],
+      deniedScopes: ['pets:read'],
+    });
+  });
+
+  it('fails closed (denies) on an unexpected DB error', async () => {
+    mockQueryOne.mockRejectedValue(new Error('connection lost'));
+
+    const result = await validateScopesForUser('user-1', 'team-1', ['pets:read']);
+
+    expect(result).toEqual({
+      valid: false,
+      allowedScopes: [],
+      deniedScopes: ['pets:read'],
+    });
+  });
+});
+
+describe('canCreateApiKeys', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('allows a superadmin', async () => {
+    mockQueryOne.mockResolvedValue({ role: 'superadmin' });
+
+    await expect(canCreateApiKeys('user-1')).resolves.toBe(true);
+    expect(mockListByUser).not.toHaveBeenCalled();
+  });
+
+  it('allows a non-superadmin whose team role scopes include admin:api-keys', async () => {
+    mockQueryOne.mockResolvedValue({ role: 'user' });
+    mockListByUser.mockResolvedValue([{ role: 'admin' }]);
+    mockGetRoleScopes.mockReturnValue(['admin:api-keys']);
+
+    await expect(canCreateApiKeys('user-1')).resolves.toBe(true);
+  });
+
+  it('denies a non-superadmin with no qualifying team role', async () => {
+    mockQueryOne.mockResolvedValue({ role: 'user' });
+    mockListByUser.mockResolvedValue([{ role: 'member' }, { role: 'viewer' }]);
+    mockGetRoleScopes.mockReturnValue(['pets:read']);
+
+    await expect(canCreateApiKeys('user-1')).resolves.toBe(false);
+  });
+
+  it('denies for a nonexistent userId', async () => {
+    mockQueryOne.mockResolvedValue(null);
+
+    await expect(canCreateApiKeys('ghost')).resolves.toBe(false);
+  });
+});

--- a/packages/core/tests/jest/api/entity/generic-handler.test.ts
+++ b/packages/core/tests/jest/api/entity/generic-handler.test.ts
@@ -1,0 +1,355 @@
+/**
+ * Regression coverage for #95: API-key authenticated requests to the generic
+ * entity routes (`/api/v1/[entity]`) previously skipped three authorization
+ * layers session-authenticated requests always went through —
+ * `checkSessionPermission` (now `checkAuthPermission`), `resolveOwnershipFilter`,
+ * and `fieldGuards` — because each was gated on `authResult.type === 'session'`.
+ * These tests drive real requests through the exported handlers
+ * (`handleGenericList`/`handleGenericUpdate`/`handleGenericDelete`) rather
+ * than re-implementing the gate logic locally, so they exercise the actual
+ * fix, not a model of it.
+ */
+
+const mockResolveEntityFromUrl = jest.fn();
+const mockValidateEntityOperation = jest.fn();
+jest.mock('@/core/lib/api/entity/resolver', () => ({
+  resolveEntityFromUrl: (...args: unknown[]) => mockResolveEntityFromUrl(...args),
+  validateEntityOperation: (...args: unknown[]) => mockValidateEntityOperation(...args),
+}));
+
+// Full mock (not a partial jest.requireActual) — the real dual-auth.ts
+// transitively loads lib/auth.ts (Better Auth + DB connection setup), which
+// isn't available in this package-level test context. hasRequiredScope below
+// mirrors the real, already-separately-tested post-#94 implementation
+// (dual-auth.ts:271-283) exactly, so callers here see real behavior.
+const mockAuthenticateRequest = jest.fn();
+const mockCanBypassTeamContext = jest.fn();
+jest.mock('@/core/lib/api/auth/dual-auth', () => ({
+  authenticateRequest: (...args: unknown[]) => mockAuthenticateRequest(...args),
+  canBypassTeamContext: (...args: unknown[]) => mockCanBypassTeamContext(...args),
+  hasRequiredScope: (authResult: { type: string; scopes?: string[] }, requiredScope: string) => {
+    if (authResult.type === 'session') return true;
+    if (authResult.type === 'api-key' && authResult.scopes) {
+      return authResult.scopes.includes(requiredScope) || authResult.scopes.includes('*');
+    }
+    return false;
+  },
+}));
+
+const mockCheckPermission = jest.fn();
+jest.mock('@/core/lib/permissions/check', () => ({
+  checkPermission: (...args: unknown[]) => mockCheckPermission(...args),
+}));
+
+const mockQueryWithRLS = jest.fn();
+const mockQueryOneWithRLS = jest.fn();
+const mockMutateWithRLS = jest.fn();
+jest.mock('@/core/lib/db', () => ({
+  queryWithRLS: (...args: unknown[]) => mockQueryWithRLS(...args),
+  queryOneWithRLS: (...args: unknown[]) => mockQueryOneWithRLS(...args),
+  mutateWithRLS: (...args: unknown[]) => mockMutateWithRLS(...args),
+}));
+
+const mockGenerateEntitySchemas = jest.fn();
+jest.mock('@/core/lib/entities/schema-generator', () => ({
+  generateEntitySchemas: (...args: unknown[]) => mockGenerateEntitySchemas(...args),
+}));
+
+jest.mock('@/core/lib/entities/entity-hooks', () => ({
+  afterEntityCreate: jest.fn(),
+  afterEntityUpdate: jest.fn(),
+  afterEntityDelete: jest.fn(),
+}));
+
+jest.mock('@nextsparkjs/registries/billing-registry', () => ({
+  BILLING_REGISTRY: { actionMappings: { limits: {} } },
+}));
+
+jest.mock('@/core/lib/services/pattern-usage.service', () => ({
+  PatternUsageService: { track: jest.fn(), untrack: jest.fn() },
+}));
+jest.mock('@/core/lib/services/subscription.service', () => ({
+  SubscriptionService: { getActive: jest.fn() },
+}));
+jest.mock('@/core/lib/services/usage.service', () => ({
+  UsageService: { track: jest.fn(), checkLimit: jest.fn() },
+}));
+
+// Full mock (not a partial jest.requireActual) — helpers.ts imports `../auth`
+// (Better Auth + DB bootstrapping), same problem as dual-auth.ts above. These
+// mirror the real (pure, config-free) implementations closely enough for the
+// LIST/UPDATE/DELETE paths under test — none of these test requests set
+// `metas`/`child`/pagination query params, so the "not requested" branches
+// are what's exercised, matching the real functions' behavior in that case.
+jest.mock('@/core/lib/api/helpers', () => ({
+  createApiResponse: (data: unknown, meta?: Record<string, unknown>, status = 200) => ({
+    status,
+    body: { success: true, data, info: { timestamp: new Date().toISOString(), ...meta } },
+    async json() { return this.body; },
+  }),
+  createApiError: (message: string, status = 400, details?: unknown, code?: string) => ({
+    status,
+    body: { success: false, error: message, code: code || `HTTP_${status}`, details },
+    async json() { return this.body; },
+  }),
+  addCorsHeaders: async (response: unknown) => response,
+  handleCorsPreflightRequest: async () => ({ status: 200 }),
+  parsePaginationParams: (request: { url: string }) => {
+    const { searchParams } = new URL(request.url);
+    const page = Math.max(1, parseInt(searchParams.get('page') || '1'));
+    const limit = Math.min(100, Math.max(1, parseInt(searchParams.get('limit') || '10')));
+    return { page, limit, offset: (page - 1) * limit };
+  },
+  createPaginationMeta: (page: number, limit: number, total: number) => ({
+    page, limit, total, totalPages: Math.ceil(total / limit), hasNextPage: page * limit < total,
+  }),
+  parseMetaParams: () => ({ includeMetadata: false, includeAll: false }),
+  parseChildParams: () => ({ includeChildren: false, includeAll: false }),
+  includeEntityMetadata: async (_entityType: string, entities: unknown[]) => entities,
+  includeEntityChildren: async (_entityName: string, entities: unknown[]) => entities,
+  handleEntityMetadataInResponse: async (_entityType: string, entity: unknown) => entity,
+  processEntityMetadata: async () => ({ success: true, errors: [] }),
+}));
+
+import {
+  handleGenericList,
+  handleGenericUpdate,
+  handleGenericDelete,
+} from '@/core/lib/api/entity/generic-handler';
+import type { EntityConfig } from '@/core/lib/entities/types';
+
+function makeRequest(options: {
+  method?: string;
+  url?: string;
+  headers?: Record<string, string>;
+  body?: unknown;
+}) {
+  const headerMap = new Map(Object.entries(options.headers ?? {}));
+  const url = options.url ?? 'http://localhost/api/v1/pets';
+  return {
+    method: options.method ?? 'GET',
+    url,
+    nextUrl: new URL(url),
+    headers: { get: (key: string) => headerMap.get(key) ?? null },
+    cookies: { get: () => undefined },
+    json: async () => options.body ?? {},
+  } as unknown as import('next/server').NextRequest;
+}
+
+const API_KEY_AUTH = (scopes: string[], userRole = 'user') => ({
+  success: true,
+  type: 'api-key' as const,
+  user: { id: 'key-owner-1', email: 'owner@test.com', role: userRole },
+  scopes,
+});
+
+const SESSION_AUTH = (userId = 'session-user-1', userRole = 'user') => ({
+  success: true,
+  type: 'session' as const,
+  user: { id: userId, email: 'user@test.com', role: userRole },
+});
+
+// Ownership-filtered entity: a `member` team role only sees rows whose
+// `ownerId` matches their own userId (direct-field ownership, no linkedBy).
+const PETS_ENTITY: EntityConfig = {
+  slug: 'pets',
+  tableName: 'pets',
+  fields: [
+    { name: 'name', type: 'text' } as never,
+    { name: 'ownerId', type: 'text' } as never,
+    { name: 'notes', type: 'text' } as never,
+  ],
+  access: {
+    api: true,
+    ownershipFilter: {
+      roles: ['member'],
+      field: 'ownerId',
+      fieldGuards: [
+        { roles: ['member'], denyFields: ['notes'] },
+      ],
+    },
+  },
+} as unknown as EntityConfig;
+
+function routeQueryOneWithRLS(teamRole: string | null, memberExists = true) {
+  mockQueryOneWithRLS.mockImplementation(async (sql: string) => {
+    if (sql.includes('SELECT id FROM "team_members"')) {
+      return memberExists ? { id: 'membership-1' } : null;
+    }
+    if (sql.includes('SELECT role FROM "team_members"')) {
+      return teamRole ? { role: teamRole } : null;
+    }
+    return null;
+  });
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockResolveEntityFromUrl.mockResolvedValue({
+    isValidEntity: true,
+    entityConfig: PETS_ENTITY,
+    entityName: 'pets',
+    hasCustomOverride: false,
+  });
+  mockValidateEntityOperation.mockReturnValue(true);
+  mockQueryWithRLS.mockResolvedValue([]);
+  mockCanBypassTeamContext.mockResolvedValue(false);
+});
+
+describe('handleGenericList — #95 authz gates now apply to API-key auth', () => {
+  it('denies an API-key request whose team role lacks entity.list permission (checkAuthPermission)', async () => {
+    mockAuthenticateRequest.mockResolvedValue(API_KEY_AUTH(['pets:read']));
+    routeQueryOneWithRLS('member');
+    mockCheckPermission.mockResolvedValue(false); // this team role can't list pets
+
+    const request = makeRequest({ headers: { 'x-team-id': 'team-1' } });
+    const response = await handleGenericList(request);
+
+    expect((response as { status: number }).status).toBe(403);
+    expect(mockCheckPermission).toHaveBeenCalledWith('key-owner-1', 'team-1', 'pets.list');
+    // The query must never run once permission is denied.
+    expect(mockQueryWithRLS).not.toHaveBeenCalled();
+  });
+
+  it('allows an API-key request whose team role has entity.list permission', async () => {
+    mockAuthenticateRequest.mockResolvedValue(API_KEY_AUTH(['pets:read']));
+    routeQueryOneWithRLS('member');
+    mockCheckPermission.mockResolvedValue(true);
+
+    const request = makeRequest({ headers: { 'x-team-id': 'team-1' } });
+    const response = await handleGenericList(request);
+
+    expect((response as { status: number }).status).toBe(200);
+    expect(mockQueryWithRLS).toHaveBeenCalled();
+  });
+
+  it('applies the ownership filter to an API-key request from a restricted team role (previously bypassed unconditionally)', async () => {
+    mockAuthenticateRequest.mockResolvedValue(API_KEY_AUTH(['pets:read']));
+    routeQueryOneWithRLS('member');
+    mockCheckPermission.mockResolvedValue(true);
+
+    const request = makeRequest({ headers: { 'x-team-id': 'team-1' } });
+    await handleGenericList(request);
+
+    const listCall = mockQueryWithRLS.mock.calls.find(([sql]: [string]) => sql.includes('FROM "pets"'));
+    expect(listCall).toBeDefined();
+    const [sql, params] = listCall as [string, unknown[]];
+    expect(sql).toContain('t."ownerId" = $');
+    expect(params).toContain('key-owner-1'); // the API key OWNER's id, not a session id
+  });
+
+  it('does NOT apply the ownership filter for a role not listed in ownershipFilter.roles', async () => {
+    mockAuthenticateRequest.mockResolvedValue(API_KEY_AUTH(['pets:read']));
+    routeQueryOneWithRLS('owner'); // 'owner' is not in ownershipFilter.roles: ['member']
+    mockCheckPermission.mockResolvedValue(true);
+
+    const request = makeRequest({ headers: { 'x-team-id': 'team-1' } });
+    await handleGenericList(request);
+
+    const listCall = mockQueryWithRLS.mock.calls.find(([sql]: [string]) => sql.includes('FROM "pets"'));
+    const [sql] = listCall as [string, unknown[]];
+    // "ownerId" still appears as a selected column — only the WHERE-clause
+    // filter condition should be absent for an unrestricted role.
+    expect(sql).not.toContain('t."ownerId" = $');
+  });
+
+  it('regression: session auth behavior is unchanged by the fix', async () => {
+    mockAuthenticateRequest.mockResolvedValue(SESSION_AUTH('session-user-1', 'user'));
+    routeQueryOneWithRLS('member');
+    mockCheckPermission.mockResolvedValue(true);
+
+    const request = makeRequest({ headers: { 'x-team-id': 'team-1' } });
+    const response = await handleGenericList(request);
+
+    expect((response as { status: number }).status).toBe(200);
+    const listCall = mockQueryWithRLS.mock.calls.find(([sql]: [string]) => sql.includes('FROM "pets"'));
+    const [sql, params] = listCall as [string, unknown[]];
+    expect(sql).toContain('t."ownerId" = $');
+    expect(params).toContain('session-user-1');
+  });
+});
+
+describe('handleGenericUpdate — fieldGuards now apply to API-key auth', () => {
+  beforeEach(() => {
+    mockGenerateEntitySchemas.mockReturnValue({
+      update: { safeParse: (data: unknown) => ({ success: true, data }) },
+    });
+  });
+
+  it('denies an API-key PATCH that touches a field the caller role is guarded from (previously bypassed unconditionally)', async () => {
+    mockAuthenticateRequest.mockResolvedValue(API_KEY_AUTH(['pets:write']));
+    routeQueryOneWithRLS('member');
+    mockCheckPermission.mockResolvedValue(true);
+
+    const request = makeRequest({
+      method: 'PATCH',
+      url: 'http://localhost/api/v1/pets/pet-1',
+      headers: { 'x-team-id': 'team-1' },
+      body: { notes: 'trying to sneak this in' },
+    });
+    const response = await handleGenericUpdate(request, { params: Promise.resolve({ entity: 'pets', id: 'pet-1' }) });
+
+    expect((response as { status: number }).status).toBe(403);
+    expect(mockMutateWithRLS).not.toHaveBeenCalled();
+  });
+
+  it('allows an API-key PATCH that does not touch a guarded field', async () => {
+    mockAuthenticateRequest.mockResolvedValue(API_KEY_AUTH(['pets:write']));
+    routeQueryOneWithRLS('member');
+    mockCheckPermission.mockResolvedValue(true);
+    mockQueryOneWithRLS.mockImplementation(async (sql: string) => {
+      if (sql.includes('SELECT role FROM "team_members"')) return { role: 'member' };
+      return { id: 'pet-1', name: 'Rex' };
+    });
+    mockMutateWithRLS.mockResolvedValue({ rows: [{ id: 'pet-1', name: 'Rex Updated' }] });
+
+    const request = makeRequest({
+      method: 'PATCH',
+      url: 'http://localhost/api/v1/pets/pet-1',
+      headers: { 'x-team-id': 'team-1' },
+      body: { name: 'Rex Updated' },
+    });
+    const response = await handleGenericUpdate(request, { params: Promise.resolve({ entity: 'pets', id: 'pet-1' }) });
+
+    expect((response as { status: number }).status).not.toBe(403);
+  });
+});
+
+describe('handleGenericDelete — #94 satellite fix: checks :delete scope, not :write', () => {
+  it('denies a key holding only the :write scope', async () => {
+    mockAuthenticateRequest.mockResolvedValue(API_KEY_AUTH(['pets:write']));
+
+    const request = makeRequest({
+      method: 'DELETE',
+      url: 'http://localhost/api/v1/pets/pet-1',
+      headers: { 'x-team-id': 'team-1' },
+    });
+    const response = await handleGenericDelete(request, { params: Promise.resolve({ entity: 'pets', id: 'pet-1' }) });
+
+    expect((response as { status: number }).status).toBe(403);
+  });
+
+  it('allows a key holding the :delete scope through the scope gate', async () => {
+    mockAuthenticateRequest.mockResolvedValue(API_KEY_AUTH(['pets:delete']));
+    routeQueryOneWithRLS('owner');
+    mockCheckPermission.mockResolvedValue(true);
+    mockQueryOneWithRLS.mockImplementation(async (sql: string) => {
+      if (sql.includes('SELECT role FROM "team_members"')) return { role: 'owner' };
+      if (sql.includes('SELECT id FROM "team_members"')) return { id: 'membership-1' };
+      return { id: 'pet-1' };
+    });
+    mockMutateWithRLS.mockResolvedValue({ rows: [{ id: 'pet-1' }] });
+
+    const request = makeRequest({
+      method: 'DELETE',
+      url: 'http://localhost/api/v1/pets/pet-1',
+      headers: { 'x-team-id': 'team-1' },
+    });
+    const response = await handleGenericDelete(request, { params: Promise.resolve({ entity: 'pets', id: 'pet-1' }) });
+
+    // Must not be rejected at the scope gate — later stages may still 404
+    // depending on how much of the delete flow this fixture models, but a
+    // 403 here specifically would mean the scope check regressed.
+    expect((response as { status: number }).status).not.toBe(403);
+  });
+});

--- a/themes/default/tests/cypress/e2e/api/_core/settings/api-keys.crud.cy.ts
+++ b/themes/default/tests/cypress/e2e/api/_core/settings/api-keys.crud.cy.ts
@@ -920,4 +920,125 @@ describe('API Keys API - CRUD Operations', {
       })
     })
   })
+
+  // ============================================
+  // #94 / #95 regression — non-superadmin scope minting and enforcement
+  // ============================================
+  //
+  // Before the fix, `validateScopesForUser` checked a hardcoded map keyed by
+  // the caller's GLOBAL role, so no non-superadmin user could ever mint a
+  // working scope for a real theme entity. It's now team-role based, derived
+  // from the same permissions matrix `checkAuthPermission` enforces at
+  // request time. Uses a real seeded team member (not the superadmin key)
+  // to exercise the actual end-user path the bug blocked.
+  //
+  // Seed data (themes/default/migrations/090_demo_users_teams.sql):
+  // - emily.johnson@nextspark.dev / Testing1234 — `member` role in
+  //   `team-everpoint-001` (Everpoint Labs).
+  // - `tasks` permissions for `member` (themes/default/config/permissions.config.ts):
+  //   create/read/list/update allowed, delete is owner/admin only.
+  describe('#94/#95 — non-superadmin scope minting matches real team-role permissions', () => {
+    const MEMBER_EMAIL = 'emily.johnson@nextspark.dev'
+    const MEMBER_PASSWORD = 'Testing1234'
+    const MEMBER_TEAM_ID = 'team-everpoint-001'
+    const createdKeys: string[] = []
+
+    before(() => {
+      cy.login(MEMBER_EMAIL, MEMBER_PASSWORD)
+    })
+
+    afterEach(() => {
+      createdKeys.forEach((id) => {
+        cy.request({
+          method: 'DELETE',
+          url: `${BASE_URL}/api/v1/api-keys/${id}`,
+          failOnStatusCode: false
+        })
+      })
+      createdKeys.length = 0
+    })
+
+    it('APIKEY_120: a member can mint tasks:read — their role legitimately has it (previously impossible for any non-superadmin)', () => {
+      cy.request({
+        method: 'POST',
+        url: `${BASE_URL}/api/v1/api-keys`,
+        headers: { 'x-team-id': MEMBER_TEAM_ID },
+        body: { name: 'Cypress Member Read Key APIKEY_120', scopes: ['tasks:read'] },
+        failOnStatusCode: false
+      }).then((response: any) => {
+        expect(response.status).to.eq(201)
+        expect(response.body.data.scopes).to.deep.eq(['tasks:read'])
+        createdKeys.push(response.body.data.id)
+      })
+    })
+
+    it('APIKEY_121: a member is denied tasks:delete — their team role does not have it', () => {
+      cy.request({
+        method: 'POST',
+        url: `${BASE_URL}/api/v1/api-keys`,
+        headers: { 'x-team-id': MEMBER_TEAM_ID },
+        body: { name: 'Cypress Member Delete Key APIKEY_121', scopes: ['tasks:delete'] },
+        failOnStatusCode: false
+      }).then((response: any) => {
+        expect(response.status).to.eq(403)
+        expect(response.body).to.have.property('code', 'INSUFFICIENT_SCOPE_PERMISSIONS')
+        expect(response.body.details.deniedScopes).to.include('tasks:delete')
+      })
+    })
+
+    it('APIKEY_122: a legitimately-scoped member key can read tasks — checkAuthPermission does not spuriously block it', () => {
+      cy.request({
+        method: 'POST',
+        url: `${BASE_URL}/api/v1/api-keys`,
+        headers: { 'x-team-id': MEMBER_TEAM_ID },
+        body: { name: 'Cypress Member Read Key APIKEY_122', scopes: ['tasks:read'] },
+        failOnStatusCode: false
+      }).then((createResponse: any) => {
+        expect(createResponse.status).to.eq(201)
+        const memberKey = createResponse.body.data.key
+        createdKeys.push(createResponse.body.data.id)
+
+        cy.request({
+          method: 'GET',
+          url: `${BASE_URL}/api/v1/tasks`,
+          headers: {
+            Authorization: `Bearer ${memberKey}`,
+            'x-team-id': MEMBER_TEAM_ID
+          },
+          failOnStatusCode: false
+        }).then((listResponse: any) => {
+          expect(listResponse.status).to.eq(200)
+        })
+      })
+    })
+
+    it('APIKEY_123: a tasks:write-only member key can no longer delete tasks (the exact escalation this fix closes)', () => {
+      cy.request({
+        method: 'POST',
+        url: `${BASE_URL}/api/v1/api-keys`,
+        headers: { 'x-team-id': MEMBER_TEAM_ID },
+        body: { name: 'Cypress Member Write Key APIKEY_123', scopes: ['tasks:write'] },
+        failOnStatusCode: false
+      }).then((createResponse: any) => {
+        expect(createResponse.status).to.eq(201)
+        const memberKey = createResponse.body.data.key
+        createdKeys.push(createResponse.body.data.id)
+
+        // Before the fix, handleGenericDelete checked the `:write` scope
+        // instead of `:delete`, so this exact key would have been able to
+        // delete — regardless of the member role never holding `tasks.delete`.
+        cy.request({
+          method: 'DELETE',
+          url: `${BASE_URL}/api/v1/tasks/00000000-0000-0000-0000-000000000000`,
+          headers: {
+            Authorization: `Bearer ${memberKey}`,
+            'x-team-id': MEMBER_TEAM_ID
+          },
+          failOnStatusCode: false
+        }).then((deleteResponse: any) => {
+          expect(deleteResponse.status).to.eq(403)
+        })
+      })
+    })
+  })
 })


### PR DESCRIPTION
## Summary

Fixes two related security bugs in the API-key authorization pipeline, discovered while implementing an MCP server on top of `/api/v1` in a downstream project.

- **#94 — Scope minting/enforcement mismatch.** `validateScopesForUser` (the gate deciding which scopes a user may mint into an API key) checked a hardcoded map keyed by the caller's **global** `users.role`, referencing a nonexistent role (`colaborator`) and missing `owner`/`viewer` entirely. Independently, the scope-registry generator backing this was dead code — it read entity properties that don't exist on the real entity-discovery shape, so `SCOPE_CONFIG.roles` was 100% hardcoded, wrong JSON referencing a nonexistent `products` entity. **No non-superadmin user could ever mint a working API key for their own theme's entities.**
- **#95 — API-key auth bypassed authorization layers.** Team-role permission checks, ownership-based row filtering, and field guards all ran **only** for session-authenticated requests on the generic entity routes (`/api/v1/[entity]`), on the assumption that scopes alone governed API-key requests. Scopes only ever expressed entity+operation granularity, so a scoped key could read/write outside its owner's team role, ownership scope, or field restrictions — broader access than the same user's own session.

## Changes

- `scope-registry.mjs` generator rewritten: the emitted file now computes `SCOPE_CONFIG.roles` at import time from `ENTITY_REGISTRY` (which entities are API-exposed) + `PERMISSIONS_BY_ROLE` (which team roles can do what to each entity) — the same source of truth request-time enforcement uses, so minting and enforcement can't drift apart again.
- `validateScopesForUser(userId, teamId, requestedScopes)` — new team-aware signature, resolves the caller's real team role via `TeamMemberService`, with an explicit global-`superadmin` bypass.
- `canCreateApiKeys` fixed with the same pattern for consistency (dead code today, zero callers).
- `POST /api/v1/api-keys` (template + `apps/dev` mirror) resolves team context via `resolveTeamContext` before validating scopes.
- `handleGenericDelete` now checks the `:delete` scope instead of `:write` (a write-scoped key could previously delete).
- Removed the undocumented, unmintable `admin:all` scope from `hasRequiredScope`.
- `resolveOwnershipFilter`, `checkSessionPermission` (renamed `checkAuthPermission`), and the `fieldGuards` block in `generic-handler.ts` now run identically for session and API-key auth.
- Fixed the `ScopeService` Jest mock (previously an empty stub with a wrong shape) — re-enables `scope.service.test.ts` (70 tests, was excluded from the suite).
- New tests: `scope-registry.test.mjs` (generator-level, `node:test`), `auth.test.ts` (`validateScopesForUser`/`canCreateApiKeys`), `generic-handler.test.ts` (drives real requests through the exported handlers to prove the #95 fix, not a re-implementation of the gate logic).
- Cypress: 4 new cases against a real seeded non-superadmin team member (Emily @ Everpoint Labs) proving end-to-end scope minting now works and the delete-scope escalation is closed.
- CHANGELOG entry under `Unreleased` / `Security`.
- Audit logging for these routes (the other half of the original #95 report) is split out to #105 — `api_audit_log.apiKeyId` is `NOT NULL`, closing that gap needs a migration.

## Test plan

- [x] `pnpm test:core` — full Jest suite passes (no new failures vs. `main`; 3 pre-existing unrelated failures confirmed present on `main` too)
- [x] `node --test packages/core/scripts/build/registry/__tests__/scope-registry.test.mjs` — 9/9 pass
- [x] `node --test packages/core/scripts/build/registry/__tests__/team-roles.test.mjs` — no regression
- [x] `node packages/core/scripts/build/registry.mjs --build` — regenerates `scope-registry.ts` correctly against real `apps/dev` entities
- [x] `pnpm build:core` — succeeds (exit 0); DTS step has the same 207 pre-existing type errors as `main` (0 new)
- [ ] Cypress `api-keys.crud.cy.ts` (new cases APIKEY_120–123) — added but not executed; needs a running dev stack + DB (`pnpm db:reset && pnpm dev`)
- [ ] Manual smoke test: non-superadmin team member mints a scope for their own theme entity via Settings → API Keys
- [ ] Spot-check `billing/plans`, `teams/[teamId]/subscription`, `teams/[teamId]/usage/[limitSlug]` for session users — these call `generateScopesForRole` with a *global* role, which now resolves against team-role-keyed `SCOPE_CONFIG.roles`; analysis shows no behavior change (see CHANGELOG/plan), but worth confirming live

Opening as draft — the Cypress run and manual smoke tests above still need a live dev stack, which wasn't available in the environment this was implemented in.

Closes #94, closes #95.

🤖 Generated with [Claude Code](https://claude.com/claude-code)