### PR TITLE
[#89][#88] Fail-closed permission checks and soft-delete-aware team membership

### DIFF
--- a/apps/dev/app/api/v1/teams/[teamId]/invitations/route.ts
+++ b/apps/dev/app/api/v1/teams/[teamId]/invitations/route.ts
@@ -132,7 +132,7 @@ export const DELETE = withRateLimitTier(withApiLogging(
 
       // Check if user has permission to manage invitations using MembershipService
       const membership = await MembershipService.get(authResult.user!.id, teamId)
-      const actionResult = membership.canPerformAction('members.invite')
+      const actionResult = membership.canPerformAction('team.members.invite')
 
       if (!actionResult.allowed) {
         const response = NextResponse.json(

--- a/apps/dev/app/api/v1/teams/[teamId]/invoices/[invoiceNumber]/route.ts
+++ b/apps/dev/app/api/v1/teams/[teamId]/invoices/[invoiceNumber]/route.ts
@@ -54,7 +54,7 @@ export const GET = withRateLimitTier(withApiLogging(
 
       // Check if user has permission to view invoices using MembershipService
       const membership = await MembershipService.get(authResult.user!.id, teamId)
-      const actionResult = membership.canPerformAction('billing.invoices')
+      const actionResult = membership.canPerformAction('team.billing.view')
 
       if (!actionResult.allowed) {
         const response = NextResponse.json(

--- a/apps/dev/app/api/v1/teams/[teamId]/invoices/route.ts
+++ b/apps/dev/app/api/v1/teams/[teamId]/invoices/route.ts
@@ -47,7 +47,7 @@ export const GET = withRateLimitTier(withApiLogging(
 
       // Check if user has permission to view invoices using MembershipService
       const membership = await MembershipService.get(authResult.user!.id, teamId)
-      const actionResult = membership.canPerformAction('billing.invoices')
+      const actionResult = membership.canPerformAction('team.billing.view')
 
       if (!actionResult.allowed) {
         const response = NextResponse.json(

--- a/apps/dev/app/api/v1/teams/[teamId]/members/[memberId]/route.ts
+++ b/apps/dev/app/api/v1/teams/[teamId]/members/[memberId]/route.ts
@@ -55,7 +55,7 @@ export const PATCH = withRateLimitTier(withApiLogging(
 
       // Check if user has permission to update member roles using MembershipService
       const membership = await MembershipService.get(authResult.user!.id, teamId)
-      const actionResult = membership.canPerformAction('members.update_role')
+      const actionResult = membership.canPerformAction('team.members.update_role')
 
       if (!actionResult.allowed) {
         const response = NextResponse.json(
@@ -194,7 +194,7 @@ export const DELETE = withRateLimitTier(withApiLogging(
 
       // Check if user has permission to remove members using MembershipService
       const membership = await MembershipService.get(authResult.user!.id, teamId)
-      const actionResult = membership.canPerformAction('members.remove')
+      const actionResult = membership.canPerformAction('team.members.remove')
 
       if (!actionResult.allowed) {
         const response = NextResponse.json(

--- a/apps/dev/app/api/v1/teams/[teamId]/members/route.ts
+++ b/apps/dev/app/api/v1/teams/[teamId]/members/route.ts
@@ -193,7 +193,7 @@ export const POST = withRateLimitTier(withApiLogging(
 
       // Check if user has permission to invite members using MembershipService
       const membership = await MembershipService.get(authResult.user!.id, teamId)
-      const actionResult = membership.canPerformAction('members.invite')
+      const actionResult = membership.canPerformAction('team.members.invite')
 
       if (!actionResult.allowed) {
         const response = NextResponse.json(

--- a/apps/dev/app/api/v1/teams/[teamId]/route.ts
+++ b/apps/dev/app/api/v1/teams/[teamId]/route.ts
@@ -118,7 +118,7 @@ export const PATCH = withRateLimitTier(withApiLogging(
 
       // Check if user has permission to edit team using MembershipService
       const membership = await MembershipService.get(authResult.user!.id, teamId)
-      const actionResult = membership.canPerformAction('teams.update')
+      const actionResult = membership.canPerformAction('team.edit')
 
       if (!actionResult.allowed) {
         const response = NextResponse.json(

--- a/apps/dev/app/api/v1/teams/[teamId]/subscription/route.ts
+++ b/apps/dev/app/api/v1/teams/[teamId]/subscription/route.ts
@@ -23,7 +23,7 @@ export const GET = withRateLimitTier(async function GET(request: NextRequest, pr
   try {
     // Check if user has permission to view subscription using MembershipService
     const membership = await MembershipService.get(auth.userId, teamId)
-    const actionResult = membership.canPerformAction('billing.view')
+    const actionResult = membership.canPerformAction('team.billing.view')
 
     if (!actionResult.allowed) {
       return NextResponse.json(

--- a/apps/dev/app/api/v1/teams/[teamId]/usage/[limitSlug]/route.ts
+++ b/apps/dev/app/api/v1/teams/[teamId]/usage/[limitSlug]/route.ts
@@ -25,7 +25,7 @@ export const GET = withRateLimitTier(async function GET(request: NextRequest, pr
   try {
     // Check if user has permission to view usage using MembershipService
     const membership = await MembershipService.get(auth.userId, teamId)
-    const actionResult = membership.canPerformAction('billing.view')
+    const actionResult = membership.canPerformAction('team.billing.view')
 
     if (!actionResult.allowed) {
       return NextResponse.json(
@@ -57,7 +57,7 @@ export const POST = withRateLimitTier(async function POST(request: NextRequest, 
   try {
     // Check if user has permission to track usage using MembershipService
     const membership = await MembershipService.get(auth.userId, teamId)
-    const actionResult = membership.canPerformAction('billing.manage')
+    const actionResult = membership.canPerformAction('team.billing.manage')
 
     if (!actionResult.allowed) {
       return NextResponse.json(

--- a/packages/core/jest.config.cjs
+++ b/packages/core/jest.config.cjs
@@ -16,7 +16,6 @@ module.exports = {
     // These tests work correctly in the context of a generated project
     'tests/jest/services/block.service.test.ts',
     'tests/jest/services/entity-type.service.test.ts',
-    'tests/jest/services/membership.service.test.ts',
     'tests/jest/services/namespace.service.test.ts',
     'tests/jest/services/permission.service.test.ts',
     'tests/jest/services/theme.service.test.ts',

--- a/packages/core/src/lib/services/membership.service.ts
+++ b/packages/core/src/lib/services/membership.service.ts
@@ -176,12 +176,20 @@ export class TeamMembership implements TeamMembershipData {
    * 4. Quota is available
    * 5. Subscription is active
    *
-   * @param action - Action slug to check
+   * The action id IS the permission id as registered in the permissions
+   * registry (e.g. 'team.members.update_role', 'customers.create',
+   * 'page-builder.access'). Ids may have any number of dot-separated segments.
+   *
+   * Fails closed: an action whose id is not a registered permission is denied
+   * (and logged) instead of silently allowed, so a typo or a renamed permission
+   * surfaces as a visible 403 rather than an unguarded endpoint (issue #89).
+   *
+   * @param action - Action slug to check (must be a registered permission id)
    * @param options - Options for quota increment
    * @returns ActionResult with allowed status and details
    *
    * @example
-   * const result = membership.canPerformAction('projects.create')
+   * const result = membership.canPerformAction('team.members.update_role')
    * if (!result.allowed) {
    *   console.log(result.message, result.reason)
    * }
@@ -211,22 +219,39 @@ export class TeamMembership implements TeamMembershipData {
       }
     }
 
-    // Parse action (e.g., 'customers.create' -> permission check)
-    const [entity, actionType] = action.split('.')
-    const permission = `${entity}.${actionType}` as Permission
-
     // 3. Check permission (RBAC)
-    if (PermissionService.isValid(permission)) {
-      if (!this.hasPermission(permission)) {
-        return {
-          allowed: false,
-          reason: 'permission_denied',
-          message: `You do not have permission: ${permission}`,
-          meta: {
-            requiredPermission: permission,
-            userRole: this.role,
-          },
-        }
+    //
+    // The full action id is the permission id. Do NOT rebuild it from the first
+    // two segments: 'team.members.update_role' must not collapse into
+    // 'team.members' (which is not a registered id).
+    const permission = action as Permission
+
+    // Fail closed: an unregistered permission id is denied, never allowed.
+    if (!PermissionService.isValid(permission)) {
+      console.warn(
+        `[MembershipService] canPerformAction('${action}') denied: '${permission}' is not a registered permission id`
+      )
+      return {
+        allowed: false,
+        reason: 'permission_denied',
+        message: `Unknown permission: ${permission}`,
+        meta: {
+          requiredPermission: permission,
+          userRole: this.role,
+          unregistered: true,
+        },
+      }
+    }
+
+    if (!this.hasPermission(permission)) {
+      return {
+        allowed: false,
+        reason: 'permission_denied',
+        message: `You do not have permission: ${permission}`,
+        meta: {
+          requiredPermission: permission,
+          userRole: this.role,
+        },
       }
     }
 

--- a/packages/core/src/lib/services/team-member.service.ts
+++ b/packages/core/src/lib/services/team-member.service.ts
@@ -38,9 +38,15 @@ export class TeamMemberService {
   /**
    * Get team member by team and user ID
    *
+   * Only resolves memberships of active teams. Team deletion is a soft delete
+   * (UPDATE "teams" SET "deletedAt"), which never fires the ON DELETE CASCADE
+   * on team_members, so membership rows outlive the team. A member of a
+   * soft-deleted team is reported as "not a member" (null), the same shape
+   * callers already handle for users who were never on the team (issue #88).
+   *
    * @param teamId - Team ID
    * @param userId - User ID
-   * @returns Team member or null if not found
+   * @returns Team member or null if not found (or if the team is soft-deleted)
    *
    * @example
    * const member = await TeamMemberService.getByTeamAndUser('team-123', 'user-456')
@@ -54,7 +60,10 @@ export class TeamMemberService {
     }
 
     return queryOneWithRLS<TeamMember>(
-      'SELECT * FROM "team_members" WHERE "teamId" = $1 AND "userId" = $2',
+      `SELECT tm.*
+         FROM "team_members" tm
+         INNER JOIN "teams" t ON t.id = tm."teamId"
+        WHERE tm."teamId" = $1 AND tm."userId" = $2 AND t."deletedAt" IS NULL`,
       [teamId, userId],
       userId
     )

--- a/packages/core/src/lib/services/team-member.service.ts
+++ b/packages/core/src/lib/services/team-member.service.ts
@@ -113,9 +113,12 @@ export class TeamMemberService {
   /**
    * Get user's role in a team
    *
+   * Only resolves roles in active teams: a member of a soft-deleted team
+   * (teams."deletedAt" set) is reported as not a member (issue #88).
+   *
    * @param teamId - Team ID
    * @param userId - User ID
-   * @returns The user's role or null if not a member
+   * @returns The user's role or null if not a member (or if the team is soft-deleted)
    *
    * @example
    * const role = await TeamMemberService.getRole('team-123', 'user-456')
@@ -126,7 +129,10 @@ export class TeamMemberService {
     }
 
     const member = await queryOneWithRLS<{ role: TeamRole }>(
-      'SELECT role FROM "team_members" WHERE "teamId" = $1 AND "userId" = $2',
+      `SELECT tm.role
+         FROM "team_members" tm
+         INNER JOIN "teams" t ON t.id = tm."teamId"
+        WHERE tm."teamId" = $1 AND tm."userId" = $2 AND t."deletedAt" IS NULL`,
       [teamId, userId],
       userId
     )
@@ -399,9 +405,12 @@ export class TeamMemberService {
   /**
    * Check if user is a member of a team
    *
+   * Only counts membership in active teams: a member of a soft-deleted team
+   * (teams."deletedAt" set) is reported as not a member (issue #88).
+   *
    * @param teamId - Team ID
    * @param userId - User ID
-   * @returns True if user is a member
+   * @returns True if user is a member of an active team
    *
    * @example
    * const isMember = await TeamMemberService.isMember('team-123', 'user-456')
@@ -412,7 +421,10 @@ export class TeamMemberService {
     }
 
     const member = await queryOneWithRLS<{ id: string }>(
-      'SELECT id FROM "team_members" WHERE "teamId" = $1 AND "userId" = $2',
+      `SELECT tm.id
+         FROM "team_members" tm
+         INNER JOIN "teams" t ON t.id = tm."teamId"
+        WHERE tm."teamId" = $1 AND tm."userId" = $2 AND t."deletedAt" IS NULL`,
       [teamId, userId],
       userId
     )

--- a/packages/core/src/lib/teams/permissions.ts
+++ b/packages/core/src/lib/teams/permissions.ts
@@ -302,7 +302,9 @@ export function getInvitableRoles(): string[] {
 
 /**
  * Validate role transition
- * Check if changing from one role to another is allowed
+ * Check if changing from one role to another is allowed.
+ *
+ * The actor must strictly outrank BOTH the current role and the new role.
  *
  * @param fromRole - Current role
  * @param toRole - New role
@@ -330,11 +332,21 @@ export function validateRoleTransition(
     }
   }
 
-  // Check if actor can manage the target role
+  // Check if actor can manage the target's CURRENT role
   if (!canManageRole(actorRole, fromRole)) {
     return {
       allowed: false,
       reason: 'You do not have permission to change this user\'s role.',
+    }
+  }
+
+  // Check if actor outranks the DESTINATION role as well. Without this an
+  // actor could promote anyone below them to any level, including above the
+  // actor's own (issue #89).
+  if (!canManageRole(actorRole, toRole)) {
+    return {
+      allowed: false,
+      reason: 'You cannot assign a role equal to or higher than your own.',
     }
   }
 

--- a/packages/core/tests/jest/__mocks__/@nextsparkjs/registries/permissions-registry.ts
+++ b/packages/core/tests/jest/__mocks__/@nextsparkjs/registries/permissions-registry.ts
@@ -36,3 +36,26 @@ export const TEAM_PERMISSIONS_BY_ROLE: Record<string, string[]> = {
   member: ['team.view', 'team.members.view'],
   viewer: ['team.view'],
 }
+
+// Entity permissions used by service tests (mirrors the default theme's customers entity)
+const ENTITY_PERMISSIONS_BY_ROLE: Record<string, string[]> = {
+  owner: ['customers.create', 'customers.read', 'customers.list', 'customers.update', 'customers.delete'],
+  admin: ['customers.create', 'customers.read', 'customers.list', 'customers.update'],
+  editor: ['customers.read', 'customers.list'],
+  member: ['customers.read', 'customers.list'],
+  viewer: [],
+}
+
+export const ROLE_PERMISSIONS_ARRAY: Record<string, string[]> = Object.fromEntries(
+  AVAILABLE_ROLES.map((role) => [
+    role,
+    [...(TEAM_PERMISSIONS_BY_ROLE[role] ?? []), ...(ENTITY_PERMISSIONS_BY_ROLE[role] ?? [])],
+  ])
+)
+
+export const PERMISSIONS_BY_ROLE: Record<string, Set<string>> = Object.fromEntries(
+  Object.entries(ROLE_PERMISSIONS_ARRAY).map(([role, perms]) => [role, new Set(perms)])
+)
+
+export const ALL_PERMISSIONS: string[] = Array.from(new Set(Object.values(ROLE_PERMISSIONS_ARRAY).flat()))
+export const ALL_PERMISSIONS_SET: Set<string> = new Set(ALL_PERMISSIONS)

--- a/packages/core/tests/jest/lib/teams/permissions.test.ts
+++ b/packages/core/tests/jest/lib/teams/permissions.test.ts
@@ -1,0 +1,77 @@
+/**
+ * Unit Tests - Teams Permissions (role hierarchy)
+ *
+ * Covers canManageRole() and validateRoleTransition().
+ * Hierarchy comes from the permissions-registry mock:
+ * owner=100, admin=50, editor=30, member=10, viewer=1
+ *
+ * Issue #89: validateRoleTransition() only compared the actor against the
+ * target's CURRENT role, so an actor could promote a lower-ranked member to
+ * any role, including one above the actor's own level.
+ */
+
+import { canManageRole, validateRoleTransition } from '@/core/lib/teams/permissions'
+
+describe('teams/permissions', () => {
+  describe('canManageRole', () => {
+    it('allows managing only roles strictly lower in the hierarchy', () => {
+      expect(canManageRole('admin', 'member')).toBe(true)
+      expect(canManageRole('owner', 'admin')).toBe(true)
+      expect(canManageRole('admin', 'admin')).toBe(false)
+      expect(canManageRole('member', 'admin')).toBe(false)
+    })
+
+    it('treats unknown roles as hierarchy 0', () => {
+      expect(canManageRole('member', 'unknown-role')).toBe(true)
+      expect(canManageRole('unknown-role', 'viewer')).toBe(false)
+    })
+  })
+
+  describe('validateRoleTransition', () => {
+    it('rejects changing the owner role', () => {
+      const result = validateRoleTransition('owner', 'admin', 'owner')
+      expect(result.allowed).toBe(false)
+      expect(result.reason).toContain('ownership transfer')
+    })
+
+    it('rejects promoting to owner', () => {
+      const result = validateRoleTransition('member', 'owner', 'owner')
+      expect(result.allowed).toBe(false)
+      expect(result.reason).toContain('ownership transfer')
+    })
+
+    it('rejects when the actor does not outrank the current role', () => {
+      const result = validateRoleTransition('admin', 'member', 'member')
+      expect(result.allowed).toBe(false)
+    })
+
+    it('allows assigning a role strictly below the actor', () => {
+      expect(validateRoleTransition('member', 'editor', 'admin')).toEqual({ allowed: true })
+      expect(validateRoleTransition('viewer', 'member', 'admin')).toEqual({ allowed: true })
+      expect(validateRoleTransition('member', 'admin', 'owner')).toEqual({ allowed: true })
+    })
+
+    describe('destination role (issue #89)', () => {
+      it('ROLE_089_1: rejects promoting a target above the actor own level', () => {
+        // editor (30) outranks member (10) but must not be able to hand out admin (50)
+        const result = validateRoleTransition('member', 'admin', 'editor')
+
+        expect(result.allowed).toBe(false)
+        expect(result.reason).toBeDefined()
+      })
+
+      it('ROLE_089_2: rejects assigning a role equal to the actor own level', () => {
+        const result = validateRoleTransition('member', 'admin', 'admin')
+
+        expect(result.allowed).toBe(false)
+      })
+
+      it('ROLE_089_3: rejects a lateral move into a higher role even when the actor outranks the current role', () => {
+        // member (10) outranks viewer (1) but cannot promote the viewer to editor (30)
+        const result = validateRoleTransition('viewer', 'editor', 'member')
+
+        expect(result.allowed).toBe(false)
+      })
+    })
+  })
+})

--- a/packages/core/tests/jest/services/membership.service.test.ts
+++ b/packages/core/tests/jest/services/membership.service.test.ts
@@ -19,6 +19,7 @@
  * - MEMB_008: TeamMembership.canPerformAction() - not_member
  * - MEMB_009: TeamMembership.canPerformAction() - permission_denied
  * - MEMB_010: TeamMembership.canPerformAction() - subscription_inactive
+ * - MEMB_089_x: TeamMembership.canPerformAction() - fail closed on unregistered permission ids (#89)
  */
 
 // Mock server-only to allow testing server components
@@ -399,24 +400,74 @@ describe('TeamMembership Class', () => {
       }
     })
 
-    it('should allow action for invalid permission format', () => {
-      const membership = createMembership({
-        role: 'admin',
-        permissions: ['customers.create'] as Permission[],
-        subscription: {
-          id: 'sub-123',
-          planSlug: 'professional',
-          planName: 'Professional',
-          status: 'active',
-          trialEndsAt: null,
-          currentPeriodEnd: new Date(),
-        },
+    describe('permission registry lookup (issue #89 - fail closed)', () => {
+      let warnSpy: jest.SpyInstance
+
+      beforeEach(() => {
+        warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {})
       })
 
-      // Action without dot notation (not a valid permission)
-      const result = membership.canPerformAction('invalid_action')
+      afterEach(() => {
+        warnSpy.mockRestore()
+      })
 
-      expect(result.allowed).toBe(true)
+      it('MEMB_089_1: should deny an unregistered permission id instead of falling through', () => {
+        // 'members.update_role' is NOT a registered id (the registry has 'team.members.update_role')
+        const membership = createMembership({
+          role: 'member',
+          permissions: ['team.view', 'team.members.view'] as Permission[],
+        })
+
+        const result = membership.canPerformAction('members.update_role')
+
+        expect(result.allowed).toBe(false)
+        if (!result.allowed) {
+          expect(result.reason).toBe('permission_denied')
+          expect(result.meta?.requiredPermission).toBe('members.update_role')
+          expect(result.meta?.userRole).toBe('member')
+        }
+        expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('members.update_role'))
+      })
+
+      it('MEMB_089_2: should deny a registered three-segment permission the role does not hold', () => {
+        const membership = createMembership({
+          role: 'member',
+          permissions: ['team.view', 'team.members.view'] as Permission[],
+        })
+
+        const result = membership.canPerformAction('team.members.update_role')
+
+        expect(result.allowed).toBe(false)
+        if (!result.allowed) {
+          expect(result.reason).toBe('permission_denied')
+          expect(result.meta?.requiredPermission).toBe('team.members.update_role')
+          expect(result.meta?.userRole).toBe('member')
+        }
+      })
+
+      it('MEMB_089_3: should allow a registered three-segment permission the role holds', () => {
+        const membership = createMembership({
+          role: 'admin',
+          permissions: ['team.members.update_role', 'team.members.remove'] as Permission[],
+        })
+
+        expect(membership.canPerformAction('team.members.update_role')).toEqual({ allowed: true })
+        expect(membership.canPerformAction('team.members.remove')).toEqual({ allowed: true })
+      })
+
+      it('MEMB_089_4: should deny an action without dot notation (not a registered permission)', () => {
+        const membership = createMembership({
+          role: 'admin',
+          permissions: ['customers.create'] as Permission[],
+        })
+
+        const result = membership.canPerformAction('invalid_action')
+
+        expect(result.allowed).toBe(false)
+        if (!result.allowed) {
+          expect(result.reason).toBe('permission_denied')
+        }
+      })
     })
 
     it('should allow action when subscription is null', () => {

--- a/packages/core/tests/jest/services/team-member.service.test.ts
+++ b/packages/core/tests/jest/services/team-member.service.test.ts
@@ -134,6 +134,20 @@ describe('TeamMemberService', () => {
 
       expect(result).toBeNull()
     })
+
+    it('TM_088: only resolves roles in active (non soft-deleted) teams', async () => {
+      // Same gap as getByTeamAndUser: team_members rows outlive teams."deletedAt" (issue #88)
+      mockQueryOneWithRLS.mockResolvedValue(null)
+
+      await TeamMemberService.getRole('team-456', 'user-789')
+
+      const [sql, params, rlsUserId] = mockQueryOneWithRLS.mock.calls[0]
+      const normalized = (sql as string).replace(/\s+/g, ' ')
+      expect(normalized).toContain('INNER JOIN "teams" t ON t.id = tm."teamId"')
+      expect(normalized).toContain('t."deletedAt" IS NULL')
+      expect(params).toEqual(['team-456', 'user-789'])
+      expect(rlsUserId).toBe('user-789')
+    })
   })
 
   // ===========================================
@@ -312,6 +326,20 @@ describe('TeamMemberService', () => {
       const result = await TeamMemberService.isMember('team-456', 'non-member')
 
       expect(result).toBe(false)
+    })
+
+    it('TM_088: only counts membership in active (non soft-deleted) teams', async () => {
+      // Same gap as getByTeamAndUser: team_members rows outlive teams."deletedAt" (issue #88)
+      mockQueryOneWithRLS.mockResolvedValue(null)
+
+      await TeamMemberService.isMember('team-456', 'user-789')
+
+      const [sql, params, rlsUserId] = mockQueryOneWithRLS.mock.calls[0]
+      const normalized = (sql as string).replace(/\s+/g, ' ')
+      expect(normalized).toContain('INNER JOIN "teams" t ON t.id = tm."teamId"')
+      expect(normalized).toContain('t."deletedAt" IS NULL')
+      expect(params).toEqual(['team-456', 'user-789'])
+      expect(rlsUserId).toBe('user-789')
     })
   })
 

--- a/packages/core/tests/jest/services/team-member.service.test.ts
+++ b/packages/core/tests/jest/services/team-member.service.test.ts
@@ -64,11 +64,25 @@ describe('TeamMemberService', () => {
       const result = await TeamMemberService.getByTeamAndUser('team-456', 'user-789')
 
       expect(result).toEqual(mockMember)
-      expect(mockQueryOneWithRLS).toHaveBeenCalledWith(
-        'SELECT * FROM "team_members" WHERE "teamId" = $1 AND "userId" = $2',
-        ['team-456', 'user-789'],
-        'user-789'
-      )
+      expect(mockQueryOneWithRLS).toHaveBeenCalledTimes(1)
+      const [sql, params, rlsUserId] = mockQueryOneWithRLS.mock.calls[0]
+      expect(sql).toMatch(/FROM "team_members" tm/)
+      expect(params).toEqual(['team-456', 'user-789'])
+      expect(rlsUserId).toBe('user-789')
+    })
+
+    it('TM_088: only resolves memberships of active (non soft-deleted) teams', async () => {
+      // Team deletion is a soft delete (UPDATE teams SET "deletedAt"), which never
+      // fires ON DELETE CASCADE, so team_members rows outlive the team. The lookup
+      // must join teams and exclude soft-deleted ones (issue #88).
+      mockQueryOneWithRLS.mockResolvedValue(null)
+
+      await TeamMemberService.getByTeamAndUser('team-456', 'user-789')
+
+      const [sql] = mockQueryOneWithRLS.mock.calls[0]
+      const normalized = (sql as string).replace(/\s+/g, ' ')
+      expect(normalized).toContain('INNER JOIN "teams" t ON t.id = tm."teamId"')
+      expect(normalized).toContain('t."deletedAt" IS NULL')
     })
 
     it('returns null when not found', async () => {


### PR DESCRIPTION
## Description
Fixes two related vulnerabilities in `MembershipService`/`TeamMemberService`: an unregistered permission id being treated as allowed (fail-open), and soft-deleted teams still granting an active role to their former members.

## Changes
- `canPerformAction()` now denies (fail-closed) on any unregistered permission id, and `validateRoleTransition` requires the actor's role to outrank the destination role. Fixed a bug where the split of a 3-segment permission id (`team.billing.manage`) was checked as a 2-segment id, leaving billing permission routes fail-open too.
- `getByTeamAndUser`, `getRole`, and `isMember` in `TeamMemberService` now exclude teams with `deletedAt` set — same predicate as `TeamService.switchActive`. No migration required.
- 8 routes under `apps/dev/app/api/v1/teams/[teamId]/**` updated to use registered permission ids.

## Testing
- [x] Unit tests RED before fix, GREEN after, for both issues (`membership.service.test.ts`, `permissions.test.ts`, `team-member.service.test.ts`)
- [x] Reproduced the soft-delete bug against a real disposable database with a fixture team+member, confirmed under RLS (`SET ROLE nextspark_app`) and with the service-role bypass
- [x] Full core suite: only the 3 known pre-existing failures (`team.service`, `block-editor/tree-view`, `block-editor/block-preview-canvas`), none introduced by this change

## Related Issues
- Fixes #89
- Fixes #88