### PR TITLE
[batch] 11 independent bug fixes (billing, CORS, i18n, a11y, auth)

### DIFF
--- a/apps/dev/app/api/superadmin/subscriptions/route.ts
+++ b/apps/dev/app/api/superadmin/subscriptions/route.ts
@@ -230,6 +230,7 @@ export const GET = withRateLimitTier(async (request: NextRequest) => {
     const totalPages = Math.ceil(total / limit);
 
     // Format subscriptions
+    const billingGateway = await getBillingGateway()
     const subscriptions = subscriptionsResult.map(sub => ({
       id: sub.id,
       team: {
@@ -257,7 +258,7 @@ export const GET = withRateLimitTier(async (request: NextRequest) => {
       cancelAtPeriodEnd: sub.cancelAtPeriodEnd,
       externalSubscriptionId: sub.externalSubscriptionId,
       paymentProvider: sub.paymentProvider,
-      providerDashboardUrl: getBillingGateway().getSubscriptionDashboardUrl(sub.externalSubscriptionId),
+      providerDashboardUrl: billingGateway.getSubscriptionDashboardUrl(sub.externalSubscriptionId),
       createdAt: sub.createdAt
     }));
 

--- a/apps/dev/app/api/superadmin/teams/[teamId]/route.ts
+++ b/apps/dev/app/api/superadmin/teams/[teamId]/route.ts
@@ -204,6 +204,7 @@ export const GET = withRateLimitTier(async (
     const subscription = subscriptionResult[0] || null;
 
     // Prepare response data
+    const billingGateway = subscription ? await getBillingGateway() : null
     const responseData = {
       team: {
         id: team.id,
@@ -225,7 +226,7 @@ export const GET = withRateLimitTier(async (
         role: member.role,
         joinedAt: member.joinedAt
       })),
-      subscription: subscription ? {
+      subscription: subscription && billingGateway ? {
         id: subscription.id,
         plan: {
           id: subscription.planId,
@@ -246,8 +247,8 @@ export const GET = withRateLimitTier(async (
         externalSubscriptionId: subscription.externalSubscriptionId,
         externalCustomerId: subscription.externalCustomerId,
         paymentProvider: subscription.paymentProvider,
-        providerName: getBillingGateway().getProviderName(),
-        providerDashboardUrl: getBillingGateway().getSubscriptionDashboardUrl(subscription.externalSubscriptionId),
+        providerName: billingGateway.getProviderName(),
+        providerDashboardUrl: billingGateway.getSubscriptionDashboardUrl(subscription.externalSubscriptionId),
         createdAt: subscription.createdAt
       } : null,
       billingHistory: billingEventsResult.map((event) => ({

--- a/apps/dev/app/api/v1/api-keys/[id]/route.ts
+++ b/apps/dev/app/api/v1/api-keys/[id]/route.ts
@@ -24,8 +24,8 @@ import { authenticateRequest, hasRequiredScope } from '@nextsparkjs/core/lib/api
 import { withRateLimitTier } from '@nextsparkjs/core/lib/api/rate-limit';
 
 // Handle CORS preflight
-export async function OPTIONS() {
-  return handleCorsPreflightRequest();
+export async function OPTIONS(request: NextRequest) {
+  return handleCorsPreflightRequest(request);
 }
 
 // GET /api/v1/api-keys/:id - Get specific API key details
@@ -54,14 +54,14 @@ export const GET = withRateLimitTier(withApiLogging(async (
 
     if (!hasPermission) {
       const response = createApiError('Insufficient permissions. Admin access required for API key management.', 403);
-      return addCorsHeaders(response);
+      return addCorsHeaders(response, req);
     }
 
     const { id } = await params;
 
     if (!id || id.trim() === '') {
       const response = createApiError('API key ID is required', 400, null, 'MISSING_API_KEY_ID');
-      return addCorsHeaders(response);
+      return addCorsHeaders(response, req);
     }
 
     const apiKey = await queryOneWithRLS(
@@ -74,7 +74,7 @@ export const GET = withRateLimitTier(withApiLogging(async (
 
     if (!apiKey) {
       const response = createApiError('API key not found', 404, null, 'API_KEY_NOT_FOUND');
-      return addCorsHeaders(response);
+      return addCorsHeaders(response, req);
     }
 
     // Get detailed usage statistics
@@ -129,11 +129,11 @@ export const GET = withRateLimitTier(withApiLogging(async (
         success_rate: null
       }
     });
-    return addCorsHeaders(response);
+    return addCorsHeaders(response, req);
   } catch (error) {
     console.error('Error fetching API key:', error);
     const response = createApiError('Internal server error', 500);
-    return addCorsHeaders(response);
+    return addCorsHeaders(response, req);
   }
 }), 'strict');
 
@@ -163,14 +163,14 @@ export const PATCH = withRateLimitTier(withApiLogging(async (
 
     if (!hasPermission) {
       const response = createApiError('Insufficient permissions. Admin access required for API key management.', 403);
-      return addCorsHeaders(response);
+      return addCorsHeaders(response, req);
     }
 
     const { id } = await params;
 
     if (!id || id.trim() === '') {
       const response = createApiError('API key ID is required', 400, null, 'MISSING_API_KEY_ID');
-      return addCorsHeaders(response);
+      return addCorsHeaders(response, req);
     }
 
     const body = await req.json();
@@ -185,11 +185,11 @@ export const PATCH = withRateLimitTier(withApiLogging(async (
       if (body[field] !== undefined) {
         if (field === 'name' && typeof body[field] !== 'string') {
           const response = createApiError('Name must be a string', 400, null, 'INVALID_NAME_TYPE');
-          return addCorsHeaders(response);
+          return addCorsHeaders(response, req);
         }
         if (field === 'status' && !['active', 'inactive', 'expired'].includes(body[field])) {
           const response = createApiError('status must be active, inactive, or expired', 400, null, 'INVALID_STATUS_TYPE');
-          return addCorsHeaders(response);
+          return addCorsHeaders(response, req);
         }
         
         updates.push(`"${field}" = $${paramCount++}`);
@@ -199,7 +199,7 @@ export const PATCH = withRateLimitTier(withApiLogging(async (
 
     if (updates.length === 0) {
       const response = createApiError('No valid fields to update', 400, null, 'NO_FIELDS');
-      return addCorsHeaders(response);
+      return addCorsHeaders(response, req);
     }
 
     updates.push(`"updatedAt" = CURRENT_TIMESTAMP`);
@@ -216,15 +216,15 @@ export const PATCH = withRateLimitTier(withApiLogging(async (
 
     if (result.rows.length === 0) {
       const response = createApiError('API key not found', 404, null, 'API_KEY_NOT_FOUND');
-      return addCorsHeaders(response);
+      return addCorsHeaders(response, req);
     }
 
     const response = createApiResponse(result.rows[0]);
-    return addCorsHeaders(response);
+    return addCorsHeaders(response, req);
   } catch (error) {
     console.error('Error updating API key:', error);
     const response = createApiError('Internal server error', 500);
-    return addCorsHeaders(response);
+    return addCorsHeaders(response, req);
   }
 }), 'strict');
 
@@ -254,14 +254,14 @@ export const DELETE = withRateLimitTier(withApiLogging(async (
 
     if (!hasPermission) {
       const response = createApiError('Insufficient permissions. Admin access required for API key management.', 403);
-      return addCorsHeaders(response);
+      return addCorsHeaders(response, req);
     }
 
     const { id } = await params;
 
     if (!id || id.trim() === '') {
       const response = createApiError('API key ID is required', 400, null, 'MISSING_API_KEY_ID');
-      return addCorsHeaders(response);
+      return addCorsHeaders(response, req);
     }
 
     // For API key auth, prevent deletion of the current API key being used
@@ -272,7 +272,7 @@ export const DELETE = withRateLimitTier(withApiLogging(async (
         null, 
         'SELF_REVOKE_FORBIDDEN'
       );
-      return addCorsHeaders(response);
+      return addCorsHeaders(response, req);
     }
 
     // Soft delete - just mark as inactive
@@ -287,7 +287,7 @@ export const DELETE = withRateLimitTier(withApiLogging(async (
 
     if (result.rows.length === 0) {
       const response = createApiError('API key not found', 404, null, 'API_KEY_NOT_FOUND');
-      return addCorsHeaders(response);
+      return addCorsHeaders(response, req);
     }
 
     const response = createApiResponse({ 
@@ -295,10 +295,10 @@ export const DELETE = withRateLimitTier(withApiLogging(async (
       id,
       name: (result.rows[0] as { name: string }).name
     });
-    return addCorsHeaders(response);
+    return addCorsHeaders(response, req);
   } catch (error) {
     console.error('Error revoking API key:', error);
     const response = createApiError('Internal server error', 500);
-    return addCorsHeaders(response);
+    return addCorsHeaders(response, req);
   }
 }), 'strict');

--- a/apps/dev/app/api/v1/api-keys/[id]/route.ts
+++ b/apps/dev/app/api/v1/api-keys/[id]/route.ts
@@ -21,6 +21,7 @@ import {
   addCorsHeaders
 } from '@nextsparkjs/core/lib/api/helpers';
 import { authenticateRequest, hasRequiredScope } from '@nextsparkjs/core/lib/api/auth/dual-auth';
+import { invalidateApiKeyCache } from '@nextsparkjs/core/lib/api/auth';
 import { withRateLimitTier } from '@nextsparkjs/core/lib/api/rate-limit';
 
 // Handle CORS preflight
@@ -209,7 +210,7 @@ export const PATCH = withRateLimitTier(withApiLogging(async (
       UPDATE "api_key" 
       SET ${updates.join(", ")}
       WHERE id = $${paramCount} AND "userId" = $${paramCount + 1}
-      RETURNING id, "keyPrefix", name, scopes, status, "lastUsedAt", "expiresAt", "createdAt", "updatedAt"
+      RETURNING id, "keyPrefix", "keyHash", name, scopes, status, "lastUsedAt", "expiresAt", "createdAt", "updatedAt"
     `;
 
     const result = await mutateWithRLS(query, values, authResult.user!.id);
@@ -219,7 +220,13 @@ export const PATCH = withRateLimitTier(withApiLogging(async (
       return addCorsHeaders(response, req);
     }
 
-    const response = createApiResponse(result.rows[0]);
+    // A status change must take effect immediately: drop the cached validation
+    // entry so the next request re-reads the row (see #92). keyHash is only
+    // used for the invalidation and never returned to the client.
+    const { keyHash, ...updatedApiKey } = result.rows[0] as { keyHash: string } & Record<string, unknown>;
+    invalidateApiKeyCache(keyHash);
+
+    const response = createApiResponse(updatedApiKey);
     return addCorsHeaders(response, req);
   } catch (error) {
     console.error('Error updating API key:', error);
@@ -280,7 +287,7 @@ export const DELETE = withRateLimitTier(withApiLogging(async (
       `UPDATE "api_key" 
        SET status = 'inactive', "updatedAt" = CURRENT_TIMESTAMP
        WHERE id = $1 AND "userId" = $2
-       RETURNING id, name`,
+       RETURNING id, name, "keyHash"`,
       [id, authResult.user!.id],
       authResult.user!.id
     );
@@ -290,10 +297,15 @@ export const DELETE = withRateLimitTier(withApiLogging(async (
       return addCorsHeaders(response, req);
     }
 
+    const revokedRow = result.rows[0] as { name: string; keyHash: string };
+
+    // Revocation must be effective right away, not after the 5 min cache TTL (see #92)
+    invalidateApiKeyCache(revokedRow.keyHash);
+
     const response = createApiResponse({ 
       revoked: true, 
       id,
-      name: (result.rows[0] as { name: string }).name
+      name: revokedRow.name
     });
     return addCorsHeaders(response, req);
   } catch (error) {

--- a/apps/dev/app/api/v1/api-keys/route.ts
+++ b/apps/dev/app/api/v1/api-keys/route.ts
@@ -20,8 +20,8 @@ const createApiKeySchema = z.object({
 });
 
 // Handle CORS preflight
-export async function OPTIONS() {
-  return handleCorsPreflightRequest();
+export async function OPTIONS(request: NextRequest) {
+  return handleCorsPreflightRequest(request);
 }
 
 // GET /api/v1/api-keys - List user's API keys with dual auth
@@ -47,7 +47,7 @@ export const GET = withRateLimitTier(withApiLogging(async (req: NextRequest): Pr
 
     if (!hasPermission) {
       const response = createApiError('Insufficient permissions. Admin access required for API key management.', 403);
-      return addCorsHeaders(response);
+      return addCorsHeaders(response, req);
     }
 
     const apiKeys = await queryWithRLS<{
@@ -125,11 +125,11 @@ export const GET = withRateLimitTier(withApiLogging(async (req: NextRequest): Pr
     }));
 
     const response = createApiResponse(keysWithStats);
-    return addCorsHeaders(response);
+    return addCorsHeaders(response, req);
   } catch (error) {
     console.error('Error fetching API keys:', error);
     const response = createApiError('Internal server error', 500);
-    return addCorsHeaders(response);
+    return addCorsHeaders(response, req);
   }
 }), 'strict');
 
@@ -156,7 +156,7 @@ export const POST = withRateLimitTier(withApiLogging(async (req: NextRequest): P
 
     if (!hasPermission) {
       const response = createApiError('Insufficient permissions. Admin access required for API key management.', 403);
-      return addCorsHeaders(response);
+      return addCorsHeaders(response, req);
     }
 
     const body = await req.json();
@@ -174,7 +174,7 @@ export const POST = withRateLimitTier(withApiLogging(async (req: NextRequest): P
         },
         'INVALID_SCOPES'
       );
-      return addCorsHeaders(response);
+      return addCorsHeaders(response, req);
     }
 
     // Validar que el usuario pueda crear API keys con estos scopes.
@@ -201,7 +201,7 @@ export const POST = withRateLimitTier(withApiLogging(async (req: NextRequest): P
         },
         'INSUFFICIENT_SCOPE_PERMISSIONS'
       );
-      return addCorsHeaders(response);
+      return addCorsHeaders(response, req);
     }
 
     // Verificar límite de API keys por usuario (máximo 10)
@@ -218,7 +218,7 @@ export const POST = withRateLimitTier(withApiLogging(async (req: NextRequest): P
         null,
         'API_KEY_LIMIT_REACHED'
       );
-      return addCorsHeaders(response);
+      return addCorsHeaders(response, req);
     }
 
     // Generar API key
@@ -249,15 +249,15 @@ export const POST = withRateLimitTier(withApiLogging(async (req: NextRequest): P
     };
 
     const response = createApiResponse(responseData, { created: true }, 201);
-    return addCorsHeaders(response);
+    return addCorsHeaders(response, req);
   } catch (error) {
     if (error instanceof z.ZodError) {
       const response = createApiError('Validation error', 400, error.issues, 'VALIDATION_ERROR');
-      return addCorsHeaders(response);
+      return addCorsHeaders(response, req);
     }
     
     console.error('Error creating API key:', error);
     const response = createApiError('Internal server error', 500);
-    return addCorsHeaders(response);
+    return addCorsHeaders(response, req);
   }
 }), 'strict');

--- a/apps/dev/app/api/v1/auth/signup-with-invite/route.ts
+++ b/apps/dev/app/api/v1/auth/signup-with-invite/route.ts
@@ -14,8 +14,8 @@ import { withSignupContext } from '@nextsparkjs/core/lib/auth-context'
 import { withRateLimitTier } from '@nextsparkjs/core/lib/api/rate-limit'
 
 // Handle CORS preflight
-export async function OPTIONS() {
-  return handleCorsPreflightRequest()
+export async function OPTIONS(request: NextRequest) {
+  return handleCorsPreflightRequest(request)
 }
 
 interface SignupWithInviteBody {
@@ -41,14 +41,14 @@ export const POST = withRateLimitTier(withApiLogging(
           null,
           'MISSING_FIELDS'
         )
-        return addCorsHeaders(response)
+        return addCorsHeaders(response, req)
       }
 
       // Validate email format
       const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/
       if (!emailRegex.test(email)) {
         const response = createApiError('Invalid email format', 400, null, 'INVALID_EMAIL')
-        return addCorsHeaders(response)
+        return addCorsHeaders(response, req)
       }
 
       // Validate password length (min 8 characters as per Better Auth config)
@@ -59,7 +59,7 @@ export const POST = withRateLimitTier(withApiLogging(
           null,
           'INVALID_PASSWORD'
         )
-        return addCorsHeaders(response)
+        return addCorsHeaders(response, req)
       }
 
       // Step 1: Validate the invitation token via the service pool (RLS bypass).
@@ -76,7 +76,7 @@ export const POST = withRateLimitTier(withApiLogging(
 
       if (!invitation) {
         const response = createApiError('Invitation not found', 404, null, 'INVITATION_NOT_FOUND')
-        return addCorsHeaders(response)
+        return addCorsHeaders(response, req)
       }
 
       // Verify invitation is for the correct email
@@ -87,7 +87,7 @@ export const POST = withRateLimitTier(withApiLogging(
           null,
           'EMAIL_MISMATCH'
         )
-        return addCorsHeaders(response)
+        return addCorsHeaders(response, req)
       }
 
       // Check if invitation is pending
@@ -98,14 +98,14 @@ export const POST = withRateLimitTier(withApiLogging(
           null,
           'INVITATION_NOT_PENDING'
         )
-        return addCorsHeaders(response)
+        return addCorsHeaders(response, req)
       }
 
       // Check if invitation has expired
       const expiresAt = new Date(invitation.expiresAt)
       if (expiresAt < new Date()) {
         const response = createApiError('Invitation has expired', 410, null, 'INVITATION_EXPIRED')
-        return addCorsHeaders(response)
+        return addCorsHeaders(response, req)
       }
 
       // Step 2: Create user using Better Auth's internal API
@@ -144,7 +144,7 @@ export const POST = withRateLimitTier(withApiLogging(
             null,
             'USER_ALREADY_EXISTS'
           )
-          return addCorsHeaders(response)
+          return addCorsHeaders(response, req)
         }
 
         const response = createApiError(
@@ -153,7 +153,7 @@ export const POST = withRateLimitTier(withApiLogging(
           null,
           'SIGNUP_FAILED'
         )
-        return addCorsHeaders(response)
+        return addCorsHeaders(response, req)
       }
 
       // Parse response to get user data
@@ -167,7 +167,7 @@ export const POST = withRateLimitTier(withApiLogging(
           null,
           'SIGNUP_FAILED'
         )
-        return addCorsHeaders(response)
+        return addCorsHeaders(response, req)
       }
 
       // Steps 3-4 run via the service pool (RLS bypass). This is a trusted
@@ -228,7 +228,7 @@ export const POST = withRateLimitTier(withApiLogging(
           { created: true },
           201
         )
-        return addCorsHeaders(response)
+        return addCorsHeaders(response, req)
       } catch (error) {
         await tx.rollback()
         throw error
@@ -236,7 +236,7 @@ export const POST = withRateLimitTier(withApiLogging(
     } catch (error) {
       console.error('Error in signup-with-invite:', error)
       const response = createApiError('Internal server error', 500)
-      return addCorsHeaders(response)
+      return addCorsHeaders(response, req)
     }
   }
 ), 'auth')

--- a/apps/dev/app/api/v1/billing/cancel/route.ts
+++ b/apps/dev/app/api/v1/billing/cancel/route.ts
@@ -104,7 +104,7 @@ export const POST = withRateLimitTier(async (request: NextRequest) => {
 
   // 6. Cancel via billing gateway
   try {
-    const gateway = getBillingGateway()
+    const gateway = await getBillingGateway()
     if (immediate) {
       await gateway.cancelSubscriptionImmediately(subscription.externalSubscriptionId)
     } else {
@@ -171,7 +171,7 @@ async function handleReactivation(teamId: string) {
   }
 
   try {
-    const gateway = getBillingGateway()
+    const gateway = await getBillingGateway()
     await gateway.reactivateSubscription(subscription.externalSubscriptionId)
 
     // Update local DB

--- a/apps/dev/app/api/v1/billing/checkout/route.ts
+++ b/apps/dev/app/api/v1/billing/checkout/route.ts
@@ -121,7 +121,8 @@ export const POST = withRateLimitTier(async (request: NextRequest) => {
     const successUrl = `${appUrl}/dashboard/settings/billing?success=true`
     const cancelUrl = `${appUrl}/dashboard/settings/billing?canceled=true`
 
-    const session = await getBillingGateway().createCheckoutSession({
+    const gateway = await getBillingGateway()
+    const session = await gateway.createCheckoutSession({
       teamId,
       planSlug,
       billingPeriod,

--- a/apps/dev/app/api/v1/billing/portal/route.ts
+++ b/apps/dev/app/api/v1/billing/portal/route.ts
@@ -69,7 +69,8 @@ export const POST = withRateLimitTier(async (request: NextRequest) => {
     const appUrl = process.env.NEXT_PUBLIC_APP_URL || 'http://localhost:5173'
     const returnUrl = `${appUrl}/dashboard/settings/billing`
 
-    const session = await getBillingGateway().createPortalSession({
+    const gateway = await getBillingGateway()
+    const session = await gateway.createPortalSession({
       customerId: subscription.externalCustomerId,
       returnUrl
     })

--- a/apps/dev/app/api/v1/billing/webhooks/polar/route.ts
+++ b/apps/dev/app/api/v1/billing/webhooks/polar/route.ts
@@ -52,7 +52,7 @@ async function handlePolarWebhook(request: NextRequest): Promise<NextResponse> {
   // 2. Verify webhook signature (MANDATORY for security)
   let event: { id: string; type: string; data: Record<string, unknown> }
   try {
-    const gateway = getBillingGateway()
+    const gateway = await getBillingGateway()
     event = gateway.verifyWebhookSignature(payload, headers)
   } catch (error) {
     console.error('[polar-webhook] Signature verification failed:', error)

--- a/apps/dev/app/api/v1/patterns/[id]/usages/route.ts
+++ b/apps/dev/app/api/v1/patterns/[id]/usages/route.ts
@@ -28,8 +28,8 @@ import { PatternUsageService } from '@nextsparkjs/core/lib/services'
 import { queryOneWithRLS } from '@nextsparkjs/core/lib/db'
 
 // Handle CORS preflight
-export async function OPTIONS() {
-  return handleCorsPreflightRequest()
+export async function OPTIONS(request: NextRequest) {
+  return handleCorsPreflightRequest(request)
 }
 
 // GET /api/v1/patterns/:id/usages - Get pattern usages
@@ -53,7 +53,7 @@ export const GET = withApiLogging(
       // Check required permissions
       if (!hasRequiredScope(authResult, 'patterns:read')) {
         const response = createApiError('Insufficient permissions', 403)
-        return addCorsHeaders(response)
+        return addCorsHeaders(response, req)
       }
 
       const { id: patternId } = await params
@@ -62,7 +62,7 @@ export const GET = withApiLogging(
       // Validate that patternId is not empty
       if (!patternId || patternId.trim() === '') {
         const response = createApiError('Pattern ID is required', 400, null, 'MISSING_PATTERN_ID')
-        return addCorsHeaders(response)
+        return addCorsHeaders(response, req)
       }
 
       // Verify pattern exists and user has access
@@ -74,7 +74,7 @@ export const GET = withApiLogging(
 
       if (!pattern) {
         const response = createApiError('Pattern not found', 404, null, 'PATTERN_NOT_FOUND')
-        return addCorsHeaders(response)
+        return addCorsHeaders(response, req)
       }
 
       // Parse query parameters
@@ -106,11 +106,11 @@ export const GET = withApiLogging(
         entityType: entityType || 'all',
       })
 
-      return addCorsHeaders(response)
+      return addCorsHeaders(response, req)
     } catch (error) {
       console.error('Error fetching pattern usages:', error)
       const response = createApiError('Internal server error', 500)
-      return addCorsHeaders(response)
+      return addCorsHeaders(response, req)
     }
   }
 )

--- a/apps/dev/app/api/v1/team-invitations/[token]/accept/route.ts
+++ b/apps/dev/app/api/v1/team-invitations/[token]/accept/route.ts
@@ -13,8 +13,8 @@ import { RATE_LIMITS } from '@nextsparkjs/core/lib/api/keys'
 import type { TeamInvitation, TeamMember } from '@nextsparkjs/core/lib/teams/types'
 
 // Handle CORS preflight
-export async function OPTIONS() {
-  return handleCorsPreflightRequest()
+export async function OPTIONS(request: NextRequest) {
+  return handleCorsPreflightRequest(request)
 }
 
 // POST /api/v1/team-invitations/:token/accept - Accept invitation and become member
@@ -47,7 +47,7 @@ export const POST = withRateLimitTier(withApiLogging(
           { retryAfter: Math.ceil((rateLimit.resetTime - Date.now()) / 1000) },
           'RATE_LIMIT_EXCEEDED'
         )
-        return addCorsHeaders(response)
+        return addCorsHeaders(response, req)
       }
 
       const { token } = await params
@@ -55,7 +55,7 @@ export const POST = withRateLimitTier(withApiLogging(
       // Validate that token is not empty
       if (!token || token.trim() === '') {
         const response = createApiError('Invitation token is required', 400, null, 'MISSING_TOKEN')
-        return addCorsHeaders(response)
+        return addCorsHeaders(response, req)
       }
 
       // Get invitation by token
@@ -67,7 +67,7 @@ export const POST = withRateLimitTier(withApiLogging(
 
       if (!invitation) {
         const response = createApiError('Invitation not found', 404, null, 'INVITATION_NOT_FOUND')
-        return addCorsHeaders(response)
+        return addCorsHeaders(response, req)
       }
 
       // Verify invitation is for the current user's email
@@ -78,7 +78,7 @@ export const POST = withRateLimitTier(withApiLogging(
           null,
           'EMAIL_MISMATCH'
         )
-        return addCorsHeaders(response)
+        return addCorsHeaders(response, req)
       }
 
       // Check if invitation is pending
@@ -89,7 +89,7 @@ export const POST = withRateLimitTier(withApiLogging(
           null,
           'INVITATION_NOT_PENDING'
         )
-        return addCorsHeaders(response)
+        return addCorsHeaders(response, req)
       }
 
       // Check if invitation has expired
@@ -103,7 +103,7 @@ export const POST = withRateLimitTier(withApiLogging(
         )
 
         const response = createApiError('Invitation has expired', 410, null, 'INVITATION_EXPIRED')
-        return addCorsHeaders(response)
+        return addCorsHeaders(response, req)
       }
 
       // Check if user is already a member
@@ -115,7 +115,7 @@ export const POST = withRateLimitTier(withApiLogging(
 
       if (existingMember) {
         const response = createApiError('You are already a member of this team', 409, null, 'ALREADY_MEMBER')
-        return addCorsHeaders(response)
+        return addCorsHeaders(response, req)
       }
 
       // Use transaction to ensure atomicity
@@ -165,7 +165,7 @@ export const POST = withRateLimitTier(withApiLogging(
         )
 
         const response = createApiResponse(memberWithUser, { created: true }, 201)
-        return addCorsHeaders(response)
+        return addCorsHeaders(response, req)
       } catch (error) {
         await tx.rollback()
         throw error
@@ -173,7 +173,7 @@ export const POST = withRateLimitTier(withApiLogging(
     } catch (error) {
       console.error('Error accepting invitation:', error)
       const response = createApiError('Internal server error', 500)
-      return addCorsHeaders(response)
+      return addCorsHeaders(response, req)
     }
   }
 ), 'write');

--- a/apps/dev/app/api/v1/team-invitations/[token]/decline/route.ts
+++ b/apps/dev/app/api/v1/team-invitations/[token]/decline/route.ts
@@ -13,8 +13,8 @@ import { RATE_LIMITS } from '@nextsparkjs/core/lib/api/keys'
 import type { TeamInvitation } from '@nextsparkjs/core/lib/teams/types'
 
 // Handle CORS preflight
-export async function OPTIONS() {
-  return handleCorsPreflightRequest()
+export async function OPTIONS(request: NextRequest) {
+  return handleCorsPreflightRequest(request)
 }
 
 // POST /api/v1/team-invitations/:token/decline - Decline invitation
@@ -47,7 +47,7 @@ export const POST = withRateLimitTier(withApiLogging(
           { retryAfter: Math.ceil((rateLimit.resetTime - Date.now()) / 1000) },
           'RATE_LIMIT_EXCEEDED'
         )
-        return addCorsHeaders(response)
+        return addCorsHeaders(response, req)
       }
 
       const { token } = await params
@@ -55,7 +55,7 @@ export const POST = withRateLimitTier(withApiLogging(
       // Validate that token is not empty
       if (!token || token.trim() === '') {
         const response = createApiError('Invitation token is required', 400, null, 'MISSING_TOKEN')
-        return addCorsHeaders(response)
+        return addCorsHeaders(response, req)
       }
 
       // Get invitation by token
@@ -67,7 +67,7 @@ export const POST = withRateLimitTier(withApiLogging(
 
       if (!invitation) {
         const response = createApiError('Invitation not found', 404, null, 'INVITATION_NOT_FOUND')
-        return addCorsHeaders(response)
+        return addCorsHeaders(response, req)
       }
 
       // Verify invitation is for the current user's email
@@ -78,7 +78,7 @@ export const POST = withRateLimitTier(withApiLogging(
           null,
           'EMAIL_MISMATCH'
         )
-        return addCorsHeaders(response)
+        return addCorsHeaders(response, req)
       }
 
       // Check if invitation is pending
@@ -89,7 +89,7 @@ export const POST = withRateLimitTier(withApiLogging(
           null,
           'INVITATION_NOT_PENDING'
         )
-        return addCorsHeaders(response)
+        return addCorsHeaders(response, req)
       }
 
       // Update invitation status to declined
@@ -104,17 +104,17 @@ export const POST = withRateLimitTier(withApiLogging(
 
       if (result.rows.length === 0) {
         const response = createApiError('Invitation not found', 404, null, 'INVITATION_NOT_FOUND')
-        return addCorsHeaders(response)
+        return addCorsHeaders(response, req)
       }
 
       const declinedInvitation = result.rows[0]
 
       const response = createApiResponse(declinedInvitation)
-      return addCorsHeaders(response)
+      return addCorsHeaders(response, req)
     } catch (error) {
       console.error('Error declining invitation:', error)
       const response = createApiError('Internal server error', 500)
-      return addCorsHeaders(response)
+      return addCorsHeaders(response, req)
     }
   }
 ), 'write');

--- a/apps/dev/app/api/v1/team-invitations/[token]/route.ts
+++ b/apps/dev/app/api/v1/team-invitations/[token]/route.ts
@@ -11,8 +11,8 @@ import type { TeamInvitation } from '@nextsparkjs/core/lib/teams/types'
 import { withRateLimitTier } from '@nextsparkjs/core/lib/api/rate-limit'
 
 // Handle CORS preflight
-export async function OPTIONS() {
-  return handleCorsPreflightRequest()
+export async function OPTIONS(request: NextRequest) {
+  return handleCorsPreflightRequest(request)
 }
 
 // GET /api/v1/team-invitations/:token - Get invitation details (public endpoint for preview)
@@ -24,7 +24,7 @@ export const GET = withRateLimitTier(withApiLogging(
       // Validate that token is not empty
       if (!token || token.trim() === '') {
         const response = createApiError('Invitation token is required', 400, null, 'MISSING_TOKEN')
-        return addCorsHeaders(response)
+        return addCorsHeaders(response, req)
       }
 
       // Get invitation by token with team and inviter details
@@ -49,14 +49,14 @@ export const GET = withRateLimitTier(withApiLogging(
 
       if (!invitation) {
         const response = createApiError('Invitation not found', 404, null, 'INVITATION_NOT_FOUND')
-        return addCorsHeaders(response)
+        return addCorsHeaders(response, req)
       }
 
       // Check if invitation has expired
       const expiresAt = new Date(invitation.expiresAt)
       if (expiresAt < new Date()) {
         const response = createApiError('Invitation has expired', 410, null, 'INVITATION_EXPIRED')
-        return addCorsHeaders(response)
+        return addCorsHeaders(response, req)
       }
 
       // Check if invitation is still pending
@@ -67,7 +67,7 @@ export const GET = withRateLimitTier(withApiLogging(
           null,
           `INVITATION_${invitation.status.toUpperCase()}`
         )
-        return addCorsHeaders(response)
+        return addCorsHeaders(response, req)
       }
 
       // Return public invitation details (don't expose sensitive data)
@@ -80,11 +80,11 @@ export const GET = withRateLimitTier(withApiLogging(
       }
 
       const response = createApiResponse(publicDetails)
-      return addCorsHeaders(response)
+      return addCorsHeaders(response, req)
     } catch (error) {
       console.error('Error fetching invitation:', error)
       const response = createApiError('Internal server error', 500)
-      return addCorsHeaders(response)
+      return addCorsHeaders(response, req)
     }
   }
 ), 'read');

--- a/apps/dev/app/api/v1/team-invitations/route.ts
+++ b/apps/dev/app/api/v1/team-invitations/route.ts
@@ -14,8 +14,8 @@ import type { TeamInvitation } from '@nextsparkjs/core/lib/teams/types'
 import { withRateLimitTier } from '@nextsparkjs/core/lib/api/rate-limit'
 
 // Handle CORS preflight
-export async function OPTIONS() {
-  return handleCorsPreflightRequest()
+export async function OPTIONS(request: NextRequest) {
+  return handleCorsPreflightRequest(request)
 }
 
 // GET /api/v1/team-invitations - List pending invitations for current user
@@ -106,10 +106,10 @@ export const GET = withRateLimitTier(withApiLogging(async (req: NextRequest): Pr
     const paginationMeta = createPaginationMeta(page, limit, total)
 
     const response = createApiResponse(invitations, paginationMeta)
-    return addCorsHeaders(response)
+    return addCorsHeaders(response, req)
   } catch (error) {
     console.error('Error fetching invitations:', error)
     const response = createApiError('Internal server error', 500)
-    return addCorsHeaders(response)
+    return addCorsHeaders(response, req)
   }
 }), 'read');

--- a/apps/dev/app/api/v1/teams/[teamId]/invitations/route.ts
+++ b/apps/dev/app/api/v1/teams/[teamId]/invitations/route.ts
@@ -14,8 +14,8 @@ import { TeamMemberService, MembershipService } from '@nextsparkjs/core/lib/serv
 import type { TeamInvitation } from '@nextsparkjs/core/lib/teams/types'
 
 // Handle CORS preflight
-export async function OPTIONS() {
-  return handleCorsPreflightRequest()
+export async function OPTIONS(request: NextRequest) {
+  return handleCorsPreflightRequest(request)
 }
 
 // GET /api/v1/teams/:teamId/invitations - List pending invitations for a team
@@ -41,7 +41,7 @@ export const GET = withRateLimitTier(withApiLogging(
       // Validate that teamId is not empty
       if (!teamId || teamId.trim() === '') {
         const response = createApiError('Team ID is required', 400, null, 'MISSING_TEAM_ID')
-        return addCorsHeaders(response)
+        return addCorsHeaders(response, req)
       }
 
       // Check if user is a member of the team
@@ -49,7 +49,7 @@ export const GET = withRateLimitTier(withApiLogging(
 
       if (!isMember) {
         const response = createApiError('Team not found or access denied', 404, null, 'TEAM_NOT_FOUND')
-        return addCorsHeaders(response)
+        return addCorsHeaders(response, req)
       }
 
       // Parse query parameters
@@ -92,11 +92,11 @@ export const GET = withRateLimitTier(withApiLogging(
       const paginationMeta = createPaginationMeta(page, limit, total)
 
       const response = createApiResponse(invitations, paginationMeta)
-      return addCorsHeaders(response)
+      return addCorsHeaders(response, req)
     } catch (error) {
       console.error('Error fetching team invitations:', error)
       const response = createApiError('Internal server error', 500)
-      return addCorsHeaders(response)
+      return addCorsHeaders(response, req)
     }
   }
 ), 'read')
@@ -127,7 +127,7 @@ export const DELETE = withRateLimitTier(withApiLogging(
 
       if (!invitationId) {
         const response = createApiError('Invitation ID is required', 400, null, 'MISSING_INVITATION_ID')
-        return addCorsHeaders(response)
+        return addCorsHeaders(response, req)
       }
 
       // Check if user has permission to manage invitations using MembershipService
@@ -144,7 +144,7 @@ export const DELETE = withRateLimitTier(withApiLogging(
           },
           { status: 403 }
         )
-        return addCorsHeaders(response)
+        return addCorsHeaders(response, req)
       }
 
       // Update invitation status to 'cancelled' (or delete it)
@@ -158,15 +158,15 @@ export const DELETE = withRateLimitTier(withApiLogging(
 
       if (result.rowCount === 0) {
         const response = createApiError('Invitation not found or already processed', 404, null, 'INVITATION_NOT_FOUND')
-        return addCorsHeaders(response)
+        return addCorsHeaders(response, req)
       }
 
       const response = createApiResponse({ deleted: true, id: invitationId })
-      return addCorsHeaders(response)
+      return addCorsHeaders(response, req)
     } catch (error) {
       console.error('Error cancelling invitation:', error)
       const response = createApiError('Internal server error', 500)
-      return addCorsHeaders(response)
+      return addCorsHeaders(response, req)
     }
   }
 ), 'write')

--- a/apps/dev/app/api/v1/teams/[teamId]/invoices/[invoiceNumber]/route.ts
+++ b/apps/dev/app/api/v1/teams/[teamId]/invoices/[invoiceNumber]/route.ts
@@ -13,8 +13,8 @@ import { MembershipService } from '@nextsparkjs/core/lib/services'
 import type { InvoiceResponse } from '@nextsparkjs/core/lib/validation/invoices'
 
 // Handle CORS preflight
-export async function OPTIONS() {
-  return handleCorsPreflightRequest()
+export async function OPTIONS(request: NextRequest) {
+  return handleCorsPreflightRequest(request)
 }
 
 // GET /api/v1/teams/:teamId/invoices/:invoiceNumber - Get single invoice (owner only)
@@ -43,13 +43,13 @@ export const GET = withRateLimitTier(withApiLogging(
       // Validate that teamId is not empty
       if (!teamId || teamId.trim() === '') {
         const response = createApiError('Team ID is required', 400, null, 'MISSING_TEAM_ID')
-        return addCorsHeaders(response)
+        return addCorsHeaders(response, req)
       }
 
       // Validate that invoiceNumber is not empty
       if (!invoiceNumber || invoiceNumber.trim() === '') {
         const response = createApiError('Invoice number is required', 400, null, 'MISSING_INVOICE_NUMBER')
-        return addCorsHeaders(response)
+        return addCorsHeaders(response, req)
       }
 
       // Check if user has permission to view invoices using MembershipService
@@ -66,7 +66,7 @@ export const GET = withRateLimitTier(withApiLogging(
           },
           { status: 403 }
         )
-        return addCorsHeaders(response)
+        return addCorsHeaders(response, req)
       }
 
       // Query single invoice by invoiceNumber
@@ -92,15 +92,15 @@ export const GET = withRateLimitTier(withApiLogging(
 
       if (invoices.length === 0) {
         const response = createApiError('Invoice not found', 404, null, 'INVOICE_NOT_FOUND')
-        return addCorsHeaders(response)
+        return addCorsHeaders(response, req)
       }
 
       const response = createApiResponse(invoices[0])
-      return addCorsHeaders(response)
+      return addCorsHeaders(response, req)
     } catch (error) {
       console.error('Error fetching invoice:', error)
       const response = createApiError('Internal server error', 500)
-      return addCorsHeaders(response)
+      return addCorsHeaders(response, req)
     }
   }
 ), 'read')

--- a/apps/dev/app/api/v1/teams/[teamId]/invoices/route.ts
+++ b/apps/dev/app/api/v1/teams/[teamId]/invoices/route.ts
@@ -15,8 +15,8 @@ import { invoiceQuerySchema } from '@nextsparkjs/core/lib/validation/invoices'
 import type { InvoiceResponse } from '@nextsparkjs/core/lib/validation/invoices'
 
 // Handle CORS preflight
-export async function OPTIONS() {
-  return handleCorsPreflightRequest()
+export async function OPTIONS(request: NextRequest) {
+  return handleCorsPreflightRequest(request)
 }
 
 // GET /api/v1/teams/:teamId/invoices - List team invoices (owner only)
@@ -42,7 +42,7 @@ export const GET = withRateLimitTier(withApiLogging(
       // Validate that teamId is not empty
       if (!teamId || teamId.trim() === '') {
         const response = createApiError('Team ID is required', 400, null, 'MISSING_TEAM_ID')
-        return addCorsHeaders(response)
+        return addCorsHeaders(response, req)
       }
 
       // Check if user has permission to view invoices using MembershipService
@@ -59,7 +59,7 @@ export const GET = withRateLimitTier(withApiLogging(
           },
           { status: 403 }
         )
-        return addCorsHeaders(response)
+        return addCorsHeaders(response, req)
       }
 
       // Parse query parameters for pagination
@@ -110,17 +110,17 @@ export const GET = withRateLimitTier(withApiLogging(
       const paginationMeta = createPaginationMeta(page, limit, total)
 
       const response = createApiResponse(invoices, paginationMeta)
-      return addCorsHeaders(response)
+      return addCorsHeaders(response, req)
     } catch (error) {
       if (error instanceof Error && error.name === 'ZodError') {
         const zodError = error as { issues?: unknown[] }
         const response = createApiError('Validation error', 400, zodError.issues, 'VALIDATION_ERROR')
-        return addCorsHeaders(response)
+        return addCorsHeaders(response, req)
       }
 
       console.error('Error fetching invoices:', error)
       const response = createApiError('Internal server error', 500)
-      return addCorsHeaders(response)
+      return addCorsHeaders(response, req)
     }
   }
 ), 'read')

--- a/apps/dev/app/api/v1/teams/[teamId]/members/[memberId]/route.ts
+++ b/apps/dev/app/api/v1/teams/[teamId]/members/[memberId]/route.ts
@@ -15,8 +15,8 @@ import { validateRoleTransition, canManageRole } from '@nextsparkjs/core/lib/tea
 import type { TeamMember, TeamRole } from '@nextsparkjs/core/lib/teams/types'
 
 // Handle CORS preflight
-export async function OPTIONS() {
-  return handleCorsPreflightRequest()
+export async function OPTIONS(request: NextRequest) {
+  return handleCorsPreflightRequest(request)
 }
 
 // PATCH /api/v1/teams/:teamId/members/:memberId - Update member role
@@ -45,12 +45,12 @@ export const PATCH = withRateLimitTier(withApiLogging(
       // Validate parameters
       if (!teamId || teamId.trim() === '') {
         const response = createApiError('Team ID is required', 400, null, 'MISSING_TEAM_ID')
-        return addCorsHeaders(response)
+        return addCorsHeaders(response, req)
       }
 
       if (!memberId || memberId.trim() === '') {
         const response = createApiError('Member ID is required', 400, null, 'MISSING_MEMBER_ID')
-        return addCorsHeaders(response)
+        return addCorsHeaders(response, req)
       }
 
       // Check if user has permission to update member roles using MembershipService
@@ -67,7 +67,7 @@ export const PATCH = withRateLimitTier(withApiLogging(
           },
           { status: 403 }
         )
-        return addCorsHeaders(response)
+        return addCorsHeaders(response, req)
       }
 
       // Get user's role for role hierarchy validation
@@ -82,7 +82,7 @@ export const PATCH = withRateLimitTier(withApiLogging(
 
       if (!targetMember) {
         const response = createApiError('Member not found', 404, null, 'MEMBER_NOT_FOUND')
-        return addCorsHeaders(response)
+        return addCorsHeaders(response, req)
       }
 
       const body = await req.json()
@@ -93,7 +93,7 @@ export const PATCH = withRateLimitTier(withApiLogging(
 
       if (!transitionValidation.allowed) {
         const response = createApiError(transitionValidation.reason || 'Invalid role transition', 403, null, 'INVALID_ROLE_TRANSITION')
-        return addCorsHeaders(response)
+        return addCorsHeaders(response, req)
       }
 
       // Check if actor can manage the target role
@@ -104,7 +104,7 @@ export const PATCH = withRateLimitTier(withApiLogging(
           null,
           'INSUFFICIENT_PERMISSIONS'
         )
-        return addCorsHeaders(response)
+        return addCorsHeaders(response, req)
       }
 
       // Update member role
@@ -119,7 +119,7 @@ export const PATCH = withRateLimitTier(withApiLogging(
 
       if (result.rows.length === 0) {
         const response = createApiError('Member not found', 404, null, 'MEMBER_NOT_FOUND')
-        return addCorsHeaders(response)
+        return addCorsHeaders(response, req)
       }
 
       // Fetch member with user details
@@ -143,17 +143,17 @@ export const PATCH = withRateLimitTier(withApiLogging(
       )
 
       const response = createApiResponse(memberWithUser)
-      return addCorsHeaders(response)
+      return addCorsHeaders(response, req)
     } catch (error) {
       if (error instanceof Error && error.name === 'ZodError') {
         const zodError = error as { issues?: unknown[] }
         const response = createApiError('Validation error', 400, zodError.issues, 'VALIDATION_ERROR')
-        return addCorsHeaders(response)
+        return addCorsHeaders(response, req)
       }
 
       console.error('Error updating member role:', error)
       const response = createApiError('Internal server error', 500)
-      return addCorsHeaders(response)
+      return addCorsHeaders(response, req)
     }
   }
 ), 'write')
@@ -184,12 +184,12 @@ export const DELETE = withRateLimitTier(withApiLogging(
       // Validate parameters
       if (!teamId || teamId.trim() === '') {
         const response = createApiError('Team ID is required', 400, null, 'MISSING_TEAM_ID')
-        return addCorsHeaders(response)
+        return addCorsHeaders(response, req)
       }
 
       if (!memberId || memberId.trim() === '') {
         const response = createApiError('Member ID is required', 400, null, 'MISSING_MEMBER_ID')
-        return addCorsHeaders(response)
+        return addCorsHeaders(response, req)
       }
 
       // Check if user has permission to remove members using MembershipService
@@ -206,7 +206,7 @@ export const DELETE = withRateLimitTier(withApiLogging(
           },
           { status: 403 }
         )
-        return addCorsHeaders(response)
+        return addCorsHeaders(response, req)
       }
 
       // Get user's role for role hierarchy validation
@@ -221,13 +221,13 @@ export const DELETE = withRateLimitTier(withApiLogging(
 
       if (!targetMember) {
         const response = createApiError('Member not found', 404, null, 'MEMBER_NOT_FOUND')
-        return addCorsHeaders(response)
+        return addCorsHeaders(response, req)
       }
 
       // Cannot remove the owner
       if (targetMember.role === 'owner') {
         const response = createApiError('Cannot remove the team owner', 403, null, 'CANNOT_REMOVE_OWNER')
-        return addCorsHeaders(response)
+        return addCorsHeaders(response, req)
       }
 
       // Check if actor can manage the target role
@@ -238,7 +238,7 @@ export const DELETE = withRateLimitTier(withApiLogging(
           null,
           'INSUFFICIENT_PERMISSIONS'
         )
-        return addCorsHeaders(response)
+        return addCorsHeaders(response, req)
       }
 
       // Remove member
@@ -250,15 +250,15 @@ export const DELETE = withRateLimitTier(withApiLogging(
 
       if (result.rows.length === 0) {
         const response = createApiError('Member not found', 404, null, 'MEMBER_NOT_FOUND')
-        return addCorsHeaders(response)
+        return addCorsHeaders(response, req)
       }
 
       const response = createApiResponse({ deleted: true, id: memberId })
-      return addCorsHeaders(response)
+      return addCorsHeaders(response, req)
     } catch (error) {
       console.error('Error removing member:', error)
       const response = createApiError('Internal server error', 500)
-      return addCorsHeaders(response)
+      return addCorsHeaders(response, req)
     }
   }
 ), 'write')

--- a/apps/dev/app/api/v1/teams/[teamId]/members/route.ts
+++ b/apps/dev/app/api/v1/teams/[teamId]/members/route.ts
@@ -21,8 +21,8 @@ import { sendTeamInvitationEmail } from '@nextsparkjs/core/lib/email/send'
 import { I18N_CONFIG } from '@nextsparkjs/core/lib/config'
 
 // Handle CORS preflight
-export async function OPTIONS() {
-  return handleCorsPreflightRequest()
+export async function OPTIONS(request: NextRequest) {
+  return handleCorsPreflightRequest(request)
 }
 
 // GET /api/v1/teams/:teamId/members - List team members
@@ -48,7 +48,7 @@ export const GET = withRateLimitTier(withApiLogging(
       // Validate that teamId is not empty
       if (!teamId || teamId.trim() === '') {
         const response = createApiError('Team ID is required', 400, null, 'MISSING_TEAM_ID')
-        return addCorsHeaders(response)
+        return addCorsHeaders(response, req)
       }
 
       // Superadmins can view members of any team
@@ -60,7 +60,7 @@ export const GET = withRateLimitTier(withApiLogging(
 
         if (!isMember) {
           const response = createApiError('Team not found or access denied', 404, null, 'TEAM_NOT_FOUND')
-          return addCorsHeaders(response)
+          return addCorsHeaders(response, req)
         }
       }
 
@@ -141,11 +141,11 @@ export const GET = withRateLimitTier(withApiLogging(
       const paginationMeta = createPaginationMeta(page, limit, total)
 
       const response = createApiResponse(members, paginationMeta)
-      return addCorsHeaders(response)
+      return addCorsHeaders(response, req)
     } catch (error) {
       console.error('Error fetching team members:', error)
       const response = createApiError('Internal server error', 500)
-      return addCorsHeaders(response)
+      return addCorsHeaders(response, req)
     }
   }
 ), 'read')
@@ -180,7 +180,7 @@ export const POST = withRateLimitTier(withApiLogging(
           { retryAfter: Math.ceil((rateLimit.resetTime - Date.now()) / 1000) },
           'RATE_LIMIT_EXCEEDED'
         )
-        return addCorsHeaders(response)
+        return addCorsHeaders(response, req)
       }
 
       const { teamId } = await params
@@ -188,7 +188,7 @@ export const POST = withRateLimitTier(withApiLogging(
       // Validate that teamId is not empty
       if (!teamId || teamId.trim() === '') {
         const response = createApiError('Team ID is required', 400, null, 'MISSING_TEAM_ID')
-        return addCorsHeaders(response)
+        return addCorsHeaders(response, req)
       }
 
       // Check if user has permission to invite members using MembershipService
@@ -205,7 +205,7 @@ export const POST = withRateLimitTier(withApiLogging(
           },
           { status: 403 }
         )
-        return addCorsHeaders(response)
+        return addCorsHeaders(response, req)
       }
 
       // Get user's role for role hierarchy validation
@@ -223,7 +223,7 @@ export const POST = withRateLimitTier(withApiLogging(
           null,
           'ROLE_HIERARCHY_VIOLATION'
         )
-        return addCorsHeaders(response)
+        return addCorsHeaders(response, req)
       }
 
       // Check if user already exists and is already a member
@@ -243,7 +243,7 @@ export const POST = withRateLimitTier(withApiLogging(
 
         if (existingMember) {
           const response = createApiError('User is already a member of this team', 409, null, 'ALREADY_MEMBER')
-          return addCorsHeaders(response)
+          return addCorsHeaders(response, req)
         }
       }
 
@@ -262,7 +262,7 @@ export const POST = withRateLimitTier(withApiLogging(
           null,
           'INVITATION_EXISTS'
         )
-        return addCorsHeaders(response)
+        return addCorsHeaders(response, req)
       }
 
       // Get team info for email
@@ -274,7 +274,7 @@ export const POST = withRateLimitTier(withApiLogging(
 
       if (!team) {
         const response = createApiError('Team not found', 404, null, 'TEAM_NOT_FOUND')
-        return addCorsHeaders(response)
+        return addCorsHeaders(response, req)
       }
 
       // Create invitation
@@ -333,17 +333,17 @@ export const POST = withRateLimitTier(withApiLogging(
       }
 
       const response = createApiResponse(invitation, { created: true }, 201)
-      return addCorsHeaders(response)
+      return addCorsHeaders(response, req)
     } catch (error) {
       if (error instanceof Error && error.name === 'ZodError') {
         const zodError = error as { issues?: unknown[] }
         const response = createApiError('Validation error', 400, zodError.issues, 'VALIDATION_ERROR')
-        return addCorsHeaders(response)
+        return addCorsHeaders(response, req)
       }
 
       console.error('Error creating invitation:', error)
       const response = createApiError('Internal server error', 500)
-      return addCorsHeaders(response)
+      return addCorsHeaders(response, req)
     }
   }
 ), 'write')

--- a/apps/dev/app/api/v1/teams/[teamId]/route.ts
+++ b/apps/dev/app/api/v1/teams/[teamId]/route.ts
@@ -14,8 +14,8 @@ import { TeamService, MembershipService } from '@nextsparkjs/core/lib/services'
 import type { Team, TeamRole } from '@nextsparkjs/core/lib/teams/types'
 
 // Handle CORS preflight
-export async function OPTIONS() {
-  return handleCorsPreflightRequest()
+export async function OPTIONS(request: NextRequest) {
+  return handleCorsPreflightRequest(request)
 }
 
 // GET /api/v1/teams/:teamId - Get team details
@@ -41,7 +41,7 @@ export const GET = withRateLimitTier(withApiLogging(
       // Validate that teamId is not empty
       if (!teamId || teamId.trim() === '') {
         const response = createApiError('Team ID is required', 400, null, 'MISSING_TEAM_ID')
-        return addCorsHeaders(response)
+        return addCorsHeaders(response, req)
       }
 
       // Check if user is a member of the team
@@ -53,7 +53,7 @@ export const GET = withRateLimitTier(withApiLogging(
 
       if (!userRole) {
         const response = createApiError('Team not found or access denied', 404, null, 'TEAM_NOT_FOUND')
-        return addCorsHeaders(response)
+        return addCorsHeaders(response, req)
       }
 
       // Fetch team with member count
@@ -72,7 +72,7 @@ export const GET = withRateLimitTier(withApiLogging(
 
       if (!team) {
         const response = createApiError('Team not found', 404, null, 'TEAM_NOT_FOUND')
-        return addCorsHeaders(response)
+        return addCorsHeaders(response, req)
       }
 
       const responseData = {
@@ -81,11 +81,11 @@ export const GET = withRateLimitTier(withApiLogging(
       }
 
       const response = createApiResponse(responseData)
-      return addCorsHeaders(response)
+      return addCorsHeaders(response, req)
     } catch (error) {
       console.error('Error fetching team:', error)
       const response = createApiError('Internal server error', 500)
-      return addCorsHeaders(response)
+      return addCorsHeaders(response, req)
     }
   }
 ), 'read')
@@ -113,7 +113,7 @@ export const PATCH = withRateLimitTier(withApiLogging(
       // Validate that teamId is not empty
       if (!teamId || teamId.trim() === '') {
         const response = createApiError('Team ID is required', 400, null, 'MISSING_TEAM_ID')
-        return addCorsHeaders(response)
+        return addCorsHeaders(response, req)
       }
 
       // Check if user has permission to edit team using MembershipService
@@ -130,7 +130,7 @@ export const PATCH = withRateLimitTier(withApiLogging(
           },
           { status: 403 }
         )
-        return addCorsHeaders(response)
+        return addCorsHeaders(response, req)
       }
 
       const body = await req.json()
@@ -141,7 +141,7 @@ export const PATCH = withRateLimitTier(withApiLogging(
         const slugAvailable = await TeamService.isSlugAvailable(validatedData.slug, teamId)
         if (!slugAvailable) {
           const response = createApiError('Team slug already exists', 409, null, 'SLUG_EXISTS')
-          return addCorsHeaders(response)
+          return addCorsHeaders(response, req)
         }
       }
 
@@ -177,7 +177,7 @@ export const PATCH = withRateLimitTier(withApiLogging(
 
       if (updates.length === 0) {
         const response = createApiError('No fields to update', 400, null, 'NO_FIELDS')
-        return addCorsHeaders(response)
+        return addCorsHeaders(response, req)
       }
 
       updates.push(`"updatedAt" = CURRENT_TIMESTAMP`)
@@ -194,7 +194,7 @@ export const PATCH = withRateLimitTier(withApiLogging(
 
       if (result.rows.length === 0) {
         const response = createApiError('Team not found', 404, null, 'TEAM_NOT_FOUND')
-        return addCorsHeaders(response)
+        return addCorsHeaders(response, req)
       }
 
       // Fetch team with member count
@@ -216,17 +216,17 @@ export const PATCH = withRateLimitTier(withApiLogging(
       }
 
       const response = createApiResponse(responseData)
-      return addCorsHeaders(response)
+      return addCorsHeaders(response, req)
     } catch (error) {
       if (error instanceof Error && error.name === 'ZodError') {
         const zodError = error as { issues?: unknown[] }
         const response = createApiError('Validation error', 400, zodError.issues, 'VALIDATION_ERROR')
-        return addCorsHeaders(response)
+        return addCorsHeaders(response, req)
       }
 
       console.error('Error updating team:', error)
       const response = createApiError('Internal server error', 500)
-      return addCorsHeaders(response)
+      return addCorsHeaders(response, req)
     }
   }
 ), 'write')
@@ -254,7 +254,7 @@ export const DELETE = withRateLimitTier(withApiLogging(
       // Validate that teamId is not empty
       if (!teamId || teamId.trim() === '') {
         const response = createApiError('Team ID is required', 400, null, 'MISSING_TEAM_ID')
-        return addCorsHeaders(response)
+        return addCorsHeaders(response, req)
       }
 
       // Use the TeamService.delete (handles owner check and personal team protection)
@@ -262,7 +262,7 @@ export const DELETE = withRateLimitTier(withApiLogging(
         await TeamService.delete(teamId, authResult.user!.id)
 
         const response = createApiResponse({ deleted: true, id: teamId })
-        return addCorsHeaders(response)
+        return addCorsHeaders(response, req)
       } catch (error) {
         if (error instanceof Error && error.message === 'Only team owner can delete the team') {
           const response = createApiError(
@@ -271,17 +271,17 @@ export const DELETE = withRateLimitTier(withApiLogging(
             null,
             'INSUFFICIENT_PERMISSIONS'
           )
-          return addCorsHeaders(response)
+          return addCorsHeaders(response, req)
         }
 
         if (error instanceof Error && error.message === 'Team not found') {
           const response = createApiError('Team not found', 404, null, 'TEAM_NOT_FOUND')
-          return addCorsHeaders(response)
+          return addCorsHeaders(response, req)
         }
 
         if (error instanceof Error && error.message === 'Personal teams cannot be deleted') {
           const response = createApiError('Personal teams cannot be deleted', 403, null, 'PERSONAL_TEAM_DELETE_FORBIDDEN')
-          return addCorsHeaders(response)
+          return addCorsHeaders(response, req)
         }
 
         throw error
@@ -289,7 +289,7 @@ export const DELETE = withRateLimitTier(withApiLogging(
     } catch (error) {
       console.error('Error deleting team:', error)
       const response = createApiError('Internal server error', 500)
-      return addCorsHeaders(response)
+      return addCorsHeaders(response, req)
     }
   }
 ), 'write')

--- a/apps/dev/app/api/v1/teams/route.ts
+++ b/apps/dev/app/api/v1/teams/route.ts
@@ -17,8 +17,8 @@ import type { Team } from '@nextsparkjs/core/lib/teams/types'
 import { APP_CONFIG_MERGED } from '@nextsparkjs/core/lib/config/config-sync'
 
 // Handle CORS preflight
-export async function OPTIONS() {
-  return handleCorsPreflightRequest()
+export async function OPTIONS(request: NextRequest) {
+  return handleCorsPreflightRequest(request)
 }
 
 // GET /api/v1/teams - List user's teams
@@ -62,7 +62,7 @@ export const GET = withRateLimitTier(withApiLogging(async (req: NextRequest): Pr
         'Insufficient permissions. Superadmin access required for scope=all.',
         403
       )
-      return addCorsHeaders(response)
+      return addCorsHeaders(response, req)
     }
 
     // Build WHERE clause based on filters
@@ -160,11 +160,11 @@ export const GET = withRateLimitTier(withApiLogging(async (req: NextRequest): Pr
     }))
 
     const response = createApiResponse(teamsWithMembers, paginationMeta)
-    return addCorsHeaders(response)
+    return addCorsHeaders(response, req)
   } catch (error) {
     console.error('Error fetching teams:', error)
     const response = createApiError('Internal server error', 500)
-    return addCorsHeaders(response)
+    return addCorsHeaders(response, req)
   }
 }), 'read')
 
@@ -199,7 +199,7 @@ export const POST = withRateLimitTier(withApiLogging(async (req: NextRequest): P
         null,
         'TEAM_CREATION_DISABLED'
       )
-      return addCorsHeaders(response)
+      return addCorsHeaders(response, req)
     }
 
     // Validate allowCreateTeams option
@@ -220,7 +220,7 @@ export const POST = withRateLimitTier(withApiLogging(async (req: NextRequest): P
           null,
           'MAX_TEAMS_REACHED'
         )
-        return addCorsHeaders(response)
+        return addCorsHeaders(response, req)
       }
     }
 
@@ -228,7 +228,7 @@ export const POST = withRateLimitTier(withApiLogging(async (req: NextRequest): P
     const slugAvailable = await TeamService.isSlugAvailable(validatedData.slug)
     if (!slugAvailable) {
       const response = createApiError('Team slug already exists', 409, null, 'SLUG_EXISTS')
-      return addCorsHeaders(response)
+      return addCorsHeaders(response, req)
     }
 
     // Use transaction to ensure atomicity
@@ -280,7 +280,7 @@ export const POST = withRateLimitTier(withApiLogging(async (req: NextRequest): P
       }
 
       const response = createApiResponse(responseData, { created: true }, 201)
-      return addCorsHeaders(response)
+      return addCorsHeaders(response, req)
     } catch (error) {
       await tx.rollback()
       throw error
@@ -289,11 +289,11 @@ export const POST = withRateLimitTier(withApiLogging(async (req: NextRequest): P
     if (error instanceof Error && error.name === 'ZodError') {
       const zodError = error as { issues?: unknown[] }
       const response = createApiError('Validation error', 400, zodError.issues, 'VALIDATION_ERROR')
-      return addCorsHeaders(response)
+      return addCorsHeaders(response, req)
     }
 
     console.error('Error creating team:', error)
     const response = createApiError('Internal server error', 500)
-    return addCorsHeaders(response)
+    return addCorsHeaders(response, req)
   }
 }), 'write')

--- a/apps/dev/app/api/v1/teams/switch/route.ts
+++ b/apps/dev/app/api/v1/teams/switch/route.ts
@@ -16,8 +16,8 @@ const switchTeamSchema = z.object({
 })
 
 // Handle CORS preflight
-export async function OPTIONS() {
-  return handleCorsPreflightRequest()
+export async function OPTIONS(request: NextRequest) {
+  return handleCorsPreflightRequest(request)
 }
 
 // POST /api/v1/teams/switch - Switch active team context
@@ -61,7 +61,7 @@ export const POST = withRateLimitTier(withApiLogging(async (req: NextRequest): P
         maxAge: 60 * 60 * 24 * 365  // 1 year
       })
 
-      return addCorsHeaders(response)
+      return addCorsHeaders(response, req)
     } catch (error) {
       if (error instanceof Error && error.message === 'User is not a member of this team') {
         const response = createApiError(
@@ -70,7 +70,7 @@ export const POST = withRateLimitTier(withApiLogging(async (req: NextRequest): P
           null,
           'NOT_TEAM_MEMBER'
         )
-        return addCorsHeaders(response)
+        return addCorsHeaders(response, req)
       }
 
       throw error
@@ -79,11 +79,11 @@ export const POST = withRateLimitTier(withApiLogging(async (req: NextRequest): P
     if (error instanceof Error && error.name === 'ZodError') {
       const zodError = error as { issues?: unknown[] }
       const response = createApiError('Validation error', 400, zodError.issues, 'VALIDATION_ERROR')
-      return addCorsHeaders(response)
+      return addCorsHeaders(response, req)
     }
 
     console.error('Error switching team:', error)
     const response = createApiError('Internal server error', 500)
-    return addCorsHeaders(response)
+    return addCorsHeaders(response, req)
   }
 }), 'write')

--- a/apps/dev/app/api/v1/theme/[...path]/route.ts
+++ b/apps/dev/app/api/v1/theme/[...path]/route.ts
@@ -12,6 +12,7 @@ import {
   type ThemeRegistryEntry
 } from '@nextsparkjs/registries/theme-registry'
 import { withRateLimitTier } from '@nextsparkjs/core/lib/api/rate-limit'
+import { validateAndAuthenticateRequest } from '@nextsparkjs/core/lib/api/helpers'
 
 export const GET = withRateLimitTier(async (
   request: NextRequest,
@@ -111,6 +112,12 @@ async function handleThemeRequest(
       console.log(`[Theme API] No route found for ${requestPath}, method: ${method}`)
     }
 
+    // The endpoint catalog is only disclosed to authenticated callers.
+    // Anonymous requests still get theme info / 404, but never the route map.
+    const endpointCatalog = (await isAuthenticatedRequest(request))
+      ? { availableEndpoints: getThemeEndpoints(themeName) }
+      : {}
+
     // Default theme info endpoint
     if (!endpointPath && method === 'GET') {
       return NextResponse.json({
@@ -124,7 +131,7 @@ async function handleThemeRequest(
           entities: themeEntry.entities?.length || 0,
           routeFiles: themeEntry.routeFiles?.length || 0,
           plugins: themeEntry.plugins || [],
-          availableEndpoints: getThemeEndpoints(themeName)
+          ...endpointCatalog
         }
       })
     }
@@ -136,7 +143,7 @@ async function handleThemeRequest(
         theme: themeName,
         path: endpointPath,
         method,
-        availableEndpoints: getThemeEndpoints(themeName)
+        ...endpointCatalog
       },
       { status: 404 }
     )
@@ -151,6 +158,20 @@ async function handleThemeRequest(
       },
       { status: 500 }
     )
+  }
+}
+
+/**
+ * Check whether the request carries a valid session or API key.
+ * Used to gate the endpoint catalog (see #104 / #109): the list of registered
+ * theme routes must not be enumerable by anonymous callers.
+ */
+async function isAuthenticatedRequest(request: NextRequest): Promise<boolean> {
+  try {
+    const { auth, rateLimitResponse } = await validateAndAuthenticateRequest(request)
+    return !rateLimitResponse && Boolean(auth?.userId)
+  } catch {
+    return false
   }
 }
 

--- a/apps/dev/app/api/v1/users/[id]/meta/[key]/route.ts
+++ b/apps/dev/app/api/v1/users/[id]/meta/[key]/route.ts
@@ -41,8 +41,8 @@ const metadataValueSchema = z.object({
 })
 
 // Handle CORS preflight
-export async function OPTIONS() {
-  return handleCorsPreflightRequest()
+export async function OPTIONS(request: NextRequest) {
+  return handleCorsPreflightRequest(request)
 }
 
 /**
@@ -86,7 +86,7 @@ export const GET = withRateLimitTier(withApiLogging(async (
         'Insufficient permissions. Admin access required for user metadata.',
         403
       )
-      return addCorsHeaders(response)
+      return addCorsHeaders(response, req)
     }
 
     const { id, key } = await params
@@ -94,12 +94,12 @@ export const GET = withRateLimitTier(withApiLogging(async (
     // Validate parameters
     if (!id || id.trim() === '') {
       const response = createApiError('User ID is required', 400, null, 'MISSING_USER_ID')
-      return addCorsHeaders(response)
+      return addCorsHeaders(response, req)
     }
 
     if (!key || key.trim() === '') {
       const response = createApiError('Metadata key is required', 400, null, 'MISSING_META_KEY')
-      return addCorsHeaders(response)
+      return addCorsHeaders(response, req)
     }
 
     // Validate key length
@@ -110,7 +110,7 @@ export const GET = withRateLimitTier(withApiLogging(async (
         null,
         'INVALID_META_KEY'
       )
-      return addCorsHeaders(response)
+      return addCorsHeaders(response, req)
     }
 
     // Get user metadata value using UserService
@@ -126,14 +126,14 @@ export const GET = withRateLimitTier(withApiLogging(async (
       key,
       value: metaValue ?? null,
     })
-    return addCorsHeaders(response)
+    return addCorsHeaders(response, req)
   } catch (error) {
     const response = createApiError(
       'Failed to fetch user metadata',
       500,
       error instanceof Error ? error.message : undefined
     )
-    return addCorsHeaders(response)
+    return addCorsHeaders(response, req)
   }
 }), 'read');
 
@@ -183,7 +183,7 @@ export const PUT = withRateLimitTier(withApiLogging(async (
         'Insufficient permissions. Admin access required for user metadata.',
         403
       )
-      return addCorsHeaders(response)
+      return addCorsHeaders(response, req)
     }
 
     const { id, key } = await params
@@ -191,12 +191,12 @@ export const PUT = withRateLimitTier(withApiLogging(async (
     // Validate parameters
     if (!id || id.trim() === '') {
       const response = createApiError('User ID is required', 400, null, 'MISSING_USER_ID')
-      return addCorsHeaders(response)
+      return addCorsHeaders(response, req)
     }
 
     if (!key || key.trim() === '') {
       const response = createApiError('Metadata key is required', 400, null, 'MISSING_META_KEY')
-      return addCorsHeaders(response)
+      return addCorsHeaders(response, req)
     }
 
     // Validate key length
@@ -207,7 +207,7 @@ export const PUT = withRateLimitTier(withApiLogging(async (
         null,
         'INVALID_META_KEY'
       )
-      return addCorsHeaders(response)
+      return addCorsHeaders(response, req)
     }
 
     // Parse and validate request body
@@ -223,7 +223,7 @@ export const PUT = withRateLimitTier(withApiLogging(async (
         null,
         'VALUE_TOO_LARGE'
       )
-      return addCorsHeaders(response)
+      return addCorsHeaders(response, req)
     }
 
     // Update metadata using UserService
@@ -245,7 +245,7 @@ export const PUT = withRateLimitTier(withApiLogging(async (
       value: validatedData.value,
       updated: true,
     })
-    return addCorsHeaders(response)
+    return addCorsHeaders(response, req)
   } catch (error) {
     // Handle validation errors
     if (error instanceof z.ZodError) {
@@ -255,7 +255,7 @@ export const PUT = withRateLimitTier(withApiLogging(async (
         error.issues,
         'VALIDATION_ERROR'
       )
-      return addCorsHeaders(response)
+      return addCorsHeaders(response, req)
     }
 
     const response = createApiError(
@@ -263,7 +263,7 @@ export const PUT = withRateLimitTier(withApiLogging(async (
       500,
       error instanceof Error ? error.message : undefined
     )
-    return addCorsHeaders(response)
+    return addCorsHeaders(response, req)
   }
 }), 'write');
 
@@ -311,7 +311,7 @@ export const DELETE = withRateLimitTier(withApiLogging(async (
         'Insufficient permissions. Admin access required for user metadata.',
         403
       )
-      return addCorsHeaders(response)
+      return addCorsHeaders(response, req)
     }
 
     const { id, key } = await params
@@ -319,12 +319,12 @@ export const DELETE = withRateLimitTier(withApiLogging(async (
     // Validate parameters
     if (!id || id.trim() === '') {
       const response = createApiError('User ID is required', 400, null, 'MISSING_USER_ID')
-      return addCorsHeaders(response)
+      return addCorsHeaders(response, req)
     }
 
     if (!key || key.trim() === '') {
       const response = createApiError('Metadata key is required', 400, null, 'MISSING_META_KEY')
-      return addCorsHeaders(response)
+      return addCorsHeaders(response, req)
     }
 
     // Validate key length
@@ -335,7 +335,7 @@ export const DELETE = withRateLimitTier(withApiLogging(async (
         null,
         'INVALID_META_KEY'
       )
-      return addCorsHeaders(response)
+      return addCorsHeaders(response, req)
     }
 
     // Delete metadata using UserService
@@ -346,13 +346,13 @@ export const DELETE = withRateLimitTier(withApiLogging(async (
       key,
       deleted: true,
     })
-    return addCorsHeaders(response)
+    return addCorsHeaders(response, req)
   } catch (error) {
     const response = createApiError(
       'Failed to delete user metadata',
       500,
       error instanceof Error ? error.message : undefined
     )
-    return addCorsHeaders(response)
+    return addCorsHeaders(response, req)
   }
 }), 'write');

--- a/apps/dev/app/api/v1/users/[id]/route.ts
+++ b/apps/dev/app/api/v1/users/[id]/route.ts
@@ -24,8 +24,8 @@ const updateUserSchema = z.object({
 });
 
 // Handle CORS preflight
-export async function OPTIONS() {
-  return handleCorsPreflightRequest();
+export async function OPTIONS(request: NextRequest) {
+  return handleCorsPreflightRequest(request);
 }
 
 // GET /api/v1/users/:id - Get specific user
@@ -54,7 +54,7 @@ export const GET = withRateLimitTier(withApiLogging(async (
 
     if (!hasPermission) {
       const response = createApiError('Insufficient permissions. Admin access required for user management.', 403);
-      return addCorsHeaders(response);
+      return addCorsHeaders(response, req);
     }
 
     const { id } = await params;
@@ -62,7 +62,7 @@ export const GET = withRateLimitTier(withApiLogging(async (
     // Validate that id is not empty
     if (!id || id.trim() === '') {
       const response = createApiError('User ID or email is required', 400, null, 'MISSING_IDENTIFIER');
-      return addCorsHeaders(response);
+      return addCorsHeaders(response, req);
     }
 
     // Search by ID or email
@@ -74,7 +74,7 @@ export const GET = withRateLimitTier(withApiLogging(async (
 
     if (!user) {
       const response = createApiError('User not found', 404, null, 'USER_NOT_FOUND');
-      return addCorsHeaders(response);
+      return addCorsHeaders(response, req);
     }
 
     // Handle metadata if requested (usando helper compartido)
@@ -82,11 +82,11 @@ export const GET = withRateLimitTier(withApiLogging(async (
     const userWithMeta = await includeEntityMetadataForSingle('user', user as { id: string }, metaParams, authResult.user!.id);
 
     const response = createApiResponse(userWithMeta);
-    return addCorsHeaders(response);
+    return addCorsHeaders(response, req);
   } catch (error) {
     console.error('Error fetching user:', error);
     const response = createApiError('Internal server error', 500);
-    return addCorsHeaders(response);
+    return addCorsHeaders(response, req);
   }
 }), 'read');
 
@@ -116,7 +116,7 @@ export const PATCH = withRateLimitTier(withApiLogging(async (
 
     if (!hasPermission) {
       const response = createApiError('Insufficient permissions. Admin access required for user management.', 403);
-      return addCorsHeaders(response);
+      return addCorsHeaders(response, req);
     }
 
     const { id } = await params;
@@ -124,7 +124,7 @@ export const PATCH = withRateLimitTier(withApiLogging(async (
     // Validate that id is not empty
     if (!id || id.trim() === '') {
       const response = createApiError('User ID or email is required', 400, null, 'MISSING_IDENTIFIER');
-      return addCorsHeaders(response);
+      return addCorsHeaders(response, req);
     }
 
     const body = await req.json();
@@ -162,7 +162,7 @@ export const PATCH = withRateLimitTier(withApiLogging(async (
     
     if (!hasEntityFieldsToUpdate && !hasMetadataToUpdate) {
       const response = createApiError('No fields to update', 400, null, 'NO_FIELDS');
-      return addCorsHeaders(response);
+      return addCorsHeaders(response, req);
     }
 
     let updatedUser;
@@ -183,7 +183,7 @@ export const PATCH = withRateLimitTier(withApiLogging(async (
 
       if (result.rows.length === 0) {
         const response = createApiError('User not found', 404, null, 'USER_NOT_FOUND');
-        return addCorsHeaders(response);
+        return addCorsHeaders(response, req);
       }
 
       updatedUser = result.rows[0];
@@ -197,7 +197,7 @@ export const PATCH = withRateLimitTier(withApiLogging(async (
 
       if (!user) {
         const response = createApiError('User not found', 404, null, 'USER_NOT_FOUND');
-        return addCorsHeaders(response);
+        return addCorsHeaders(response, req);
       }
 
       updatedUser = user;
@@ -214,16 +214,16 @@ export const PATCH = withRateLimitTier(withApiLogging(async (
     const responseData = await handleEntityMetadataInResponse('user', updatedUser as { id: string }, metadataWasProvided, authResult.user!.id);
 
     const response = createApiResponse(responseData);
-    return addCorsHeaders(response);
+    return addCorsHeaders(response, req);
   } catch (error) {
     if (error instanceof z.ZodError) {
       const response = createApiError('Validation error', 400, error.issues, 'VALIDATION_ERROR');
-      return addCorsHeaders(response);
+      return addCorsHeaders(response, req);
     }
     
     console.error('Error updating user:', error);
     const response = createApiError('Internal server error', 500);
-    return addCorsHeaders(response);
+    return addCorsHeaders(response, req);
   }
 }), 'write');
 
@@ -253,7 +253,7 @@ export const DELETE = withRateLimitTier(withApiLogging(async (
 
     if (!hasPermission) {
       const response = createApiError('Insufficient permissions. Admin access required for user management.', 403);
-      return addCorsHeaders(response);
+      return addCorsHeaders(response, req);
     }
 
     const { id } = await params;
@@ -261,7 +261,7 @@ export const DELETE = withRateLimitTier(withApiLogging(async (
     // Validate that id is not empty
     if (!id || id.trim() === '') {
       const response = createApiError('User ID or email is required', 400, null, 'MISSING_IDENTIFIER');
-      return addCorsHeaders(response);
+      return addCorsHeaders(response, req);
     }
 
     // First, get the user to check if it exists and prevent self-deletion
@@ -273,13 +273,13 @@ export const DELETE = withRateLimitTier(withApiLogging(async (
 
     if (!targetUser) {
       const response = createApiError('User not found', 404, null, 'USER_NOT_FOUND');
-      return addCorsHeaders(response);
+      return addCorsHeaders(response, req);
     }
 
     // Prevent self-deletion
     if ((targetUser as Record<string, unknown>).id === authResult.user!.id) {
       const response = createApiError('Cannot delete your own account via API', 403, null, 'SELF_DELETE_FORBIDDEN');
-      return addCorsHeaders(response);
+      return addCorsHeaders(response, req);
     }
 
     const result = await mutateWithRLS(
@@ -290,14 +290,14 @@ export const DELETE = withRateLimitTier(withApiLogging(async (
 
     if (result.rows.length === 0) {
       const response = createApiError('User not found', 404, null, 'USER_NOT_FOUND');
-      return addCorsHeaders(response);
+      return addCorsHeaders(response, req);
     }
 
     const response = createApiResponse({ deleted: true, id });
-    return addCorsHeaders(response);
+    return addCorsHeaders(response, req);
   } catch (error) {
     console.error('Error deleting user:', error);
     const response = createApiError('Internal server error', 500);
-    return addCorsHeaders(response);
+    return addCorsHeaders(response, req);
   }
 }), 'write');

--- a/apps/dev/app/api/v1/users/route.ts
+++ b/apps/dev/app/api/v1/users/route.ts
@@ -34,8 +34,8 @@ const createUserSchema = z.object({
 
 
 // Handle CORS preflight
-export async function OPTIONS() {
-  return handleCorsPreflightRequest();
+export async function OPTIONS(request: NextRequest) {
+  return handleCorsPreflightRequest(request);
 }
 
 // GET /api/v1/users - List users with dual auth
@@ -58,7 +58,7 @@ export const GET = withRateLimitTier(withApiLogging(async (req: NextRequest): Pr
     // SECURITY: Only superadmins can list all users
     if (!hasAdminPermission(authResult, 'users:read')) {
       const response = createApiError('Insufficient permissions. Superadmin access required.', 403);
-      return addCorsHeaders(response);
+      return addCorsHeaders(response, req);
     }
 
     const metaParams = parseMetaParams(req);
@@ -103,11 +103,11 @@ export const GET = withRateLimitTier(withApiLogging(async (req: NextRequest): Pr
     const usersWithMeta = await includeEntityMetadata('user', users as { id: string }[], metaParams, authResult.user!.id);
 
     const response = createApiResponse(usersWithMeta, paginationMeta);
-    return addCorsHeaders(response);
+    return addCorsHeaders(response, req);
   } catch (error) {
     console.error('Error fetching users:', error);
     const response = createApiError('Internal server error', 500);
-    return addCorsHeaders(response);
+    return addCorsHeaders(response, req);
   }
 }), 'read');
 
@@ -131,7 +131,7 @@ export const POST = withRateLimitTier(withApiLogging(async (req: NextRequest): P
     // SECURITY: Only superadmins can create users
     if (!hasAdminPermission(authResult, 'users:write')) {
       const response = createApiError('Insufficient permissions. Superadmin access required.', 403);
-      return addCorsHeaders(response);
+      return addCorsHeaders(response, req);
     }
 
     const body = await req.json();
@@ -147,7 +147,7 @@ export const POST = withRateLimitTier(withApiLogging(async (req: NextRequest): P
 
     if (existingUser.length > 0) {
       const response = createApiError('Email already exists', 409, null, 'EMAIL_EXISTS');
-      return addCorsHeaders(response);
+      return addCorsHeaders(response, req);
     }
 
     const newUserId = globalThis.crypto.randomUUID();
@@ -183,16 +183,16 @@ export const POST = withRateLimitTier(withApiLogging(async (req: NextRequest): P
     const responseData = await handleEntityMetadataInResponse('user', createdUser as { id: string }, metadataWasProvided, authResult.user!.id);
     
     const response = createApiResponse(responseData, { created: true }, 201);
-    return addCorsHeaders(response);
+    return addCorsHeaders(response, req);
   } catch (error) {
     if (error instanceof z.ZodError) {
       const response = createApiError('Validation error', 400, error.issues, 'VALIDATION_ERROR');
-      return addCorsHeaders(response);
+      return addCorsHeaders(response, req);
     }
     
     console.error('Error creating user:', error);
     const response = createApiError('Internal server error', 500);
-    return addCorsHeaders(response);
+    return addCorsHeaders(response, req);
   }
 }), 'write');
 

--- a/apps/dev/app/dashboard/layout.tsx
+++ b/apps/dev/app/dashboard/layout.tsx
@@ -3,7 +3,7 @@
 import { useAuth } from '@nextsparkjs/core/hooks/useAuth'
 import { useRouter } from 'next/navigation'
 import { useEffect, Suspense } from 'react'
-import { Loader2 } from 'lucide-react'
+import { DashboardAuthSkeleton } from '@nextsparkjs/core/components/dashboard/layouts/DashboardAuthSkeleton'
 import { DashboardProviders } from '@nextsparkjs/core/providers/DashboardProviders'
 import { DashboardTranslationPreloader } from '@nextsparkjs/core/lib/i18n/DashboardTranslationPreloader'
 import { TranslationDebugger } from '@nextsparkjs/core/utils/dev/TranslationDebugger'
@@ -35,11 +35,7 @@ function DashboardLayoutContent({ children }: { children: React.ReactNode }) {
   }, [user, isLoading, router])
 
   if (isLoading) {
-    return (
-      <div className="min-h-screen flex items-center justify-center">
-        <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
-      </div>
-    )
+    return <DashboardAuthSkeleton />
   }
 
   if (!user) {

--- a/apps/dev/app/layout.ppr.tsx
+++ b/apps/dev/app/layout.ppr.tsx
@@ -55,27 +55,22 @@ export const metadata: Metadata = getMetadataOrDefault(
   defaultMetadata
 )
 
-export default function RootLayout({
+export default async function RootLayout({
   children,
 }: Readonly<{
   children: React.ReactNode
 }>) {
+  const billingHints = await getBillingResourceHints()
+
   return (
     <html lang={DEFAULT_LOCALE} suppressHydrationWarning>
       <head>
-        {(() => {
-          const hints = getBillingResourceHints()
-          return (
-            <>
-              {hints.preconnect.map((domain) => (
-                <link key={`pre-${domain}`} rel="preconnect" href={domain} />
-              ))}
-              {[...hints.preconnect, ...hints.dnsPrefetch].map((domain) => (
-                <link key={`dns-${domain}`} rel="dns-prefetch" href={domain} />
-              ))}
-            </>
-          )
-        })()}
+        {billingHints.preconnect.map((domain) => (
+          <link key={`pre-${domain}`} rel="preconnect" href={domain} />
+        ))}
+        {[...billingHints.preconnect, ...billingHints.dnsPrefetch].map((domain) => (
+          <link key={`dns-${domain}`} rel="dns-prefetch" href={domain} />
+        ))}
       </head>
       <body
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}

--- a/apps/dev/app/layout.tsx
+++ b/apps/dev/app/layout.tsx
@@ -56,23 +56,17 @@ export default async function RootLayout({
   const locale = await getUserLocale()
   const messages = await getMessages({ locale })
   const defaultTheme = await getDefaultThemeMode()
+  const billingHints = await getBillingResourceHints()
 
   return (
     <html lang={locale} suppressHydrationWarning>
       <head>
-        {(() => {
-          const hints = getBillingResourceHints()
-          return (
-            <>
-              {hints.preconnect.map((domain) => (
-                <link key={`pre-${domain}`} rel="preconnect" href={domain} />
-              ))}
-              {[...hints.preconnect, ...hints.dnsPrefetch].map((domain) => (
-                <link key={`dns-${domain}`} rel="dns-prefetch" href={domain} />
-              ))}
-            </>
-          )
-        })()}
+        {billingHints.preconnect.map((domain) => (
+          <link key={`pre-${domain}`} rel="preconnect" href={domain} />
+        ))}
+        {[...billingHints.preconnect, ...billingHints.dnsPrefetch].map((domain) => (
+          <link key={`dns-${domain}`} rel="dns-prefetch" href={domain} />
+        ))}
       </head>
       <body
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}

--- a/packages/core/src/components/billing/InvoicesTable.tsx
+++ b/packages/core/src/components/billing/InvoicesTable.tsx
@@ -2,7 +2,7 @@
 
 import Link from 'next/link'
 import { ExternalLink } from 'lucide-react'
-import { useTranslations } from 'next-intl'
+import { useTranslations, useLocale } from 'next-intl'
 import {
   Table,
   TableBody,
@@ -43,13 +43,15 @@ export function InvoicesTable({
   onPageChange,
 }: InvoicesTableProps) {
   const t = useTranslations('settings.billing.invoices')
+  // Active next-intl locale so dates/amounts follow the app language (see #85)
+  const locale = useLocale()
 
   const currentPage = Math.floor(offset / limit) + 1
   const totalPages = Math.ceil(total / limit)
 
   const formatDate = (dateString: string) => {
     const date = new Date(dateString)
-    return new Intl.DateTimeFormat('en-US', {
+    return new Intl.DateTimeFormat(locale, {
       year: 'numeric',
       month: 'short',
       day: 'numeric',
@@ -57,7 +59,7 @@ export function InvoicesTable({
   }
 
   const formatCurrency = (amount: number, currency: string) => {
-    return new Intl.NumberFormat('en-US', {
+    return new Intl.NumberFormat(locale, {
       style: 'currency',
       currency: currency,
     }).format(amount)

--- a/packages/core/src/components/dashboard/layouts/AuthGuard.tsx
+++ b/packages/core/src/components/dashboard/layouts/AuthGuard.tsx
@@ -3,7 +3,7 @@
 import { useAuth } from '../../../hooks/useAuth'
 import { useRouter } from 'next/navigation'
 import { useEffect } from 'react'
-import { Loader2 } from 'lucide-react'
+import { DashboardAuthSkeleton } from './DashboardAuthSkeleton'
 import { useEnsureUserMetadata } from '../../../hooks/useEnsureUserMetadata'
 import { useAuthMethodDetector } from '../../../hooks/useAuthMethodDetector'
 
@@ -29,11 +29,7 @@ export function AuthGuard({ children }: AuthGuardProps) {
   }, [user, isLoading, router])
 
   if (isLoading) {
-    return (
-      <div className="min-h-screen flex items-center justify-center">
-        <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
-      </div>
-    )
+    return <DashboardAuthSkeleton />
   }
 
   if (!user) {

--- a/packages/core/src/components/dashboard/layouts/DashboardAuthLayout.tsx
+++ b/packages/core/src/components/dashboard/layouts/DashboardAuthLayout.tsx
@@ -3,7 +3,7 @@
 import { useAuth } from '../../../hooks/useAuth'
 import { useRouter } from 'next/navigation'
 import { useEffect, Suspense } from 'react'
-import { Loader2 } from 'lucide-react'
+import { DashboardAuthSkeleton } from './DashboardAuthSkeleton'
 import { DashboardTranslationPreloader } from '../../../lib/i18n/DashboardTranslationPreloader'
 import { TranslationDebugger } from '../../../utils/dev/TranslationDebugger'
 import { useEnsureUserMetadata } from '../../../hooks/useEnsureUserMetadata'
@@ -40,11 +40,7 @@ function DashboardLayoutContent({ children }: { children: React.ReactNode }) {
   }, [user, isLoading, router])
 
   if (isLoading) {
-    return (
-      <div className="min-h-screen flex items-center justify-center">
-        <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
-      </div>
-    )
+    return <DashboardAuthSkeleton />
   }
 
   if (!user) {

--- a/packages/core/src/components/dashboard/layouts/DashboardAuthSkeleton.tsx
+++ b/packages/core/src/components/dashboard/layouts/DashboardAuthSkeleton.tsx
@@ -1,0 +1,63 @@
+'use client'
+
+import { Skeleton, SkeletonContainer } from '../../ui/skeleton'
+
+/**
+ * Structural skeleton shown while the dashboard auth gate resolves the session.
+ *
+ * Replaces the bare centered spinner on a blank screen (see #91): a sidebar
+ * rail, a topbar strip and a content placeholder give users the shape of what
+ * is coming instead of an empty page. Built only from the existing Skeleton
+ * primitives (bg-muted + reduced pulse), so it inherits the active theme and
+ * stays deliberately restrained — this is seen many times a day.
+ *
+ * The sidebar rail collapses below the `md:` breakpoint, matching the real
+ * dashboard sidebar, so mobile never shows a phantom sidebar block.
+ *
+ * Shared by AuthGuard, DashboardAuthLayout and the generated
+ * app/dashboard/layout.tsx so the public API and the template cannot drift.
+ */
+export function DashboardAuthSkeleton() {
+  return (
+    <div
+      className="min-h-screen flex bg-background"
+      data-cy="dashboard-loading-skeleton"
+      role="status"
+      aria-busy="true"
+      aria-live="polite"
+    >
+      <span className="sr-only">Loading</span>
+
+      {/* Sidebar rail */}
+      <div
+        className="hidden md:flex md:w-64 md:flex-col md:border-r md:border-border md:p-4 md:gap-3"
+        aria-hidden="true"
+      >
+        <Skeleton className="h-8 w-32" />
+        <SkeletonContainer className="mt-4 flex flex-col gap-2">
+          <Skeleton className="h-9 w-full" />
+          <Skeleton className="h-9 w-full" />
+          <Skeleton className="h-9 w-full" />
+          <Skeleton className="h-9 w-full" />
+          <Skeleton className="h-9 w-full" />
+        </SkeletonContainer>
+      </div>
+
+      {/* Topbar + content column */}
+      <div className="flex flex-1 flex-col" aria-hidden="true">
+        <div className="flex h-14 items-center gap-3 border-b border-border px-4">
+          <Skeleton className="h-8 w-8 rounded-full" />
+          <Skeleton className="h-5 w-40" />
+        </div>
+        <div className="flex-1 p-4 md:p-6">
+          <SkeletonContainer className="grid grid-cols-1 gap-4 md:grid-cols-3">
+            <Skeleton className="h-24 w-full rounded-xl" />
+            <Skeleton className="h-24 w-full rounded-xl" />
+            <Skeleton className="h-24 w-full rounded-xl" />
+          </SkeletonContainer>
+          <Skeleton className="mt-4 h-64 w-full rounded-xl" />
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/packages/core/src/components/dashboard/layouts/index.ts
+++ b/packages/core/src/components/dashboard/layouts/index.ts
@@ -1,5 +1,6 @@
 export { AuthGuard } from './AuthGuard'
 export { DashboardAuthLayout } from './DashboardAuthLayout'
+export { DashboardAuthSkeleton } from './DashboardAuthSkeleton'
 export { DashboardShell } from './DashboardShell'
 export { Sidebar } from './Sidebar'
 export { TopNavbar } from './TopNavbar'

--- a/packages/core/src/components/entities/EntityFieldRenderer.tsx
+++ b/packages/core/src/components/entities/EntityFieldRenderer.tsx
@@ -447,6 +447,7 @@ function renderFormField(
     case 'timezone':
       return (
         <TimezoneSelect
+          id={baseProps.id}
           value={value as string | undefined}
           onChange={onChange}
           placeholder={field.display.placeholder}
@@ -457,6 +458,7 @@ function renderFormField(
     case 'currency':
       return (
         <CurrencySelect
+          id={baseProps.id}
           value={value as string | undefined}
           onChange={onChange}
           placeholder={field.display.placeholder}
@@ -467,6 +469,7 @@ function renderFormField(
     case 'country':
       return (
         <CountrySelect
+          id={baseProps.id}
           value={value as string | undefined}
           onChange={onChange}
           placeholder={field.display.placeholder}

--- a/packages/core/src/components/ui/combobox.tsx
+++ b/packages/core/src/components/ui/combobox.tsx
@@ -34,6 +34,13 @@ interface ComboboxProps {
   disabled?: boolean
   clearable?: boolean
   className?: string
+  /**
+   * Id applied to the focusable trigger (role="combobox") so a `<label for>`
+   * can target it. Without it the label points at nothing (see #90).
+   */
+  id?: string
+  /** Accessible name for the clear control. */
+  clearLabel?: string
 }
 
 export function Combobox({
@@ -46,10 +53,13 @@ export function Combobox({
   disabled = false,
   clearable = false,
   className,
+  id,
+  clearLabel = "Limpiar selección",
 }: ComboboxProps) {
   const [open, setOpen] = React.useState(false)
 
   const selectedOption = options.find((option) => option.value === value)
+  const showClear = clearable && !disabled && !!selectedOption
 
   const handleSelect = (optionValue: string | number) => {
     if (disabled) return
@@ -59,55 +69,52 @@ export function Combobox({
     setOpen(false)
   }
 
-  const handleClear = (e: React.MouseEvent) => {
-    e.stopPropagation()
+  const handleClear = () => {
     if (disabled) return
     onChange(undefined)
   }
 
   return (
     <Popover open={open} onOpenChange={setOpen}>
-      <PopoverTrigger asChild>
-        <Button
-          variant="outline"
-          role="combobox"
-          aria-expanded={open}
-          className={cn(
-            "w-full justify-between",
-            disabled && "opacity-50 cursor-not-allowed",
-            className
-          )}
-          disabled={disabled}
-        >
-          <span className="truncate">
-            {selectedOption ? selectedOption.label : placeholder}
-          </span>
-          <div className="flex items-center gap-1">
-            {clearable && selectedOption && (
-              <span
-                role="button"
-                tabIndex={0}
-                onClick={handleClear}
-                onKeyDown={(e) => {
-                  if (e.key === "Enter" || e.key === " ") {
-                    e.preventDefault()
-                    // Create a synthetic mouse event for handleClear
-                    const syntheticEvent = {
-                      preventDefault: () => {},
-                      stopPropagation: () => {}
-                    } as React.MouseEvent<HTMLSpanElement>
-                    handleClear(syntheticEvent)
-                  }
-                }}
-                className="h-4 w-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 cursor-pointer"
-              >
-                <X className="h-3 w-3" />
-              </span>
+      {/*
+        The clear control is a real <button> rendered as a SIBLING of the
+        trigger (nesting interactive elements inside the trigger button is
+        invalid). It is absolutely positioned over the trigger's right edge
+        with a 44x44px hit area (touch-target minimum) — see #90.
+      */}
+      <div className="relative w-full">
+        <PopoverTrigger asChild>
+          <Button
+            id={id}
+            variant="outline"
+            role="combobox"
+            aria-expanded={open}
+            className={cn(
+              "w-full justify-between",
+              showClear && "pr-14",
+              disabled && "opacity-50 cursor-not-allowed",
+              className
             )}
+            disabled={disabled}
+          >
+            <span className="truncate">
+              {selectedOption ? selectedOption.label : placeholder}
+            </span>
             <ChevronsUpDown className="h-4 w-4 shrink-0 opacity-50" />
-          </div>
-        </Button>
-      </PopoverTrigger>
+          </Button>
+        </PopoverTrigger>
+        {showClear && (
+          <button
+            type="button"
+            aria-label={clearLabel}
+            title={clearLabel}
+            onClick={handleClear}
+            className="absolute right-7 top-1/2 inline-flex h-11 w-11 -translate-y-1/2 items-center justify-center rounded-sm text-muted-foreground transition-colors hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring cursor-pointer"
+          >
+            <X className="h-3.5 w-3.5" aria-hidden="true" />
+          </button>
+        )}
+      </div>
       <PopoverContent
         className="p-0"
         align="start"

--- a/packages/core/src/components/ui/country-select.tsx
+++ b/packages/core/src/components/ui/country-select.tsx
@@ -121,6 +121,8 @@ interface CountrySelectProps {
   disabled?: boolean
   className?: string
   clearable?: boolean
+  /** Forwarded to the combobox trigger so `<label for>` resolves (see #90) */
+  id?: string
 }
 
 export function CountrySelect({
@@ -130,6 +132,7 @@ export function CountrySelect({
   disabled = false,
   className,
   clearable = true,
+  id,
 }: CountrySelectProps) {
   return (
     <div className="relative">
@@ -143,6 +146,7 @@ export function CountrySelect({
         emptyMessage="No se encontraron países."
         disabled={disabled}
         clearable={clearable}
+        id={id}
         className={cn("pl-10", className)}
       />
     </div>

--- a/packages/core/src/components/ui/currency-select.tsx
+++ b/packages/core/src/components/ui/currency-select.tsx
@@ -50,6 +50,8 @@ interface CurrencySelectProps {
   disabled?: boolean
   className?: string
   clearable?: boolean
+  /** Forwarded to the combobox trigger so `<label for>` resolves (see #90) */
+  id?: string
 }
 
 export function CurrencySelect({
@@ -59,6 +61,7 @@ export function CurrencySelect({
   disabled = false,
   className,
   clearable = true,
+  id,
 }: CurrencySelectProps) {
   return (
     <div className="relative">
@@ -72,6 +75,7 @@ export function CurrencySelect({
         emptyMessage="No se encontraron monedas."
         disabled={disabled}
         clearable={clearable}
+        id={id}
         className={cn("pl-10", className)}
       />
     </div>

--- a/packages/core/src/components/ui/timezone-select.tsx
+++ b/packages/core/src/components/ui/timezone-select.tsx
@@ -45,6 +45,8 @@ interface TimezoneSelectProps {
   disabled?: boolean
   className?: string
   clearable?: boolean
+  /** Forwarded to the combobox trigger so `<label for>` resolves (see #90) */
+  id?: string
 }
 
 export function TimezoneSelect({
@@ -54,6 +56,7 @@ export function TimezoneSelect({
   disabled = false,
   className,
   clearable = true,
+  id,
 }: TimezoneSelectProps) {
   return (
     <div className="relative">
@@ -67,6 +70,7 @@ export function TimezoneSelect({
         emptyMessage="No se encontraron zonas horarias."
         disabled={disabled}
         clearable={clearable}
+        id={id}
         className={cn("pl-10", className)}
       />
     </div>

--- a/packages/core/src/hooks/useEnsureUserMetadata.ts
+++ b/packages/core/src/hooks/useEnsureUserMetadata.ts
@@ -52,6 +52,33 @@ const DEFAULT_METADATA: UserMetadata = {
   }
 }
 
+type MetadataBlock = keyof UserMetadata
+
+const METADATA_BLOCKS = Object.keys(DEFAULT_METADATA) as MetadataBlock[]
+
+/**
+ * Returns the default blocks (uiPreferences, securityPreferences,
+ * notificationsPreferences) that are still missing from the user's meta.
+ *
+ * Each block is checked independently: other flows (onboarding progress, tours,
+ * active team pointer, ...) write their own keys into `meta` early, so an
+ * "is meta empty?" guard would almost never fire for real users (see #119).
+ * Only the missing blocks are returned so existing preferences are never
+ * overwritten.
+ */
+export function getMissingMetadataDefaults(
+  meta: UserMetadata | null | undefined
+): Partial<UserMetadata> {
+  const missing: Partial<UserMetadata> = {}
+  for (const block of METADATA_BLOCKS) {
+    const current = meta?.[block]
+    if (current === null || current === undefined) {
+      missing[block] = DEFAULT_METADATA[block] as never
+    }
+  }
+  return missing
+}
+
 /**
  * Hook to ensure user has default metadata
  * Uses TanStack Query for proper caching and deduplication
@@ -80,9 +107,9 @@ export function useEnsureUserMetadata() {
     gcTime: 30 * 60 * 1000, // 30 minutes cache
   })
 
-  // Mutation to create default metadata
+  // Mutation to create the missing default metadata blocks
   const createMetadataMutation = useMutation({
-    mutationFn: async () => {
+    mutationFn: async (metadata: Partial<UserMetadata>) => {
       const response = await fetch('/api/internal/user-metadata', {
         method: 'POST',
         headers: {
@@ -90,7 +117,7 @@ export function useEnsureUserMetadata() {
         },
         body: JSON.stringify({
           userId,
-          metadata: DEFAULT_METADATA
+          metadata
         })
       })
       if (!response.ok) {
@@ -111,12 +138,13 @@ export function useEnsureUserMetadata() {
   useEffect(() => {
     if (!isFetched || !userData || hasCreatedMetadata.current) return
 
-    const needsMetadata = !userData.meta || Object.keys(userData.meta).length === 0
+    const missingDefaults = getMissingMetadataDefaults(userData.meta)
+    const needsMetadata = Object.keys(missingDefaults).length > 0
 
     if (needsMetadata && !createMetadataMutation.isPending) {
       hasCreatedMetadata.current = true
-      console.log('Creating default metadata for user:', userId)
-      createMetadataMutation.mutate()
+      console.log('Creating default metadata for user:', userId, Object.keys(missingDefaults))
+      createMetadataMutation.mutate(missingDefaults)
     }
   }, [isFetched, userData, userId, createMetadataMutation])
 }

--- a/packages/core/src/lib/api/auth.ts
+++ b/packages/core/src/lib/api/auth.ts
@@ -124,7 +124,7 @@ export async function validateApiKey(request: NextRequest): Promise<ApiKeyAuth |
     // Verificar expiración y actualizar status si es necesario
     if (keyData.expiresAt && new Date(keyData.expiresAt) < new Date()) {
       // Marcar como expirada de forma asíncrona
-      markAsExpired(keyData.id).catch(console.error);
+      markAsExpired(keyData.id, keyHash).catch(console.error);
       await constantTimeDelay(startTime);
       return null;
     }
@@ -181,18 +181,44 @@ async function resetFailedAttempts(keyId: string): Promise<void> {
 /**
  * Marca una API key como expirada
  */
-async function markAsExpired(keyId: string): Promise<void> {
+async function markAsExpired(keyId: string, keyHash: string): Promise<void> {
   try {
     await queryOne(
       'UPDATE "api_key" SET status = $1 WHERE id = $2',
       ['expired', keyId]
     );
     
-    // Invalidar cache
-    const cacheKey = getCacheKey('api_key', keyId);
-    apiKeyCache.delete(cacheKey);
+    // Invalidar cache (la entrada está indexada por hash, no por id)
+    invalidateApiKeyCache(keyHash);
   } catch (error) {
     console.error('Failed to mark API key as expired:', error);
+  }
+}
+
+/**
+ * Elimina del cache la entrada de una API key (indexada por keyHash).
+ *
+ * Debe llamarse cada vez que cambia el `status` de una key (revocación,
+ * desactivación, expiración): validateApiKey() consulta el cache ANTES que la
+ * base de datos, así que sin esta invalidación una key revocada sigue
+ * autenticando hasta que vence el TTL (5 min). Ver #92.
+ */
+export function invalidateApiKeyCache(keyHash: string): void {
+  apiKeyCache.delete(getCacheKey('api_key', keyHash));
+}
+
+/**
+ * Variante por id para los call sites que no tienen el hash a mano.
+ * Hace una lectura extra; preferí invalidateApiKeyCache(keyHash) cuando el
+ * hash ya viene en la fila (por ejemplo vía RETURNING "keyHash").
+ */
+export async function invalidateApiKeyCacheById(keyId: string): Promise<void> {
+  const row = await queryOne<{ keyHash: string }>(
+    'SELECT "keyHash" FROM "api_key" WHERE id = $1',
+    [keyId]
+  );
+  if (row?.keyHash) {
+    invalidateApiKeyCache(row.keyHash);
   }
 }
 

--- a/packages/core/src/lib/billing/gateways/factory.ts
+++ b/packages/core/src/lib/billing/gateways/factory.ts
@@ -10,41 +10,61 @@
  */
 
 import { BILLING_REGISTRY } from '@nextsparkjs/registries/billing-registry'
-import { StripeGateway } from './stripe'
-import { PolarGateway } from './polar'
 import type { BillingGateway } from './interface'
 
 let gatewayInstance: BillingGateway | null = null
+let gatewayLoading: Promise<BillingGateway> | null = null
 
 /**
  * Get the billing gateway for the configured payment provider.
  * Singleton - the same instance is returned on subsequent calls.
  *
  * Provider is determined by BILLING_REGISTRY.config.provider (from billing.config.ts).
+ *
+ * Gateway modules are imported dynamically inside the switch so that only the
+ * configured provider's SDK ends up in the bundle (see #127). Every call site
+ * that transitively imports this factory (root layout resource hints, auth
+ * pages, ...) would otherwise ship every provider SDK.
  */
-export function getBillingGateway(): BillingGateway {
-  if (!gatewayInstance) {
-    const provider = BILLING_REGISTRY.provider
-    switch (provider) {
-      case 'stripe':
-        gatewayInstance = new StripeGateway()
-        break
-      case 'polar':
-        gatewayInstance = new PolarGateway()
-        break
-      // Future providers:
-      // case 'paddle': { ... }
-      // case 'lemonsqueezy': { ... }
-      // case 'mercadopago': { ... }
-      default:
-        throw new Error(
-          `Unsupported billing provider: "${provider}". ` +
-          `Supported providers: stripe, polar. ` +
-          `Check your billing.config.ts provider setting.`
-        )
-    }
+export async function getBillingGateway(): Promise<BillingGateway> {
+  if (gatewayInstance) {
+    return gatewayInstance
   }
-  return gatewayInstance
+  if (!gatewayLoading) {
+    gatewayLoading = loadGateway()
+      .then((gateway) => {
+        gatewayInstance = gateway
+        return gateway
+      })
+      .finally(() => {
+        gatewayLoading = null
+      })
+  }
+  return gatewayLoading
+}
+
+async function loadGateway(): Promise<BillingGateway> {
+  const provider = BILLING_REGISTRY.provider
+  switch (provider) {
+    case 'stripe': {
+      const { StripeGateway } = await import('./stripe')
+      return new StripeGateway()
+    }
+    case 'polar': {
+      const { PolarGateway } = await import('./polar')
+      return new PolarGateway()
+    }
+    // Future providers (each one only enters the bundle when configured):
+    // case 'paddle': { const { PaddleGateway } = await import('./paddle'); return new PaddleGateway() }
+    // case 'lemonsqueezy': { ... }
+    // case 'mercadopago': { ... }
+    default:
+      throw new Error(
+        `Unsupported billing provider: "${provider}". ` +
+        `Supported providers: stripe, polar. ` +
+        `Check your billing.config.ts provider setting.`
+      )
+  }
 }
 
 /**
@@ -55,9 +75,10 @@ export function getBillingGateway(): BillingGateway {
  * // In layout.tsx:
  * const { preconnect, dnsPrefetch } = getBillingResourceHints()
  */
-export function getBillingResourceHints(): { preconnect: string[]; dnsPrefetch: string[] } {
+export async function getBillingResourceHints(): Promise<{ preconnect: string[]; dnsPrefetch: string[] }> {
   try {
-    return getBillingGateway().getResourceHintDomains()
+    const gateway = await getBillingGateway()
+    return gateway.getResourceHintDomains()
   } catch {
     return { preconnect: [], dnsPrefetch: [] }
   }
@@ -69,4 +90,5 @@ export function getBillingResourceHints(): { preconnect: string[]; dnsPrefetch: 
  */
 export function resetBillingGateway(): void {
   gatewayInstance = null
+  gatewayLoading = null
 }

--- a/packages/core/src/lib/billing/stripe-webhook.ts
+++ b/packages/core/src/lib/billing/stripe-webhook.ts
@@ -74,7 +74,8 @@ export async function handleStripeWebhook(
   // and verifyWebhookSignature internally uses Stripe SDK's constructEvent.
   let event: Stripe.Event
   try {
-    const verified = getBillingGateway().verifyWebhookSignature(payload, signature)
+    const gateway = await getBillingGateway()
+    const verified = gateway.verifyWebhookSignature(payload, signature)
     // The webhook event data contains the full Stripe event structure
     event = { id: verified.id, type: verified.type, data: verified.data } as Stripe.Event
   } catch (error) {

--- a/packages/core/src/lib/services/subscription.service.ts
+++ b/packages/core/src/lib/services/subscription.service.ts
@@ -474,7 +474,8 @@ export class SubscriptionService {
 
     // 5. Update via payment provider
     try {
-      await getBillingGateway().updateSubscriptionPlan({
+      const gateway = await getBillingGateway()
+      await gateway.updateSubscriptionPlan({
         subscriptionId: currentSub.externalSubscriptionId,
         newPriceId,
       })

--- a/packages/core/src/messages/de/index.ts
+++ b/packages/core/src/messages/de/index.ts
@@ -6,6 +6,7 @@ import common from './common.json'
 import dashboard from './dashboard.json'
 import devtools from './devtools.json'
 import docs from './docs.json'
+import email from './email.json'
 import entities from './entities.json'
 import footer from './footer.json'
 import home from './home.json'
@@ -27,6 +28,7 @@ export default {
   dashboard,
   devtools,
   docs,
+  email,
   entities,
   footer,
   home,

--- a/packages/core/src/messages/en/index.ts
+++ b/packages/core/src/messages/en/index.ts
@@ -6,6 +6,7 @@ import common from './common.json'
 import dashboard from './dashboard.json'
 import devtools from './devtools.json'
 import docs from './docs.json'
+import email from './email.json'
 import entities from './entities.json'
 import footer from './footer.json'
 import home from './home.json'
@@ -28,6 +29,7 @@ export default {
   dashboard,
   devtools,
   docs,
+  email,
   entities,
   footer,
   home,

--- a/packages/core/src/messages/es/index.ts
+++ b/packages/core/src/messages/es/index.ts
@@ -6,6 +6,7 @@ import common from './common.json'
 import dashboard from './dashboard.json'
 import devtools from './devtools.json'
 import docs from './docs.json'
+import email from './email.json'
 import entities from './entities.json'
 import footer from './footer.json'
 import home from './home.json'
@@ -28,6 +29,7 @@ export default {
   dashboard,
   devtools,
   docs,
+  email,
   entities,
   footer,
   home,

--- a/packages/core/src/messages/fr/index.ts
+++ b/packages/core/src/messages/fr/index.ts
@@ -6,6 +6,7 @@ import common from './common.json'
 import dashboard from './dashboard.json'
 import devtools from './devtools.json'
 import docs from './docs.json'
+import email from './email.json'
 import entities from './entities.json'
 import footer from './footer.json'
 import home from './home.json'
@@ -27,6 +28,7 @@ export default {
   dashboard,
   devtools,
   docs,
+  email,
   entities,
   footer,
   home,

--- a/packages/core/src/messages/it/index.ts
+++ b/packages/core/src/messages/it/index.ts
@@ -6,6 +6,7 @@ import common from './common.json'
 import dashboard from './dashboard.json'
 import devtools from './devtools.json'
 import docs from './docs.json'
+import email from './email.json'
 import entities from './entities.json'
 import footer from './footer.json'
 import home from './home.json'
@@ -27,6 +28,7 @@ export default {
   dashboard,
   devtools,
   docs,
+  email,
   entities,
   footer,
   home,

--- a/packages/core/src/messages/pt/index.ts
+++ b/packages/core/src/messages/pt/index.ts
@@ -6,6 +6,7 @@ import common from './common.json'
 import dashboard from './dashboard.json'
 import devtools from './devtools.json'
 import docs from './docs.json'
+import email from './email.json'
 import entities from './entities.json'
 import footer from './footer.json'
 import home from './home.json'
@@ -27,6 +28,7 @@ export default {
   dashboard,
   devtools,
   docs,
+  email,
   entities,
   footer,
   home,

--- a/packages/core/templates/contents/themes/starter/styles/globals.css
+++ b/packages/core/templates/contents/themes/starter/styles/globals.css
@@ -200,8 +200,12 @@
 /* =============================================
    BASE STYLES
    ============================================= */
-* {
-  border-color: var(--border);
+/* Must live in @layer base: un-layered rules beat every Tailwind v4 utility
+   (border-primary, border-destructive, ...) regardless of specificity. */
+@layer base {
+  * {
+    border-color: var(--border);
+  }
 }
 
 body {

--- a/packages/core/templates/proxy.ts
+++ b/packages/core/templates/proxy.ts
@@ -64,8 +64,47 @@ function isPublicPath(pathname: string): boolean {
   )
 }
 
+/**
+ * Identity headers this proxy injects for downstream server code.
+ *
+ * SECURITY (#87): these headers are trusted by RSC layouts and permission
+ * checks, so an inbound value must NEVER reach the app. They are stripped from
+ * every request before any path branching and re-added only from the verified
+ * session. Gating the strip on protected prefixes is not enough: Next.js
+ * dispatches Server Actions by the `Next-Action` header, not by the URL, so an
+ * action can be POSTed to a public path with a forged `x-user-id`.
+ */
+const TRUSTED_IDENTITY_HEADERS = ['x-user-id', 'x-user-email', 'x-pathname'] as const
+
+/**
+ * Build the request headers forwarded to the app: inbound copy minus every
+ * trusted identity header, plus the real pathname.
+ */
+function sanitizeRequestHeaders(request: NextRequest): Headers {
+  const headers = new Headers(request.headers)
+  for (const name of TRUSTED_IDENTITY_HEADERS) {
+    headers.delete(name)
+  }
+  headers.set('x-pathname', request.nextUrl.pathname)
+  return headers
+}
+
+/**
+ * Continue to the app with the (sanitized) request headers.
+ * Every pass-through in this proxy MUST go through here so the strip applies
+ * to public paths, /api/v1 and unmatched routes alike.
+ */
+function passThrough(requestHeaders: Headers): NextResponse {
+  return NextResponse.next({
+    request: { headers: requestHeaders },
+  })
+}
+
 export async function proxy(request: NextRequest) {
   const { pathname } = request.nextUrl
+
+  // 0. Strip forgeable identity headers before ANY branching (see #87)
+  const requestHeaders = sanitizeRequestHeaders(request)
 
   // 1. Check for theme middleware override
   const activeTheme = process.env.NEXT_PUBLIC_ACTIVE_THEME
@@ -114,17 +153,17 @@ export async function proxy(request: NextRequest) {
         return NextResponse.redirect(loginUrl)
       }
     }
-    return NextResponse.next()
+    return passThrough(requestHeaders)
   }
 
   // 4. Allow public paths
   if (isPublicPath(pathname)) {
-    return NextResponse.next()
+    return passThrough(requestHeaders)
   }
 
   // 5. API v1 routes handle their own dual authentication
   if (pathname.startsWith('/api/v1')) {
-    return NextResponse.next()
+    return passThrough(requestHeaders)
   }
 
   // 6. Protected routes - require authentication and inject user headers
@@ -162,20 +201,17 @@ export async function proxy(request: NextRequest) {
         }
       }
 
-      // Inject user headers for downstream use
+      // Inject user headers for downstream use, ONLY from the verified session
+      // (requestHeaders already had any inbound values stripped).
       // IMPORTANT: EntityPermissionLayout depends on these headers
-      const requestHeaders = new Headers(request.headers)
       if (session.user?.id) {
         requestHeaders.set('x-user-id', session.user.id)
       }
       if (session.user?.email) {
         requestHeaders.set('x-user-email', session.user.email)
       }
-      requestHeaders.set('x-pathname', pathname)
 
-      return NextResponse.next({
-        request: { headers: requestHeaders },
-      })
+      return passThrough(requestHeaders)
     } catch (error) {
       console.error('Proxy error:', error)
       const loginUrl = new URL('/login', request.url)
@@ -184,7 +220,7 @@ export async function proxy(request: NextRequest) {
     }
   }
 
-  return NextResponse.next()
+  return passThrough(requestHeaders)
 }
 
 export const config = {

--- a/packages/core/tests/jest/__mocks__/next-server.js
+++ b/packages/core/tests/jest/__mocks__/next-server.js
@@ -9,6 +9,14 @@ class MockNextRequest {
     this.method = options.method || 'GET'
     this.headers = new Map(Object.entries(options.headers || {}))
     this._body = options.body
+    // Minimal nextUrl (pathname/origin/searchParams/clone) for proxy/middleware tests
+    try {
+      const parsed = new URL(url, 'http://localhost')
+      parsed.clone = () => new URL(parsed.toString())
+      this.nextUrl = parsed
+    } catch {
+      this.nextUrl = undefined
+    }
   }
 
   async json() {
@@ -47,6 +55,22 @@ class MockNextResponse {
       ...options,
       headers: { 'Content-Type': 'application/json', ...options.headers }
     })
+  }
+
+  // Pass-through response. Keeps the forwarded request headers (if any) so
+  // middleware/proxy tests can assert what reaches the app.
+  static next(init = {}) {
+    const response = new MockNextResponse(null, { status: 200, headers: init.headers })
+    response.type = 'next'
+    response.requestHeaders = init.request && init.request.headers ? init.request.headers : null
+    return response
+  }
+
+  static redirect(url, status = 307) {
+    const response = new MockNextResponse(null, { status, headers: { Location: String(url) } })
+    response.type = 'redirect'
+    response.redirectUrl = String(url)
+    return response
   }
 }
 

--- a/packages/core/tests/jest/components/dashboard/layouts/DashboardAuthSkeleton.test.tsx
+++ b/packages/core/tests/jest/components/dashboard/layouts/DashboardAuthSkeleton.test.tsx
@@ -1,0 +1,29 @@
+/**
+ * @jest-environment jsdom
+ *
+ * Dashboard auth-gate skeleton (#91): the loading state is a structural shell
+ * (sidebar rail, topbar, content placeholders) announced as busy, not a bare
+ * spinner on a blank screen.
+ */
+import { describe, test, expect } from '@jest/globals'
+import { render, screen } from '@testing-library/react'
+import { DashboardAuthSkeleton } from '@/core/components/dashboard/layouts/DashboardAuthSkeleton'
+
+describe('DashboardAuthSkeleton (#91)', () => {
+  test('renders an accessible busy shell with sidebar, topbar and content placeholders', () => {
+    const { container } = render(<DashboardAuthSkeleton />)
+
+    const shell = screen.getByRole('status')
+    expect(shell).toHaveAttribute('data-cy', 'dashboard-loading-skeleton')
+    expect(shell).toHaveAttribute('aria-busy', 'true')
+
+    // Sidebar rail only from md: up (no phantom sidebar on mobile)
+    const sidebar = container.querySelector('.md\\:w-64')
+    expect(sidebar).not.toBeNull()
+    expect(sidebar).toHaveClass('hidden', 'md:flex')
+
+    // Several skeleton blocks, all theme-token based (bg-muted)
+    const blocks = container.querySelectorAll('.bg-muted')
+    expect(blocks.length).toBeGreaterThanOrEqual(10)
+  })
+})

--- a/packages/core/tests/jest/components/ui/combobox.test.tsx
+++ b/packages/core/tests/jest/components/ui/combobox.test.tsx
@@ -1,0 +1,61 @@
+/**
+ * @jest-environment jsdom
+ *
+ * Combobox accessibility contract (#90):
+ * - the focusable trigger (role="combobox") carries the `id` so a <label for>
+ *   resolves to a real element
+ * - the clear control is a real <button> with an accessible name, rendered as
+ *   a sibling of the trigger (not nested inside it), sized for touch (44px)
+ */
+import { describe, test, expect, jest } from '@jest/globals'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { Combobox } from '@/core/components/ui/combobox'
+import { TimezoneSelect } from '@/core/components/ui/timezone-select'
+
+const options = [
+  { value: 'a', label: 'Option A' },
+  { value: 'b', label: 'Option B' },
+]
+
+describe('Combobox (#90)', () => {
+  test('applies the id to the combobox trigger so <label for> resolves', () => {
+    render(
+      <>
+        <label htmlFor="field-tz">Timezone</label>
+        <Combobox id="field-tz" options={options} value="a" onChange={() => {}} />
+      </>
+    )
+    const trigger = screen.getByRole('combobox')
+    expect(trigger).toHaveAttribute('id', 'field-tz')
+    expect(document.getElementById('field-tz')).toBe(trigger)
+    expect(screen.getByLabelText('Timezone')).toBe(trigger)
+  })
+
+  test('renders the clear control as a labelled button outside the trigger with a 44px hit area', () => {
+    const onChange = jest.fn()
+    render(<Combobox options={options} value="a" onChange={onChange} clearable clearLabel="Clear timezone" />)
+
+    const clear = screen.getByRole('button', { name: 'Clear timezone' })
+    expect(clear.tagName).toBe('BUTTON')
+    expect(clear).toHaveAttribute('type', 'button')
+    expect(clear).toHaveClass('h-11', 'w-11')
+    // Not nested inside the combobox trigger (interactive-in-interactive is invalid)
+    expect(screen.getByRole('combobox').contains(clear)).toBe(false)
+
+    fireEvent.click(clear)
+    expect(onChange).toHaveBeenCalledWith(undefined)
+  })
+
+  test('does not render a clear control without a selection or when disabled', () => {
+    const { rerender } = render(<Combobox options={options} value={undefined} onChange={() => {}} clearable />)
+    expect(screen.queryByRole('button', { name: /limpiar|clear/i })).toBeNull()
+
+    rerender(<Combobox options={options} value="a" onChange={() => {}} clearable disabled />)
+    expect(screen.queryByRole('button', { name: /limpiar|clear/i })).toBeNull()
+  })
+
+  test('TimezoneSelect forwards the id to the trigger', () => {
+    render(<TimezoneSelect id="field-timezone" value="UTC" onChange={() => {}} />)
+    expect(screen.getByRole('combobox')).toHaveAttribute('id', 'field-timezone')
+  })
+})

--- a/packages/core/tests/jest/hooks/useEnsureUserMetadata.test.ts
+++ b/packages/core/tests/jest/hooks/useEnsureUserMetadata.test.ts
@@ -1,0 +1,64 @@
+/**
+ * useEnsureUserMetadata — per-block default seeding (#119)
+ *
+ * The old guard (`!meta || Object.keys(meta).length === 0`) only fired when
+ * meta was completely empty, so any early write (onboarding, tours, active
+ * team) silently disabled seeding. Each preference block must be checked
+ * independently and only the missing ones sent, so existing data is never
+ * overwritten.
+ */
+import { describe, test, expect, jest } from '@jest/globals'
+
+jest.mock('@tanstack/react-query', () => ({
+  useQuery: jest.fn(),
+  useMutation: jest.fn(),
+  useQueryClient: jest.fn(),
+}))
+jest.mock('../../../src/lib/auth-client', () => ({
+  authClient: { useSession: jest.fn() },
+}))
+jest.mock('../../../src/hooks/useUserSettings', () => ({
+  USER_PROFILE_WITH_META_QUERY_KEY: (id?: string) => ['user-profile-with-meta', id],
+}))
+
+import { getMissingMetadataDefaults } from '../../../src/hooks/useEnsureUserMetadata'
+
+const ALL_BLOCKS = ['uiPreferences', 'securityPreferences', 'notificationsPreferences']
+
+describe('getMissingMetadataDefaults', () => {
+  test('returns every block when meta is missing or empty', () => {
+    expect(Object.keys(getMissingMetadataDefaults(undefined)).sort()).toEqual([...ALL_BLOCKS].sort())
+    expect(Object.keys(getMissingMetadataDefaults(null)).sort()).toEqual([...ALL_BLOCKS].sort())
+    expect(Object.keys(getMissingMetadataDefaults({})).sort()).toEqual([...ALL_BLOCKS].sort())
+  })
+
+  test('still seeds all preference blocks when unrelated keys were written first', () => {
+    const meta = { onboardingProgress: { step: 3 }, activeTeamId: 'team-1' } as Record<string, unknown>
+    const missing = getMissingMetadataDefaults(meta)
+
+    expect(Object.keys(missing).sort()).toEqual([...ALL_BLOCKS].sort())
+    // Never touches the keys other flows own
+    expect(missing).not.toHaveProperty('onboardingProgress')
+    expect(missing).not.toHaveProperty('activeTeamId')
+  })
+
+  test('only returns the blocks that are actually missing', () => {
+    const missing = getMissingMetadataDefaults({
+      uiPreferences: { theme: 'dark', sidebarCollapsed: true },
+      notificationsPreferences: { pushEnabled: false },
+    })
+
+    expect(Object.keys(missing)).toEqual(['securityPreferences'])
+    expect(missing.securityPreferences).toEqual({ loginAlertsEnabled: true })
+  })
+
+  test('returns nothing when every block already exists (even if partially filled)', () => {
+    const missing = getMissingMetadataDefaults({
+      uiPreferences: {},
+      securityPreferences: {},
+      notificationsPreferences: {},
+    })
+
+    expect(missing).toEqual({})
+  })
+})

--- a/packages/core/tests/jest/lib/api/api-key-cache-invalidation.test.ts
+++ b/packages/core/tests/jest/lib/api/api-key-cache-invalidation.test.ts
@@ -1,0 +1,104 @@
+/**
+ * API key cache invalidation (#92)
+ *
+ * validateApiKey() consults an in-process cache BEFORE the database, so a
+ * revoked key kept authenticating for up to 5 minutes. Status changes must
+ * drop the cached entry so the next request re-reads the row.
+ */
+import { describe, test, expect, jest, beforeEach } from '@jest/globals'
+import type { NextRequest } from 'next/server'
+
+jest.mock('../../../../src/lib/db', () => ({
+  queryOne: jest.fn(),
+}))
+
+import { queryOne } from '../../../../src/lib/db'
+import { ApiKeyManager } from '../../../../src/lib/api/keys'
+import {
+  validateApiKey,
+  invalidateApiKeyCache,
+  invalidateApiKeyCacheById,
+} from '../../../../src/lib/api/auth'
+
+const mockedQueryOne = queryOne as unknown as jest.Mock
+
+function requestWithKey(key: string): NextRequest {
+  return {
+    headers: {
+      get: (header: string) => (header === 'Authorization' ? `Bearer ${key}` : null),
+    },
+  } as unknown as NextRequest
+}
+
+function activeRow(id: string, userId = 'user-1') {
+  return {
+    id,
+    userId,
+    scopes: ['users:read'],
+    status: 'active',
+    expiresAt: null,
+    failedAttempts: 0,
+    lockedUntil: null,
+  }
+}
+
+/** Only count the SELECT that looks the key up (not lastUsedAt updates etc.) */
+function lookupCalls() {
+  return mockedQueryOne.mock.calls.filter(([sql]) => String(sql).includes('WHERE "keyHash"')).length
+}
+
+describe('API key cache invalidation (#92)', () => {
+  beforeEach(() => {
+    mockedQueryOne.mockReset()
+  })
+
+  test('a revoked key keeps authenticating from cache until the entry is invalidated', async () => {
+    const { key, hash } = await ApiKeyManager.generateApiKey()
+    const keyId = 'key-revoke-test'
+
+    mockedQueryOne.mockImplementation(async (sql: string) => {
+      if (String(sql).includes('WHERE "keyHash"')) return activeRow(keyId)
+      return null
+    })
+
+    // 1. First use populates the cache
+    expect(await validateApiKey(requestWithKey(key))).toMatchObject({ keyId })
+    expect(lookupCalls()).toBe(1)
+
+    // 2. The key is revoked in the DB, but the cache still says active
+    mockedQueryOne.mockImplementation(async (sql: string) => {
+      if (String(sql).includes('WHERE "keyHash"')) return { ...activeRow(keyId), status: 'inactive' }
+      return null
+    })
+    expect(await validateApiKey(requestWithKey(key))).toMatchObject({ keyId })
+    expect(lookupCalls()).toBe(1) // served from cache: this is the bug window
+
+    // 3. Invalidating (what the revoke endpoint now does) forces a re-read → rejected
+    invalidateApiKeyCache(hash)
+    expect(await validateApiKey(requestWithKey(key))).toBeNull()
+    expect(lookupCalls()).toBe(2)
+  })
+
+  test('invalidateApiKeyCacheById resolves the hash and drops the entry', async () => {
+    const { key, hash } = await ApiKeyManager.generateApiKey()
+    const keyId = 'key-by-id-test'
+
+    mockedQueryOne.mockImplementation(async (sql: string) => {
+      if (String(sql).includes('WHERE "keyHash"')) return activeRow(keyId)
+      if (String(sql).includes('SELECT "keyHash"')) return { keyHash: hash }
+      return null
+    })
+
+    expect(await validateApiKey(requestWithKey(key))).toMatchObject({ keyId })
+    expect(lookupCalls()).toBe(1)
+
+    await invalidateApiKeyCacheById(keyId)
+
+    mockedQueryOne.mockImplementation(async (sql: string) => {
+      if (String(sql).includes('WHERE "keyHash"')) return { ...activeRow(keyId), status: 'inactive' }
+      return null
+    })
+    expect(await validateApiKey(requestWithKey(key))).toBeNull()
+    expect(lookupCalls()).toBe(2)
+  })
+})

--- a/packages/core/tests/jest/lib/billing/stripe.test.ts
+++ b/packages/core/tests/jest/lib/billing/stripe.test.ts
@@ -495,21 +495,27 @@ describe('Stripe Gateway', () => {
   // ===========================================
 
   describe('getBillingGateway() factory', () => {
-    test('should return a StripeGateway when provider is stripe', () => {
-      const gw = getBillingGateway()
+    test('should return a StripeGateway when provider is stripe', async () => {
+      const gw = await getBillingGateway()
       expect(gw).toBeInstanceOf(StripeGateway)
     })
 
-    test('should return the same singleton instance', () => {
-      const gw1 = getBillingGateway()
-      const gw2 = getBillingGateway()
+    test('should return the same singleton instance', async () => {
+      const gw1 = await getBillingGateway()
+      const gw2 = await getBillingGateway()
       expect(gw1).toBe(gw2)
     })
 
-    test('should return a new instance after reset', () => {
-      const gw1 = getBillingGateway()
+    test('should share one instance across concurrent first calls', async () => {
       resetBillingGateway()
-      const gw2 = getBillingGateway()
+      const [gw1, gw2] = await Promise.all([getBillingGateway(), getBillingGateway()])
+      expect(gw1).toBe(gw2)
+    })
+
+    test('should return a new instance after reset', async () => {
+      const gw1 = await getBillingGateway()
+      resetBillingGateway()
+      const gw2 = await getBillingGateway()
       expect(gw1).not.toBe(gw2)
     })
   })

--- a/packages/core/tests/jest/templates/proxy.test.ts
+++ b/packages/core/tests/jest/templates/proxy.test.ts
@@ -1,0 +1,95 @@
+/**
+ * Proxy identity-header hardening (#87)
+ *
+ * Inbound x-user-id / x-user-email / x-pathname must never reach the app:
+ * they are stripped on EVERY path (public, /api/v1, unmatched) and re-added
+ * only from the verified session on protected routes.
+ */
+import { describe, test, expect, jest, beforeEach } from '@jest/globals'
+
+jest.mock('@better-fetch/fetch', () => ({
+  betterFetch: jest.fn(),
+}))
+
+jest.mock('@nextsparkjs/core/lib/middleware', () => ({
+  hasThemeMiddleware: () => false,
+  executeThemeMiddleware: jest.fn(),
+  getThemeAppConfig: () => undefined,
+}))
+
+import { betterFetch } from '@better-fetch/fetch'
+import { NextRequest } from 'next/server'
+import { proxy } from '../../../templates/proxy'
+
+type PassThrough = { type?: string; requestHeaders?: Headers | null; redirectUrl?: string }
+
+const FORGED = {
+  'x-user-id': 'attacker-controlled-id',
+  'x-user-email': 'attacker@example.com',
+  'x-pathname': '/admin',
+}
+
+function makeRequest(path: string, extraHeaders: Record<string, string> = {}) {
+  const request = new NextRequest(`http://localhost:3000${path}`, { method: 'POST' }) as unknown as NextRequest
+  // Use the global Headers polyfill (tests/jest/setup.ts) so `new Headers(request.headers)`
+  // inside the proxy copies the inbound headers exactly like the runtime does.
+  ;(request as unknown as { headers: Headers }).headers = new Headers({
+    ...FORGED,
+    'next-action': 'abc123',
+    cookie: '',
+    ...extraHeaders,
+  })
+  return request
+}
+
+const mockedFetch = betterFetch as unknown as jest.Mock
+
+describe('proxy identity headers (#87)', () => {
+  beforeEach(() => {
+    mockedFetch.mockReset()
+    delete process.env.NEXT_PUBLIC_ACTIVE_THEME
+  })
+
+  test.each([
+    ['public path', '/login'],
+    ['root', '/'],
+    ['api v1', '/api/v1/teams'],
+    ['unmatched path', '/some-marketing-page'],
+  ])('strips forged identity headers on %s', async (_label, path) => {
+    const response = (await proxy(makeRequest(path))) as unknown as PassThrough
+
+    expect(response.type).toBe('next')
+    const forwarded = response.requestHeaders as Headers
+    expect(forwarded).toBeTruthy()
+    expect(forwarded.get('x-user-id')).toBeNull()
+    expect(forwarded.get('x-user-email')).toBeNull()
+    // x-pathname is always the real pathname, never the inbound value
+    expect(forwarded.get('x-pathname')).toBe(path)
+    // Unrelated headers still pass through
+    expect(forwarded.get('next-action')).toBe('abc123')
+    expect(mockedFetch).not.toHaveBeenCalled()
+  })
+
+  test('re-adds identity headers only from the verified session on protected routes', async () => {
+    mockedFetch.mockResolvedValue({
+      data: { user: { id: 'real-user-id', email: 'real@example.com', role: 'member' } },
+    })
+
+    const response = (await proxy(makeRequest('/dashboard'))) as unknown as PassThrough
+
+    expect(response.type).toBe('next')
+    const forwarded = response.requestHeaders as Headers
+    expect(forwarded.get('x-user-id')).toBe('real-user-id')
+    expect(forwarded.get('x-user-email')).toBe('real@example.com')
+    expect(forwarded.get('x-pathname')).toBe('/dashboard')
+  })
+
+  test('redirects to login on protected routes without a session (forged header does not help)', async () => {
+    mockedFetch.mockResolvedValue({ data: null })
+
+    const response = (await proxy(makeRequest('/dashboard'))) as unknown as PassThrough
+
+    expect(response.type).toBe('redirect')
+    expect(response.redirectUrl).toContain('/login')
+  })
+})


### PR DESCRIPTION
## Description
Batch of 11 small, mutually-independent fixes (no shared files between them), plus closing a duplicate issue.

## Changes
- #104 (+#109 closed as duplicate): theme catalog endpoint now requires auth before exposing `availableEndpoints`
- #127: billing gateway factory uses dynamic `import()` per provider instead of importing every SDK statically
- #111: 19 API routes pass `request` through to `handleCorsPreflightRequest`/`addCorsHeaders`
- #103: starter theme's global border-color rule wrapped in `@layer base`
- #92: revoking/expiring an API key now invalidates its cache immediately (also fixed `markAsExpired` deleting by id instead of hash)
- #87: proxy strips trusted identity headers unconditionally before any branch, re-injecting only from a real session
- #100: `email.json` wired into the message index of all 6 locales (was rendering raw i18n keys)
- #119: `useEnsureUserMetadata` checks/seeds each preferences block independently instead of all-or-nothing
- #91: shared `DashboardAuthSkeleton` replaces the bare spinner in the auth-gate across 3 layout files
- #90: `TimezoneSelect`/`Combobox` clear button is a real 44px target with `aria-label`, and the trigger has a matching `id`
- #85: `InvoicesTable` formats dates/currency with `useLocale()` instead of hardcoded `en-US`

## Testing
- [x] Live verification against a disposable database for #104 (anon vs. authenticated), #92 (revoke → immediate 401), #99-adjacent invite flow re-confirmed already fixed on `main`
- [x] Unit/render tests added for #92, #87, #119, #91, #90
- [x] Full core suite: only the 3 known pre-existing failures

## Related Issues
- Fixes #104, #127, #111, #103, #92, #87, #100, #119, #91, #90, #85
- Closes #109 (duplicate of #104)