### PR TITLE
fix(mobile): commit login state atomically so no render pairs the new user with the previous team (fixes #121)

### DIFF
--- a/packages/mobile/src/providers/AuthProvider.tsx
+++ b/packages/mobile/src/providers/AuthProvider.tsx
@@ -10,7 +10,8 @@ import {
   useCallback,
   type ReactNode,
 } from 'react'
-import { apiClient, ApiError } from '../api/client'
+import { apiClient } from '../api/client'
+import { ApiError } from '../api/client.types'
 import { authApi, teamsApi } from '../api/core'
 import type { User, Team } from '../api/core/types'
 
@@ -110,11 +111,9 @@ export function AuthProvider({ children }: AuthProviderProps) {
     try {
       // Login to get token
       const loginResponse = await authApi.login(email, password)
-      setUser(loginResponse.user)
 
       // Get user's teams
       const teamsResponse = await teamsApi.getTeams()
-      setTeams(teamsResponse.data)
 
       if (teamsResponse.data.length === 0) {
         throw new ApiError('No teams available', 400)
@@ -123,6 +122,12 @@ export function AuthProvider({ children }: AuthProviderProps) {
       // Select first team
       const firstTeam = teamsResponse.data[0]
       await teamsApi.switchTeam(firstTeam.id)
+
+      // Commit user, teams and team together, once everything succeeded: no
+      // render ever pairs the new user with the previous session's team, and a
+      // failed login leaves the previous state untouched.
+      setUser(loginResponse.user)
+      setTeams(teamsResponse.data)
       setTeam(firstTeam)
     } finally {
       setIsLoading(false)

--- a/packages/mobile/tests/jest/providers/AuthProvider.test.tsx
+++ b/packages/mobile/tests/jest/providers/AuthProvider.test.tsx
@@ -70,4 +70,63 @@ describe('AuthProvider', () => {
     expect(result.current.user).toBeNull()
     expect(result.current.isAuthenticated).toBe(false)
   })
+
+  describe('login while another session is active', () => {
+    const userA = { id: 'user-a', name: 'A', email: 'a@example.com' }
+    const teamA = { id: 'team-a', name: 'Team A', role: 'member' }
+    const userB = { id: 'user-b', name: 'B', email: 'b@example.com' }
+    const teamB = { id: 'team-b', name: 'Team B', role: 'member' }
+
+    beforeEach(() => {
+      ;(apiClient.getToken as jest.Mock).mockReturnValue('token-a')
+      ;(apiClient.getStoredUser as jest.Mock).mockReturnValue(userA)
+      ;(authApi.getSession as jest.Mock).mockResolvedValue({ user: userA })
+      ;(teamsApi.getTeams as jest.Mock).mockResolvedValue({ data: [teamA] })
+      ;(apiClient.getTeamId as jest.Mock).mockReturnValue('team-a')
+      ;(teamsApi.switchTeam as jest.Mock).mockResolvedValue(undefined)
+    })
+
+    it('never renders the new user paired with the previous team', async () => {
+      const renders: Array<{ user: string | undefined; team: string | undefined }> = []
+      const { result } = renderHook(
+        () => {
+          const auth = useAuth()
+          renders.push({ user: auth.user?.id, team: auth.team?.id })
+          return auth
+        },
+        { wrapper }
+      )
+      await waitFor(() => expect(result.current.isAuthenticated).toBe(true))
+
+      ;(authApi.login as jest.Mock).mockResolvedValue({ user: userB })
+      ;(teamsApi.getTeams as jest.Mock).mockResolvedValue({ data: [teamB] })
+
+      await act(async () => {
+        await result.current.login('b@example.com', 'password')
+      })
+
+      expect(result.current.user).toEqual(userB)
+      expect(result.current.team).toEqual(teamB)
+      expect(renders).not.toContainEqual({ user: 'user-b', team: 'team-a' })
+    })
+
+    it('leaves the previous session untouched when the login fails', async () => {
+      const { result } = renderHook(() => useAuth(), { wrapper })
+      await waitFor(() => expect(result.current.isAuthenticated).toBe(true))
+
+      ;(authApi.login as jest.Mock).mockResolvedValue({ user: userB })
+      ;(teamsApi.getTeams as jest.Mock).mockResolvedValue({ data: [] })
+
+      await act(async () => {
+        await expect(result.current.login('b@example.com', 'password')).rejects.toThrow(
+          'No teams available'
+        )
+      })
+
+      expect(result.current.user).toEqual(userA)
+      expect(result.current.team).toEqual(teamA)
+      expect(result.current.isAuthenticated).toBe(true)
+      expect(result.current.isLoading).toBe(false)
+    })
+  })
 })


### PR DESCRIPTION
## Summary

Fixes #121. `AuthProvider.login()` updated state in three steps — `setUser(newUser)`, then `await getTeams()`, then `setTeam(firstTeam)` — so at least one render exposed **the new user paired with the previous session's team**, and during an account switch without an explicit `logout()` `isAuthenticated` never dropped. Consumers keyed on `(user, team)` (analytics identity, per-team caches) observed an inconsistent pair and could not tell a user change from a team change.

## Changes

- **`packages/mobile/src/providers/AuthProvider.tsx`** — `login()` performs every network step first (`login`, `getTeams`, `switchTeam`) and only then applies `setUser` / `setTeams` / `setTeam` together (React 18 batches them into one render). Side effect worth having: a failed login (network error, "No teams available") now leaves the previous in-memory session untouched instead of half-updated.
- `ApiError` is imported from `client.types` (as `api/core/auth.ts` already does): with the `client` module mocked, the automocked class lost the error message on `throw new ApiError('No teams available', 400)`.
- **Tests** — `tests/jest/providers/AuthProvider.test.tsx`: records every render during an account switch and asserts no render pairs `user-b` with `team-a`; a failed login keeps user A / team A authenticated and `isLoading` false.

Behavior on success is unchanged (same final state, same calls). Overlaps with #122 only on the `ApiError` import line; either merge order works.

## Verification

- `pnpm test` in `packages/mobile`: 53/53, `pnpm typecheck` clean.
- Observed in a consumer app (Expo SDK 54): analytics events emitted right after an account switch were attributed to the previous user until the async identify caught up; the app needed a client-side "user changed → reset" guard that this change makes unnecessary.

## Test plan

- [x] `AuthProvider.test.tsx` — 5/5 in the suite, including the two new cases
