### PR TITLE
fix(mobile): restore the active team offline and expose refreshSession (fixes #120)

### DIFF
--- a/packages/mobile/src/api/client.ts
+++ b/packages/mobile/src/api/client.ts
@@ -12,7 +12,7 @@
 import Constants from 'expo-constants'
 import * as Storage from '../lib/storage'
 import { ApiError, type RequestConfig } from './client.types'
-import type { User } from './core/types'
+import type { Team, User } from './core/types'
 
 /**
  * Resolve API URL from configuration
@@ -60,11 +60,13 @@ const API_URL = getApiUrl()
 const TOKEN_KEY = 'nextspark.auth.token'
 const TEAM_ID_KEY = 'nextspark.auth.teamId'
 const USER_KEY = 'nextspark.auth.user'
+const TEAM_KEY = 'nextspark.auth.team'
 
 export class ApiClient {
   private token: string | null = null
   private teamId: string | null = null
   private storedUser: User | null = null
+  private storedTeam: Team | null = null
 
   /**
    * Initialize client by loading stored credentials
@@ -78,6 +80,14 @@ export class ApiClient {
         this.storedUser = JSON.parse(userJson)
       } catch {
         this.storedUser = null
+      }
+    }
+    const teamJson = await Storage.getItemAsync(TEAM_KEY)
+    if (teamJson) {
+      try {
+        this.storedTeam = JSON.parse(teamJson)
+      } catch {
+        this.storedTeam = null
       }
     }
   }
@@ -117,6 +127,23 @@ export class ApiClient {
   }
 
   /**
+   * Get the stored active team (the full record, for offline session restore)
+   */
+  getStoredTeam(): Team | null {
+    return this.storedTeam
+  }
+
+  /**
+   * Set the active team: persists the id (sent as x-team-id) and the full
+   * record, so a session can be restored without reaching the server.
+   */
+  async setTeam(team: Team): Promise<void> {
+    this.storedTeam = team
+    await this.setTeamId(team.id)
+    await Storage.setItemAsync(TEAM_KEY, JSON.stringify(team))
+  }
+
+  /**
    * Get stored user info
    */
   getStoredUser(): User | null {
@@ -138,9 +165,11 @@ export class ApiClient {
     this.token = null
     this.teamId = null
     this.storedUser = null
+    this.storedTeam = null
     await Storage.deleteItemAsync(TOKEN_KEY)
     await Storage.deleteItemAsync(TEAM_ID_KEY)
     await Storage.deleteItemAsync(USER_KEY)
+    await Storage.deleteItemAsync(TEAM_KEY)
   }
 
   // ==========================================

--- a/packages/mobile/src/providers/AuthProvider.tsx
+++ b/packages/mobile/src/providers/AuthProvider.tsx
@@ -10,7 +10,8 @@ import {
   useCallback,
   type ReactNode,
 } from 'react'
-import { apiClient, ApiError } from '../api/client'
+import { apiClient } from '../api/client'
+import { ApiError } from '../api/client.types'
 import { authApi, teamsApi } from '../api/core'
 import type { User, Team } from '../api/core/types'
 
@@ -23,6 +24,12 @@ interface AuthContextValue {
   login: (email: string, password: string) => Promise<void>
   logout: () => Promise<void>
   selectTeam: (team: Team) => Promise<void>
+  /**
+   * Re-validate the session with the server without toggling `isLoading`.
+   * Meant for "connectivity is back" / "app returned to foreground": a session
+   * restored offline gets confirmed (fresh user + teams) or cleared (401).
+   */
+  refreshSession: () => Promise<void>
 }
 
 const AuthContext = createContext<AuthContextValue | undefined>(undefined)
@@ -37,72 +44,99 @@ export function AuthProvider({ children }: AuthProviderProps) {
   const [teams, setTeams] = useState<Team[]>([])
   const [isLoading, setIsLoading] = useState(true)
 
-  // Initialize auth state from storage
-  useEffect(() => {
-    const initAuth = async () => {
-      try {
-        await apiClient.init()
+  /**
+   * Persist the active team as a full record: the id travels as `x-team-id`
+   * on every request, the record is what an offline start restores from.
+   */
+  const applyTeam = useCallback(async (nextTeam: Team) => {
+    await apiClient.setTeam(nextTeam)
+    setTeam(nextTeam)
+  }, [])
 
-        // Check if we have stored credentials
-        const hasToken = apiClient.getToken()
+  /**
+   * Restore the session from storage and validate it with the server.
+   *
+   * Offline-first: when the server cannot be reached (anything but a 401) the
+   * stored user AND the stored team are kept, so `isAuthenticated` stays true
+   * and the app keeps working on cached data until `refreshSession()` gets an
+   * answer. Only a 401 clears the credentials.
+   */
+  const restoreSession = useCallback(async () => {
+    try {
+      await apiClient.init()
+
+      // Check if we have stored credentials
+      const hasToken = apiClient.getToken()
+      const storedUser = apiClient.getStoredUser()
+
+      if (!hasToken && !storedUser) return
+
+      // Try to validate session with server and get fresh user data
+      const sessionResponse = await authApi.getSession()
+
+      if (sessionResponse?.user) {
+        // Session is valid, use fresh user data
+        setUser(sessionResponse.user)
+      } else if (storedUser) {
+        // Session call failed but we have stored user - try to use it
+        // This allows offline-first behavior
+        setUser(storedUser)
+      } else {
+        // No valid session and no stored user - clear auth
+        await apiClient.clearAuth()
+        return
+      }
+
+      // Get teams and restore team selection
+      const teamsResponse = await teamsApi.getTeams()
+      setTeams(teamsResponse.data)
+
+      if (teamsResponse.data.length > 0) {
+        // Check if we have a stored team ID
+        const storedTeamId = apiClient.getTeamId()
+        const storedTeam = teamsResponse.data.find(t => t.id === storedTeamId)
+
+        // Prefer the stored team; otherwise the first one
+        await applyTeam(storedTeam ?? teamsResponse.data[0])
+      } else {
+        // Membership list is authoritative when the server answers: no teams
+        // means no active team, even if one was stored
+        setTeam(null)
+      }
+    } catch (error) {
+      // Only clear auth for authentication failures (401)
+      // For network errors or other issues, keep credentials to allow retry
+      if (error instanceof ApiError && error.status === 401) {
+        await apiClient.clearAuth()
+        setUser(null)
+        setTeam(null)
+        setTeams([])
+      } else {
+        console.warn('[AuthProvider] Init failed (network or server error):', error)
+        // Use the stored user AND team for offline-first behavior: without the
+        // team, `isAuthenticated` would read false and the app would send a
+        // user with a perfectly valid session back to login
         const storedUser = apiClient.getStoredUser()
-
-        if (hasToken || storedUser) {
-          // Try to validate session with server and get fresh user data
-          const sessionResponse = await authApi.getSession()
-
-          if (sessionResponse?.user) {
-            // Session is valid, use fresh user data
-            setUser(sessionResponse.user)
-          } else if (storedUser) {
-            // Session call failed but we have stored user - try to use it
-            // This allows offline-first behavior
-            setUser(storedUser)
-          } else {
-            // No valid session and no stored user - clear auth
-            await apiClient.clearAuth()
-            return
-          }
-
-          // Get teams and restore team selection
-          const teamsResponse = await teamsApi.getTeams()
-          setTeams(teamsResponse.data)
-
-          if (teamsResponse.data.length > 0) {
-            // Check if we have a stored team ID
-            const storedTeamId = apiClient.getTeamId()
-            const storedTeam = teamsResponse.data.find(t => t.id === storedTeamId)
-
-            if (storedTeam) {
-              setTeam(storedTeam)
-            } else {
-              // Select first team by default
-              const firstTeam = teamsResponse.data[0]
-              await teamsApi.switchTeam(firstTeam.id)
-              setTeam(firstTeam)
-            }
+        const storedTeam = apiClient.getStoredTeam()
+        if (storedUser) {
+          setUser(storedUser)
+          if (storedTeam) {
+            setTeam(storedTeam)
+            setTeams(teams => (teams.some(t => t.id === storedTeam.id) ? teams : [storedTeam]))
           }
         }
-      } catch (error) {
-        // Only clear auth for authentication failures (401)
-        // For network errors or other issues, keep credentials to allow retry
-        if (error instanceof ApiError && error.status === 401) {
-          await apiClient.clearAuth()
-        } else {
-          console.warn('[AuthProvider] Init failed (network or server error):', error)
-          // Try to use stored user for offline-first behavior
-          const storedUser = apiClient.getStoredUser()
-          if (storedUser) {
-            setUser(storedUser)
-          }
-        }
-      } finally {
-        setIsLoading(false)
       }
     }
+  }, [applyTeam])
 
-    initAuth()
-  }, [])
+  // Initialize auth state from storage
+  useEffect(() => {
+    restoreSession().finally(() => setIsLoading(false))
+  }, [restoreSession])
+
+  const refreshSession = useCallback(async () => {
+    await restoreSession()
+  }, [restoreSession])
 
   const login = useCallback(async (email: string, password: string) => {
     setIsLoading(true)
@@ -121,13 +155,11 @@ export function AuthProvider({ children }: AuthProviderProps) {
       }
 
       // Select first team
-      const firstTeam = teamsResponse.data[0]
-      await teamsApi.switchTeam(firstTeam.id)
-      setTeam(firstTeam)
+      await applyTeam(teamsResponse.data[0])
     } finally {
       setIsLoading(false)
     }
-  }, [])
+  }, [applyTeam])
 
   const logout = useCallback(async () => {
     await authApi.logout()
@@ -136,10 +168,12 @@ export function AuthProvider({ children }: AuthProviderProps) {
     setTeams([])
   }, [])
 
-  const selectTeam = useCallback(async (newTeam: Team) => {
-    await teamsApi.switchTeam(newTeam.id)
-    setTeam(newTeam)
-  }, [])
+  const selectTeam = useCallback(
+    async (newTeam: Team) => {
+      await applyTeam(newTeam)
+    },
+    [applyTeam]
+  )
 
   const value: AuthContextValue = {
     user,
@@ -150,6 +184,7 @@ export function AuthProvider({ children }: AuthProviderProps) {
     login,
     logout,
     selectTeam,
+    refreshSession,
   }
 
   return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>

--- a/packages/mobile/tests/jest/api/client.test.ts
+++ b/packages/mobile/tests/jest/api/client.test.ts
@@ -42,6 +42,35 @@ describe('ApiClient', () => {
       expect(apiClient.getTeamId()).toBe(mockTeamId)
       expect(apiClient.getStoredUser()).toEqual(mockUser)
     })
+
+    it('loads the stored team record', async () => {
+      const mockTeam = { id: 'team-1', name: 'Team One', role: 'member' }
+
+      ;(SecureStore.getItemAsync as jest.Mock)
+        .mockResolvedValueOnce(null)
+        .mockResolvedValueOnce('team-1')
+        .mockResolvedValueOnce(null)
+        .mockResolvedValueOnce(JSON.stringify(mockTeam))
+
+      await apiClient.init()
+
+      expect(apiClient.getStoredTeam()).toEqual(mockTeam)
+    })
+  })
+
+  describe('setTeam', () => {
+    it('stores the team id and the full record', async () => {
+      const team = { id: 'team-1', name: 'Team One', role: 'member' }
+      await apiClient.setTeam(team)
+
+      expect(SecureStore.setItemAsync).toHaveBeenCalledWith('nextspark.auth.teamId', 'team-1')
+      expect(SecureStore.setItemAsync).toHaveBeenCalledWith(
+        'nextspark.auth.team',
+        JSON.stringify(team)
+      )
+      expect(apiClient.getTeamId()).toBe('team-1')
+      expect(apiClient.getStoredTeam()).toEqual(team)
+    })
   })
 
   describe('setToken', () => {
@@ -93,13 +122,15 @@ describe('ApiClient', () => {
   describe('clearAuth', () => {
     it('clears all stored credentials', async () => {
       await apiClient.setToken('token')
-      await apiClient.setTeamId('team-id')
+      await apiClient.setTeam({ id: 'team-id', name: 'Team', role: 'member' })
 
       await apiClient.clearAuth()
 
       expect(apiClient.getToken()).toBeNull()
       expect(apiClient.getTeamId()).toBeNull()
       expect(apiClient.getStoredUser()).toBeNull()
+      expect(apiClient.getStoredTeam()).toBeNull()
+      expect(SecureStore.deleteItemAsync).toHaveBeenCalledWith('nextspark.auth.team')
     })
   })
 })

--- a/packages/mobile/tests/jest/providers/AuthProvider.test.tsx
+++ b/packages/mobile/tests/jest/providers/AuthProvider.test.tsx
@@ -3,6 +3,7 @@ import { renderHook, act, waitFor } from '@testing-library/react-native'
 import { AuthProvider, useAuth } from '../../../src/providers/AuthProvider'
 import { apiClient } from '../../../src/api/client'
 import { authApi, teamsApi } from '../../../src/api/core'
+import { ApiError } from '../../../src/api/client.types'
 
 // Mock the API modules
 jest.mock('../../../src/api/client')
@@ -18,6 +19,8 @@ describe('AuthProvider', () => {
     ;(apiClient.init as jest.Mock).mockResolvedValue(undefined)
     ;(apiClient.getToken as jest.Mock).mockReturnValue(null)
     ;(apiClient.getStoredUser as jest.Mock).mockReturnValue(null)
+    ;(apiClient.getStoredTeam as jest.Mock).mockReturnValue(null)
+    ;(apiClient.setTeam as jest.Mock).mockResolvedValue(undefined)
   })
 
   it('provides auth context', async () => {
@@ -69,5 +72,120 @@ describe('AuthProvider', () => {
 
     expect(result.current.user).toBeNull()
     expect(result.current.isAuthenticated).toBe(false)
+  })
+
+  describe('session restore', () => {
+    const storedUser = { id: 'user-1', name: 'Stored User', email: 'stored@example.com' }
+    const storedTeam = { id: 'team-1', name: 'Stored Team', role: 'member' }
+
+    beforeEach(() => {
+      ;(apiClient.getToken as jest.Mock).mockReturnValue('stored-token')
+      ;(apiClient.getStoredUser as jest.Mock).mockReturnValue(storedUser)
+      ;(apiClient.getStoredTeam as jest.Mock).mockReturnValue(storedTeam)
+    })
+
+    it('restores user and team from the server when it answers', async () => {
+      const freshUser = { ...storedUser, name: 'Fresh User' }
+      ;(authApi.getSession as jest.Mock).mockResolvedValue({ user: freshUser })
+      ;(teamsApi.getTeams as jest.Mock).mockResolvedValue({ data: [storedTeam] })
+      ;(apiClient.getTeamId as jest.Mock).mockReturnValue('team-1')
+
+      const { result } = renderHook(() => useAuth(), { wrapper })
+      await waitFor(() => expect(result.current.isLoading).toBe(false))
+
+      expect(result.current.user).toEqual(freshUser)
+      expect(result.current.team).toEqual(storedTeam)
+      expect(result.current.isAuthenticated).toBe(true)
+      expect(apiClient.setTeam).toHaveBeenCalledWith(storedTeam)
+    })
+
+    it('keeps user AND team from storage when the server is unreachable', async () => {
+      ;(authApi.getSession as jest.Mock).mockRejectedValue(new TypeError('Network request failed'))
+
+      const { result } = renderHook(() => useAuth(), { wrapper })
+      await waitFor(() => expect(result.current.isLoading).toBe(false))
+
+      expect(result.current.user).toEqual(storedUser)
+      expect(result.current.team).toEqual(storedTeam)
+      expect(result.current.teams).toEqual([storedTeam])
+      expect(result.current.isAuthenticated).toBe(true)
+      expect(apiClient.clearAuth).not.toHaveBeenCalled()
+    })
+
+    it('stays unauthenticated offline when no team was ever stored', async () => {
+      ;(apiClient.getStoredTeam as jest.Mock).mockReturnValue(null)
+      ;(authApi.getSession as jest.Mock).mockRejectedValue(new TypeError('Network request failed'))
+
+      const { result } = renderHook(() => useAuth(), { wrapper })
+      await waitFor(() => expect(result.current.isLoading).toBe(false))
+
+      expect(result.current.user).toEqual(storedUser)
+      expect(result.current.team).toBeNull()
+      expect(result.current.isAuthenticated).toBe(false)
+    })
+
+    it('clears everything on a 401', async () => {
+      ;(authApi.getSession as jest.Mock).mockRejectedValue(new ApiError('Unauthorized', 401))
+      ;(apiClient.clearAuth as jest.Mock).mockResolvedValue(undefined)
+
+      const { result } = renderHook(() => useAuth(), { wrapper })
+      await waitFor(() => expect(result.current.isLoading).toBe(false))
+
+      expect(apiClient.clearAuth).toHaveBeenCalled()
+      expect(result.current.user).toBeNull()
+      expect(result.current.team).toBeNull()
+      expect(result.current.isAuthenticated).toBe(false)
+    })
+
+    it('refreshSession confirms an offline-restored session once the server answers', async () => {
+      ;(authApi.getSession as jest.Mock).mockRejectedValueOnce(new TypeError('Network request failed'))
+
+      const { result } = renderHook(() => useAuth(), { wrapper })
+      await waitFor(() => expect(result.current.isLoading).toBe(false))
+      expect(result.current.isAuthenticated).toBe(true)
+
+      const otherTeam = { id: 'team-2', name: 'Other Team', role: 'member' }
+      ;(authApi.getSession as jest.Mock).mockResolvedValue({ user: storedUser })
+      ;(teamsApi.getTeams as jest.Mock).mockResolvedValue({ data: [storedTeam, otherTeam] })
+      ;(apiClient.getTeamId as jest.Mock).mockReturnValue('team-1')
+
+      await act(async () => {
+        await result.current.refreshSession()
+      })
+
+      expect(result.current.teams).toEqual([storedTeam, otherTeam])
+      expect(result.current.team).toEqual(storedTeam)
+      expect(result.current.isLoading).toBe(false)
+    })
+
+    it('refreshSession drops the restored team when the server says there is none', async () => {
+      ;(authApi.getSession as jest.Mock).mockRejectedValueOnce(new TypeError('Network request failed'))
+
+      const { result } = renderHook(() => useAuth(), { wrapper })
+      await waitFor(() => expect(result.current.isAuthenticated).toBe(true))
+
+      ;(authApi.getSession as jest.Mock).mockResolvedValue({ user: storedUser })
+      ;(teamsApi.getTeams as jest.Mock).mockResolvedValue({ data: [] })
+
+      await act(async () => {
+        await result.current.refreshSession()
+      })
+
+      expect(result.current.team).toBeNull()
+      expect(result.current.isAuthenticated).toBe(false)
+    })
+  })
+
+  it('persists the selected team as a full record', async () => {
+    const newTeam = { id: 'team-9', name: 'Nine', role: 'owner' }
+    const { result } = renderHook(() => useAuth(), { wrapper })
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
+
+    await act(async () => {
+      await result.current.selectTeam(newTeam)
+    })
+
+    expect(apiClient.setTeam).toHaveBeenCalledWith(newTeam)
+    expect(result.current.team).toEqual(newTeam)
   })
 })


### PR DESCRIPTION
## Summary

Fixes #120. On a cold start `AuthProvider` restores the stored session and revalidates it with `getSession()`. When that call failed for a **network** reason (not a 401), the `catch` kept the stored user but never set the team — the team only came from `getTeams()` on the happy path. Since `isAuthenticated` is `!!user && !!team`, an app opened without connectivity reported the user as unauthenticated and every gate sent them to login, although the session was valid. Nothing re-ran the restoration when connectivity came back.

## Changes

1. **`packages/mobile/src/api/client.ts`** — `ApiClient` now persists the active `Team` **record** (`nextspark.auth.team`) next to the id it already stored: `getStoredTeam()`, `setTeam(team)` (also writes the id, so `x-team-id` keeps working), loaded in `init()`, removed by `clearAuth()`.
2. **`packages/mobile/src/providers/AuthProvider.tsx`**
   - The non-401 failure path restores **user and team** from storage (`teams` gets the stored team so consumers see a consistent list). Without a stored team the behavior is unchanged (user only, unauthenticated).
   - When the server *does* answer, the membership list is authoritative: an empty list clears the active team even if one was stored.
   - A 401 clears the in-memory state too (before, only storage was cleared).
   - Every place that sets a team goes through one `applyTeam()` that persists the record (`selectTeam`, `login`, restore).
   - New **`refreshSession()`** on the context: re-runs the validation without toggling `isLoading`, so an app can confirm (fresh user + teams) or drop (401) an offline-restored session from a reconnect / foreground handler.
   - `ApiError` is imported from `client.types` (like `api/core/auth.ts` does) so `instanceof` works when `client` is mocked.
3. **Tests** — `tests/jest/providers/AuthProvider.test.tsx`: offline restore keeps user+team, offline without stored team stays unauthenticated, 401 clears everything, `refreshSession` confirms / drops the restored team, `selectTeam` persists the record. `tests/jest/api/client.test.ts`: team record load, `setTeam`, `clearAuth`.

No breaking changes: `switchTeam(teamId)` and `setTeamId()` keep working; `refreshSession` is additive.

## Verification

- `pnpm test` in `packages/mobile`: 60/60 (6 suites), `pnpm typecheck` clean, `pnpm build` (tsup) clean.
- Reproduced the bug on a real device (Galaxy A16, Expo SDK 54, app on beta.167) with a theme-side workaround implementing the same idea (remember the last team, put it back when the provider ends with user and no team): airplane mode → cold start → the app now stays authenticated and shows its loader; connectivity back → home, no re-login. This PR moves that behavior into the provider, where it belongs.

## Test plan

- [x] `packages/mobile/tests/jest/providers/AuthProvider.test.tsx` — 10/10
- [x] `packages/mobile/tests/jest/api/client.test.ts` — team record load / set / clear
- [ ] Consumer app: call `refreshSession()` from a NetInfo "reconnected" handler and drop the client-side workaround once this is published
