### PR TITLE
[#101][#117][#113] Fix superadmin multi-team reporting and Sheet accessibility

### DIFF
--- a/apps/dev/app/api/superadmin/users/[userId]/route.ts
+++ b/apps/dev/app/api/superadmin/users/[userId]/route.ts
@@ -129,11 +129,18 @@ export const GET = withRateLimitTier(async (request: NextRequest, { params }: Ro
       ORDER BY "metaKey"
     `;
 
-    // Execute all queries in parallel
+    // Execute all queries in parallel.
+    //
+    // The team_members queries run on the service (RLS-bypass) pool: team_members
+    // has no superadmin/developer bypass policy, so with the acting admin's own
+    // id as RLS context the SELECT policy silently ANDs "teams the actor belongs
+    // to" on top of WHERE "userId" = $1 and under-reports multi-team users.
+    // Authorization is already enforced above (superadmin/developer role check)
+    // and the WHERE clause scopes the rows to the subject user.
     const [userResults, teamsResults, countsResults, metasResults] = await Promise.all([
       queryWithRLS(userQuery, [userId], session.user.id) as Promise<UserResult[]>,
-      queryWithRLS(teamsQuery, [userId], session.user.id) as Promise<TeamMembershipResult[]>,
-      queryWithRLS(countsQuery, [userId], session.user.id) as Promise<{
+      queryWithRLS(teamsQuery, [userId], session.user.id, { service: true }) as Promise<TeamMembershipResult[]>,
+      queryWithRLS(countsQuery, [userId], session.user.id, { service: true }) as Promise<{
         totalTeams: number;
         ownedTeams: number;
       }[]>,

--- a/packages/core/src/components/ui/sheet.tsx
+++ b/packages/core/src/components/ui/sheet.tsx
@@ -48,29 +48,82 @@ const sheetVariants = cva(
   }
 )
 
+/**
+ * Registration channel between `SheetContent` and `SheetDescription`.
+ *
+ * Radix warns at runtime when a Dialog content has `aria-describedby` but no
+ * matching `Description` element in the DOM. `SheetContent` renders a visually
+ * hidden fallback description by default and drops it as soon as a real
+ * `SheetDescription` registers itself, so consumers get an accessible Sheet
+ * out of the box without duplicating descriptions when they do provide one.
+ */
+type UnregisterDescription = () => void
+const SheetDescriptionContext = React.createContext<(() => UnregisterDescription) | null>(null)
+
+// useLayoutEffect on the client so the fallback is swapped before paint;
+// useEffect on the server where layout effects are a no-op.
+const useIsomorphicLayoutEffect =
+  typeof window !== "undefined" ? React.useLayoutEffect : React.useEffect
+
+/**
+ * Close button: 44x44px hit area (WCAG 2.5.5 / platform tap-target minimum)
+ * around a 16px glyph. `right-0.5 top-0.5` + `h-11 w-11` keeps the glyph at the
+ * same visual spot as the previous `right-4 top-4` 16px button.
+ */
+const sheetCloseButtonClassName =
+  "absolute right-0.5 top-0.5 inline-flex h-11 w-11 items-center justify-center rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-accent"
+
 interface SheetContentProps
   extends React.ComponentPropsWithoutRef<typeof SheetPrimitive.Content>,
-    VariantProps<typeof sheetVariants> {}
+    VariantProps<typeof sheetVariants> {
+  /**
+   * Extra classes merged onto the built-in close button (position, size,
+   * colors...). The default already meets the 44x44px touch target.
+   */
+  closeButtonClassName?: string
+}
 
 const SheetContent = React.forwardRef<
   React.ElementRef<typeof SheetPrimitive.Content>,
   SheetContentProps
->(({ side = "right", className, children, ...props }, ref) => (
-  <SheetPortal>
-    <SheetOverlay />
-    <SheetPrimitive.Content
-      ref={ref}
-      className={cn(sheetVariants({ side }), className)}
-      {...props}
-    >
-      <SheetPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-accent">
-        <Cross2Icon className="h-4 w-4" />
-        <span className="sr-only">Close</span>
-      </SheetPrimitive.Close>
-      {children}
-    </SheetPrimitive.Content>
-  </SheetPortal>
-))
+>(({ side = "right", className, closeButtonClassName, children, ...props }, ref) => {
+  const [hasDescription, setHasDescription] = React.useState(false)
+  const descriptionCount = React.useRef(0)
+
+  const registerDescription = React.useCallback((): UnregisterDescription => {
+    descriptionCount.current += 1
+    setHasDescription(true)
+    return () => {
+      descriptionCount.current -= 1
+      if (descriptionCount.current === 0) setHasDescription(false)
+    }
+  }, [])
+
+  return (
+    <SheetPortal>
+      <SheetOverlay />
+      <SheetPrimitive.Content
+        ref={ref}
+        className={cn(sheetVariants({ side }), className)}
+        {...props}
+      >
+        <SheetDescriptionContext.Provider value={registerDescription}>
+          <SheetPrimitive.Close className={cn(sheetCloseButtonClassName, closeButtonClassName)}>
+            <Cross2Icon className="h-4 w-4" aria-hidden="true" />
+            <span className="sr-only">Close</span>
+          </SheetPrimitive.Close>
+          {children}
+          {/*
+            Fallback description (see SheetDescriptionContext). Rendered after
+            `children` so, during the single commit where both can coexist,
+            the consumer's description wins the `aria-describedby` lookup.
+          */}
+          {!hasDescription && <SheetPrimitive.Description className="sr-only" />}
+        </SheetDescriptionContext.Provider>
+      </SheetPrimitive.Content>
+    </SheetPortal>
+  )
+})
 SheetContent.displayName = SheetPrimitive.Content.displayName
 
 const SheetHeader = ({
@@ -116,13 +169,21 @@ SheetTitle.displayName = SheetPrimitive.Title.displayName
 const SheetDescription = React.forwardRef<
   React.ElementRef<typeof SheetPrimitive.Description>,
   React.ComponentPropsWithoutRef<typeof SheetPrimitive.Description>
->(({ className, ...props }, ref) => (
-  <SheetPrimitive.Description
-    ref={ref}
-    className={cn("text-sm text-muted-foreground", className)}
-    {...props}
-  />
-))
+>(({ className, ...props }, ref) => {
+  const registerDescription = React.useContext(SheetDescriptionContext)
+
+  // Tell the enclosing SheetContent a real description exists so it drops
+  // its visually hidden fallback. No-op when used outside SheetContent.
+  useIsomorphicLayoutEffect(() => registerDescription?.(), [registerDescription])
+
+  return (
+    <SheetPrimitive.Description
+      ref={ref}
+      className={cn("text-sm text-muted-foreground", className)}
+      {...props}
+    />
+  )
+})
 SheetDescription.displayName = SheetPrimitive.Description.displayName
 
 export {

--- a/packages/core/tests/jest/components/ui/sheet.test.tsx
+++ b/packages/core/tests/jest/components/ui/sheet.test.tsx
@@ -1,0 +1,137 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { describe, test, expect, jest, beforeEach, afterEach } from '@jest/globals'
+import { render, screen, cleanup } from '@testing-library/react'
+import type { ReactNode } from 'react'
+import {
+  Sheet,
+  SheetContent,
+  SheetHeader,
+  SheetTitle,
+  SheetDescription,
+} from '@/core/components/ui/sheet'
+
+const RADIX_MISSING_DESCRIPTION = 'Missing `Description`'
+
+function renderOpenSheet(content: ReactNode) {
+  return render(
+    <Sheet open onOpenChange={() => {}}>
+      {content}
+    </Sheet>
+  )
+}
+
+function getDialog() {
+  return screen.getByRole('dialog')
+}
+
+function getCloseButton() {
+  return screen.getByRole('button', { name: /close/i })
+}
+
+describe('Sheet', () => {
+  let warnSpy: ReturnType<typeof jest.spyOn>
+
+  beforeEach(() => {
+    warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {})
+  })
+
+  afterEach(() => {
+    warnSpy.mockRestore()
+    cleanup()
+  })
+
+  const missingDescriptionWarnings = () =>
+    warnSpy.mock.calls.filter(
+      ([message]) => typeof message === 'string' && message.includes(RADIX_MISSING_DESCRIPTION)
+    )
+
+  describe('Description fallback (#113)', () => {
+    test('does not trigger the Radix "Missing Description" warning when no SheetDescription is passed', () => {
+      renderOpenSheet(
+        <SheetContent side="bottom">
+          <SheetHeader>
+            <SheetTitle>Sort</SheetTitle>
+          </SheetHeader>
+        </SheetContent>
+      )
+
+      expect(missingDescriptionWarnings()).toHaveLength(0)
+    })
+
+    test('renders a visually hidden fallback description that aria-describedby resolves to', () => {
+      renderOpenSheet(
+        <SheetContent>
+          <SheetTitle>Sort</SheetTitle>
+        </SheetContent>
+      )
+
+      const dialog = getDialog()
+      const describedById = dialog.getAttribute('aria-describedby')
+      expect(describedById).toBeTruthy()
+
+      const description = document.getElementById(describedById as string)
+      expect(description).not.toBeNull()
+      expect(dialog).toContainElement(description)
+      expect(description).toHaveClass('sr-only')
+    })
+
+    test('uses the consumer SheetDescription instead of the fallback when one is provided', () => {
+      renderOpenSheet(
+        <SheetContent>
+          <SheetHeader>
+            <SheetTitle>Sort</SheetTitle>
+            <SheetDescription>Choose how the list is ordered</SheetDescription>
+          </SheetHeader>
+        </SheetContent>
+      )
+
+      const describedById = getDialog().getAttribute('aria-describedby') as string
+      const matches = document.querySelectorAll(`[id="${describedById}"]`)
+
+      expect(matches).toHaveLength(1)
+      expect(matches[0]).toHaveTextContent('Choose how the list is ordered')
+      expect(matches[0]).not.toHaveClass('sr-only')
+      expect(missingDescriptionWarnings()).toHaveLength(0)
+    })
+  })
+
+  describe('Close button tap target (#117)', () => {
+    test('renders the default close button with a 44x44 hit area', () => {
+      renderOpenSheet(
+        <SheetContent>
+          <SheetTitle>Sort</SheetTitle>
+        </SheetContent>
+      )
+
+      expect(getCloseButton()).toHaveClass('h-11', 'w-11')
+    })
+
+    test('merges closeButtonClassName onto the close button (tailwind-merge resolves conflicts)', () => {
+      renderOpenSheet(
+        <SheetContent closeButtonClassName="right-2 top-2 text-red-500">
+          <SheetTitle>Sort</SheetTitle>
+        </SheetContent>
+      )
+
+      const closeButton = getCloseButton()
+      expect(closeButton).toHaveClass('right-2', 'top-2', 'text-red-500')
+      expect(closeButton).not.toHaveClass('right-0.5', 'top-0.5')
+    })
+
+    test('does not leak closeButtonClassName onto the content element', () => {
+      renderOpenSheet(
+        <SheetContent closeButtonClassName="text-red-500">
+          <SheetTitle>Sort</SheetTitle>
+        </SheetContent>
+      )
+
+      const dialog = getDialog()
+      expect(dialog).not.toHaveClass('text-red-500')
+      expect(dialog).not.toHaveAttribute('closeButtonClassName')
+      expect(dialog).not.toHaveAttribute('closebuttonclassname')
+    })
+  })
+})


### PR DESCRIPTION
## Description
Two unrelated small fixes bundled together (no shared files, neither justified its own branch alone).

## Changes
- #101: superadmin user-detail endpoint now bypasses RLS (`{service: true}`) when reading team memberships, instead of being scoped to the acting admin — was under-reporting team counts for multi-team users
- #117 / #113: `Sheet`'s close button now has a real 44×44px hit area (`closeButtonClassName` prop) and `SheetContent` auto-renders a `VisuallyHidden` `Description` fallback when none is passed, removing the Radix accessibility warning

## Testing
- [x] #101 reproduced and verified against a live database with a real multi-team user
- [x] #117/#113: close button hit-area measured at 44×44 in Chromium at 360px viewport, 6 new Jest tests
- [x] Full core suite: only the 3 known pre-existing failures

## Related Issues
- Fixes #101, #117, #113