### PR TITLE
[#96][#118][#97][#105] Fix SQL injection in generic list, missing hooks, and add audit logging

### DIFF
--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -39,6 +39,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     `mcp:<tool>` endpoint prefix.
   - New dependency: `@modelcontextprotocol/sdk` (`zod` was already in core's dependency tree).
   - New package export: `@nextsparkjs/core/lib/mcp`.
+- **Audit logging for the generic entity routes (#105).** Every authenticated
+  request to `/api/v1/[entity]` and `/api/v1/[entity]/[id]` — session or
+  API-key — now writes an `api_audit_log` row (endpoint, method, status code,
+  IP, user agent, response time; `apiKeyId` for API keys, `NULL` for
+  sessions). Logging is fire-and-forget and never affects the response. The
+  request body is not stored.
+  - **Migration `025_api_audit_log_nullable_api_key.sql`** drops the `NOT NULL`
+    on `api_audit_log."apiKeyId"` (the FK is unchanged). Run `db:migrate`.
+  - `DualAuthResult` gains `keyId` (the authenticating `api_key.id`) so the
+    audit row can be attributed without an extra lookup.
+  - MCP tool calls now produce two rows: the existing `mcp:<tool>` row and the
+    underlying API call's row.
 
 ### Security
 
@@ -120,13 +132,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     with the constraint name; `23503` on create/update → `422
     FOREIGN_KEY_VIOLATION` (was: opaque `500`). `23505` → `409` and delete
     `23503` → `409` are unchanged.
-
-### Known Limitations
-
-- Requests against the generic entity routes (`/api/v1/[entity]`) — session or
-  API-key — are still not written to `api_audit_log`; that table's `apiKeyId`
-  column is `NOT NULL`, so closing this gap needs a migration and a new logging
-  path, tracked separately from the fixes above.
 
 ## [0.1.0-beta.167]
 

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -97,6 +97,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   the write; a thrown error rejects the create with `400
   BEFORE_CREATE_REJECTED` (or the 4xx `status` the error carries).
 
+- **Generic entity handler no longer fails silently on bad list parameters,
+  unknown body keys, or CHECK-constraint violations (#97).** Each of these used
+  to return a plausible-looking wrong answer instead of an error the caller
+  could act on:
+  - `?search=` on an entity with none of `name`/`title`/`slug`/`content` → `400
+    SEARCH_NOT_SUPPORTED` (was: every row, unfiltered).
+  - A custom filter whose key is not an entity field (`?statuz=active`) → `400
+    INVALID_FILTER` naming the key(s) (was: filter silently dropped). Legacy
+    client params (`includeMeta`, `userId`, `sort`/`order`, `userFiltered`)
+    stay accepted; `sort`/`order` now work as aliases of `sortBy`/`sortOrder`.
+  - An invalid `?sortBy=` → `400 INVALID_SORT_FIELD` (was: silent default sort).
+  - `?dateField=2026-01-15` on a `date`/`datetime` field matches the whole
+    day (`>= day AND < day + 1`) instead of an equality that never matched a
+    timestamp; values with a time component keep exact equality.
+  - Create/update schemas from `generateEntitySchemas` are now `.strict()`:
+    an unknown body key (`notes` for `note`) → `400 VALIDATION_ERROR` with an
+    `unrecognized_keys` issue (was: silently stripped, `201`). Keys the handler
+    consumes itself (`metas`, `userId`, `teamId`, taxonomy relation arrays,
+    builder `blocks`/`settings`) are unaffected.
+  - PostgreSQL `23514` CHECK violations → `422 CHECK_CONSTRAINT_VIOLATION`
+    with the constraint name; `23503` on create/update → `422
+    FOREIGN_KEY_VIOLATION` (was: opaque `500`). `23505` → `409` and delete
+    `23503` → `409` are unchanged.
+
 ### Known Limitations
 
 - Requests against the generic entity routes (`/api/v1/[entity]`) — session or

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -88,6 +88,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   validated first (`400 INVALID_FIELD`) through the same `isEntityField` check
   both branches share.
 
+### Fixed
+
+- **`beforeEntityCreate` is now invoked by the generic create handler (#118).**
+  `POST /api/v1/{entity}` only fired `afterEntityCreate`, so the
+  `entity.<slug>.before_create` filter could neither reshape nor reject a
+  payload before the INSERT. The hook now runs after authorization and before
+  the write; a thrown error rejects the create with `400
+  BEFORE_CREATE_REJECTED` (or the 4xx `status` the error carries).
+
 ### Known Limitations
 
 - Requests against the generic entity routes (`/api/v1/[entity]`) — session or

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -80,6 +80,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   field restrictions — broader access than the same user's own session. All three
   checks now run identically for both auth types.
 
+- **SQL identifier injection in the generic list `distinct` query (#96).**
+  `GET /api/v1/{entity}?fields=X&distinct=true` interpolated the raw `fields`
+  value as a quoted SQL identifier without validating it against the entity's
+  fields — unlike the sibling non-distinct branch — so any caller with
+  `<slug>:read` could inject SQL into the SELECT list. The name is now
+  validated first (`400 INVALID_FIELD`) through the same `isEntityField` check
+  both branches share.
+
 ### Known Limitations
 
 - Requests against the generic entity routes (`/api/v1/[entity]`) — session or

--- a/packages/core/docs/05-api/03-dynamic-endpoints.md
+++ b/packages/core/docs/05-api/03-dynamic-endpoints.md
@@ -164,6 +164,27 @@ export const OPTIONS = handleGenericOptions // CORS
 | `child` | LIST, READ | Include child entities |
 | `{field}={value}` | LIST | Custom field filtering |
 
+### Parameter validation
+
+Unsupported list parameters are **rejected with `400`** rather than silently
+ignored, so a typo never produces a plausible-looking but wrong result:
+
+| Situation | Status | `code` |
+|-----------|--------|--------|
+| `{field}` is not a declared entity field (e.g. `?statuz=active`) | 400 | `INVALID_FILTER` — `details.invalidKeys` lists the offending keys |
+| `sortBy` is neither an entity field nor `id`/`createdAt`/`updatedAt`/`teamId` | 400 | `INVALID_SORT_FIELD` |
+| `search` on an entity with none of `name`/`title`/`slug`/`content` | 400 | `SEARCH_NOT_SUPPORTED` |
+| `fields=X&distinct=true` where `X` is not an entity field | 400 | `INVALID_FIELD` |
+
+Filtering a `date`/`datetime` field with a bare calendar day
+(`?publishedAt=2026-01-15`) matches the **whole day** (`>= 2026-01-15 AND
+< 2026-01-16`). A value with a time component is compared for exact equality.
+Use `dateField`/`from`/`to` for arbitrary ranges.
+
+Create/update bodies are validated with **strict** schemas: an unknown key
+(e.g. `notes` when the field is `note`) returns `400 VALIDATION_ERROR` with an
+`unrecognized_keys` issue instead of being dropped.
+
 ---
 
 ## LIST Operation (GET)
@@ -827,6 +848,16 @@ X-API-Key: sk_live_abc123...  (alternative to Authorization)
   }
 }
 ```
+
+Database integrity errors on write operations are mapped to client errors
+instead of a generic `500`:
+
+| PostgreSQL error | Status | `code` |
+|------------------|--------|--------|
+| `23505` unique violation | 409 | `UNIQUE_CONSTRAINT_VIOLATION` |
+| `23514` CHECK constraint violation | 422 | `CHECK_CONSTRAINT_VIOLATION` — `details.constraint` names the constraint |
+| `23503` foreign key violation on create/update (dangling reference) | 422 | `FOREIGN_KEY_VIOLATION` |
+| `23503` foreign key violation on delete (row still referenced) | 409 | `FOREIGN_KEY_VIOLATION` |
 
 ---
 

--- a/packages/core/migrations/005_api_audit_log.sql
+++ b/packages/core/migrations/005_api_audit_log.sql
@@ -3,7 +3,8 @@
 
 CREATE TABLE IF NOT EXISTS "api_audit_log" (
   id TEXT PRIMARY KEY DEFAULT gen_random_uuid()::text,
-  "apiKeyId" TEXT NOT NULL REFERENCES public."api_key"(id) ON DELETE CASCADE,
+  -- NULL for session-authenticated requests (see 025_api_audit_log_nullable_api_key.sql)
+  "apiKeyId" TEXT REFERENCES public."api_key"(id) ON DELETE CASCADE,
   "userId"   TEXT NOT NULL REFERENCES public."users"(id) ON DELETE CASCADE,
   endpoint   TEXT NOT NULL,
   method     TEXT NOT NULL,

--- a/packages/core/migrations/025_api_audit_log_nullable_api_key.sql
+++ b/packages/core/migrations/025_api_audit_log_nullable_api_key.sql
@@ -1,0 +1,12 @@
+-- Migration: 025_api_audit_log_nullable_api_key.sql
+-- Description: Allow api_audit_log rows without an API key (#105)
+--
+-- The generic entity routes (/api/v1/[entity], /api/v1/[entity]/[id]) now
+-- write an audit row for every authenticated request, whether it was
+-- authenticated with an API key or with a browser session. Session requests
+-- have no key, so "apiKeyId" must accept NULL. The foreign key stays as-is:
+-- a FK only constrains non-null values.
+--
+-- Idempotent: DROP NOT NULL on an already-nullable column is a no-op.
+
+ALTER TABLE "api_audit_log" ALTER COLUMN "apiKeyId" DROP NOT NULL;

--- a/packages/core/src/components/entities/wrappers/EntityFormWrapper.tsx
+++ b/packages/core/src/components/entities/wrappers/EntityFormWrapper.tsx
@@ -54,6 +54,9 @@ export function EntityFormWrapper({
 
   const [initialData, setInitialData] = useState<Record<string, unknown>>(propsInitialData || {})
   const [isLoadingData, setIsLoadingData] = useState(false)
+  // Last failed save, shown inside the form (#97 follow-up). Before, a 400 from
+  // the API only reached console.error/onError and the Save button looked inert.
+  const [submitError, setSubmitError] = useState<string | null>(null)
 
   // Load initial data for edit mode or use provided initialData for create mode
   useEffect(() => {
@@ -91,6 +94,7 @@ export function EntityFormWrapper({
   }, [mode, id, entityType, entityConfig, onError, isOverride, propsInitialData])
 
   const handleSubmit = useCallback(async (data: Record<string, unknown>) => {
+    setSubmitError(null)
     try {
       console.log(`${mode === 'create' ? 'Creating' : 'Updating'} ${entityType}:`, data)
 
@@ -104,8 +108,10 @@ export function EntityFormWrapper({
         onSuccess?.(id)
       }
     } catch (error) {
-      console.error(`❌ Failed to ${mode} ${entityType}:`, error)
-      onError?.(error instanceof Error ? error : new Error(`Failed to ${mode} ${entityType}`))
+      const failure = error instanceof Error ? error : new Error(`Failed to ${mode} ${entityType}`)
+      console.error(`❌ Failed to ${mode} ${entityType}:`, failure)
+      setSubmitError(failure.message)
+      onError?.(failure)
     }
   }, [entityType, mode, id, onSuccess, onError])
 
@@ -162,6 +168,7 @@ export function EntityFormWrapper({
           mode={mode}
           initialData={initialData}
           onSubmit={handleSubmit}
+          error={submitError}
           className={className}
           teamId={teamId}
         />

--- a/packages/core/src/lib/api/auth/dual-auth.ts
+++ b/packages/core/src/lib/api/auth/dual-auth.ts
@@ -55,6 +55,8 @@ export interface DualAuthResult {
   type: 'api-key' | 'session' | 'none'
   user: DualAuthUser | null
   scopes?: string[]
+  /** `api_key.id` of the key that authenticated the request (type 'api-key' only). Used for audit logging (#105). */
+  keyId?: string
   rateLimitResponse?: Response
   /** Set when a dev-only x-act-as-user override replaced the real caller. */
   actingAs?: { originalUserId: string; originalRole: string }
@@ -221,7 +223,8 @@ async function tryApiKeyAuth(request: NextRequest): Promise<DualAuthResult> {
         name: userInfo?.name,
         defaultTeamId
       },
-      scopes: apiAuth.scopes || []
+      scopes: apiAuth.scopes || [],
+      keyId: apiAuth.keyId
     }
   } catch (error) {
     console.error('API Key auth failed:', error)

--- a/packages/core/src/lib/api/entity/audit-log.ts
+++ b/packages/core/src/lib/api/entity/audit-log.ts
@@ -1,0 +1,73 @@
+/**
+ * Audit logging for the generic entity routes (#105).
+ *
+ * `logApiUsage` (lib/api/helpers.ts) is hard-typed to `ApiKeyAuth` and is
+ * only triggered by the legacy `withApiLogging` wrapper, whose header-based
+ * `getApiAuth` never sees the dual-auth flow the generic handlers use — so
+ * neither session nor API-key activity on `/api/v1/[entity]` was ever
+ * written to `api_audit_log`.
+ *
+ * This module accepts the real `DualAuthResult` the handlers already hold and
+ * writes one row per authenticated request (`apiKeyId` is NULL for sessions;
+ * migration 025 dropped the NOT NULL). It is invoked fire-and-forget from
+ * `runWithAuditLog` in generic-handler.ts, so a logging failure can never turn
+ * a successful response into an error.
+ *
+ * The request body is deliberately NOT stored: entity payloads routinely
+ * carry personal data, and endpoint + method + status already identify what
+ * was touched (the record id is part of the path for read/update/delete).
+ */
+
+import type { NextRequest } from 'next/server'
+import { mutateWithRLS } from '../../db'
+import type { DualAuthResult } from '../auth/dual-auth'
+
+/**
+ * Mutable slot a handler fills in once it has authenticated the request, so
+ * the wrapper can attribute the response to a user / API key.
+ */
+export interface AuditContext {
+  auth: DualAuthResult | null
+}
+
+export async function logGenericHandlerUsage(
+  auth: DualAuthResult | null,
+  request: NextRequest,
+  statusCode: number,
+  responseTime?: number
+): Promise<void> {
+  // Unauthenticated requests (public reads, 401s) have no principal to
+  // attribute the row to — "userId" is NOT NULL and that is intentional.
+  const userId = auth?.success ? auth.user?.id : undefined
+  if (!userId) return
+
+  const apiKeyId = auth?.type === 'api-key' ? auth.keyId ?? null : null
+
+  try {
+    const endpoint = request.nextUrl.pathname
+    const method = request.method
+    const ipAddress = request.headers.get('x-forwarded-for') || request.headers.get('x-real-ip') || 'unknown'
+    const userAgent = request.headers.get('user-agent')
+
+    await mutateWithRLS(
+      `INSERT INTO "api_audit_log"
+       ("apiKeyId", "userId", endpoint, method, "statusCode", "ipAddress", "userAgent", "requestBody", "responseTime")
+       VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)`,
+      [
+        apiKeyId,
+        userId,
+        endpoint,
+        method,
+        statusCode,
+        ipAddress,
+        userAgent,
+        null,
+        typeof responseTime === 'number' ? Math.round(responseTime) : null,
+      ],
+      userId
+    )
+  } catch (error) {
+    // Never break the response; never fail silently either.
+    console.error('[generic-handler:audit] failed to write api_audit_log entry:', error)
+  }
+}

--- a/packages/core/src/lib/api/entity/generic-handler.ts
+++ b/packages/core/src/lib/api/entity/generic-handler.ts
@@ -32,6 +32,7 @@ import {
   handleCorsPreflightRequest
 } from '../helpers'
 import { beforeEntityCreate, afterEntityCreate, afterEntityUpdate, afterEntityDelete } from '../../entities/entity-hooks'
+import { logGenericHandlerUsage, type AuditContext } from './audit-log'
 import { checkPermission } from '../../permissions/check'
 import type { Permission } from '../../permissions/types'
 import { extractPatternIds } from '../../blocks/pattern-resolver'
@@ -754,10 +755,48 @@ async function validateTeamContextWithBypass(
   return { valid: true, teamId, isBypass: false }
 }
 
+// ==========================================
+// AUDIT LOGGING (#105)
+// ==========================================
+
+/**
+ * Run a handler implementation and record the outcome in api_audit_log.
+ *
+ * The implementation receives a mutable AuditContext and stores the
+ * DualAuthResult in it as soon as the request is authenticated; whatever
+ * status the handler ends up returning (200, 403, 429, 500…) is logged against
+ * that principal. Unauthenticated requests are not logged (no principal).
+ *
+ * Logging is fire-and-forget: it is started before the response is returned
+ * but never awaited, and logGenericHandlerUsage swallows its own errors, so a
+ * failing audit write can never turn a successful response into an error.
+ */
+async function runWithAuditLog(
+  request: NextRequest,
+  run: (audit: AuditContext) => Promise<NextResponse>
+): Promise<NextResponse> {
+  const startedAt = Date.now()
+  const audit: AuditContext = { auth: null }
+  let statusCode = 500
+  try {
+    const response = await run(audit)
+    statusCode = response.status
+    return response
+  } finally {
+    logGenericHandlerUsage(audit.auth, request, statusCode, Date.now() - startedAt).catch(error => {
+      console.error('[generic-handler:audit] unexpected audit failure:', error)
+    })
+  }
+}
+
 /**
  * Generic LIST handler (GET /api/v1/[entity])
  */
 export async function handleGenericList(request: NextRequest): Promise<NextResponse> {
+  return runWithAuditLog(request, audit => handleGenericListImpl(request, audit))
+}
+
+async function handleGenericListImpl(request: NextRequest, audit: AuditContext): Promise<NextResponse> {
   try {
     // Resolve entity from URL
     const resolution = await resolveEntityFromUrl(request.nextUrl.pathname)
@@ -775,6 +814,7 @@ export async function handleGenericList(request: NextRequest): Promise<NextRespo
 
     // Authenticate request
     const authResult = await authenticateRequest(request)
+    audit.auth = authResult
     let userId: string | null = null
     let teamId: string | null = null
     let isBypass = false  // Track if admin bypass is active (skip userId filter)
@@ -1334,6 +1374,10 @@ export async function handleGenericList(request: NextRequest): Promise<NextRespo
  * Generic CREATE handler (POST /api/v1/[entity])
  */
 export async function handleGenericCreate(request: NextRequest): Promise<NextResponse> {
+  return runWithAuditLog(request, audit => handleGenericCreateImpl(request, audit))
+}
+
+async function handleGenericCreateImpl(request: NextRequest, audit: AuditContext): Promise<NextResponse> {
   try {
     // Resolve entity from URL
     const resolution = await resolveEntityFromUrl(request.nextUrl.pathname)
@@ -1351,6 +1395,7 @@ export async function handleGenericCreate(request: NextRequest): Promise<NextRes
 
     // Authenticate request
     const authResult = await authenticateRequest(request)
+    audit.auth = authResult
 
     if (!authResult.success) {
       return NextResponse.json(
@@ -1766,6 +1811,10 @@ export async function handleGenericCreate(request: NextRequest): Promise<NextRes
  * Generic READ handler (GET /api/v1/[entity]/[id])
  */
 export async function handleGenericRead(request: NextRequest, { params }: { params: Promise<{ entity: string; id: string }> }): Promise<NextResponse> {
+  return runWithAuditLog(request, audit => handleGenericReadImpl(request, audit, { params }))
+}
+
+async function handleGenericReadImpl(request: NextRequest, audit: AuditContext, { params }: { params: Promise<{ entity: string; id: string }> }): Promise<NextResponse> {
   try {
     const { id } = await params
 
@@ -1785,6 +1834,7 @@ export async function handleGenericRead(request: NextRequest, { params }: { para
 
     // Authenticate request
     const authResult = await authenticateRequest(request)
+    audit.auth = authResult
     let userId: string | null = null
     let teamId: string | null = null
     let isBypass = false  // Track if admin bypass is active (skip userId filter)
@@ -1973,6 +2023,10 @@ export async function handleGenericRead(request: NextRequest, { params }: { para
  * Generic UPDATE handler (PATCH /api/v1/[entity]/[id])
  */
 export async function handleGenericUpdate(request: NextRequest, { params }: { params: Promise<{ entity: string; id: string }> }): Promise<NextResponse> {
+  return runWithAuditLog(request, audit => handleGenericUpdateImpl(request, audit, { params }))
+}
+
+async function handleGenericUpdateImpl(request: NextRequest, audit: AuditContext, { params }: { params: Promise<{ entity: string; id: string }> }): Promise<NextResponse> {
   try {
     const { id } = await params
 
@@ -1992,6 +2046,7 @@ export async function handleGenericUpdate(request: NextRequest, { params }: { pa
 
     // Authenticate request
     const authResult = await authenticateRequest(request)
+    audit.auth = authResult
 
     if (!authResult.success) {
       return NextResponse.json(
@@ -2355,6 +2410,10 @@ export async function handleGenericUpdate(request: NextRequest, { params }: { pa
  * Generic DELETE handler (DELETE /api/v1/[entity]/[id])
  */
 export async function handleGenericDelete(request: NextRequest, { params }: { params: Promise<{ entity: string; id: string }> }): Promise<NextResponse> {
+  return runWithAuditLog(request, audit => handleGenericDeleteImpl(request, audit, { params }))
+}
+
+async function handleGenericDeleteImpl(request: NextRequest, audit: AuditContext, { params }: { params: Promise<{ entity: string; id: string }> }): Promise<NextResponse> {
   try {
     const { id } = await params
 
@@ -2374,6 +2433,7 @@ export async function handleGenericDelete(request: NextRequest, { params }: { pa
 
     // Authenticate request
     const authResult = await authenticateRequest(request)
+    audit.auth = authResult
 
     if (!authResult.success) {
       return NextResponse.json(

--- a/packages/core/src/lib/api/entity/generic-handler.ts
+++ b/packages/core/src/lib/api/entity/generic-handler.ts
@@ -31,7 +31,7 @@ import {
   addCorsHeaders,
   handleCorsPreflightRequest
 } from '../helpers'
-import { afterEntityCreate, afterEntityUpdate, afterEntityDelete } from '../../entities/entity-hooks'
+import { beforeEntityCreate, afterEntityCreate, afterEntityUpdate, afterEntityDelete } from '../../entities/entity-hooks'
 import { checkPermission } from '../../permissions/check'
 import type { Permission } from '../../permissions/types'
 import { extractPatternIds } from '../../blocks/pattern-resolver'
@@ -319,6 +319,24 @@ function getTableName(entityConfig: EntityConfig): string {
  */
 function isEntityField(entityConfig: EntityConfig, fieldName: string): boolean {
   return entityConfig.fields.some((field: EntityField) => field.name === fieldName)
+}
+
+/**
+ * HTTP status to use when a `before_*` entity hook rejects a write by
+ * throwing. A hook may attach a numeric 4xx `status` (or `statusCode`) to the
+ * error to pick the response code (e.g. 403 for an ownership violation);
+ * anything else is reported as a 400 — never a 500, since a hook rejection is
+ * a validation outcome the caller can act on, not a server fault.
+ */
+function hookRejectionStatus(error: unknown): number {
+  if (error && typeof error === 'object') {
+    const candidate = (error as { status?: unknown; statusCode?: unknown }).status
+      ?? (error as { statusCode?: unknown }).statusCode
+    if (typeof candidate === 'number' && candidate >= 400 && candidate < 500) {
+      return candidate
+    }
+  }
+  return 400
 }
 
 // ==========================================
@@ -1191,7 +1209,7 @@ export async function handleGenericCreate(request: NextRequest): Promise<NextRes
       return addCorsHeaders(response, request)
     }
 
-    const validatedData = validation.data
+    let validatedData = validation.data as Record<string, unknown>
 
     // Reject HTML markup in name/title fields (stored-XSS prevention)
     const xssField = checkNameFieldXss(entityConfig, validatedData as Record<string, unknown>)
@@ -1263,6 +1281,31 @@ export async function handleGenericCreate(request: NextRequest): Promise<NextRes
     // and API-key auth, in addition to the coarse `:write` scope check above.
     const permDenied = await checkAuthPermission(authResult, entityConfig.slug, 'create', teamId, request)
     if (permDenied) return permDenied
+
+    // #118: pre-write extension point, mirroring the beforeEntityUpdate
+    // contract. Plugins registered on `entity.<slug>.before_create` receive the
+    // validated payload — plus the resolved `userId`/`teamId` for context (both
+    // are stamped by the handler below and ignored if the hook changes them) —
+    // and may return a modified payload, or throw to reject the create before
+    // anything is persisted.
+    try {
+      validatedData = await beforeEntityCreate(
+        entityConfig.slug,
+        { ...validatedData, userId: userIdToUse, teamId },
+        authResult.user!.id
+      )
+    } catch (hookError) {
+      console.error(`[generic-handler] beforeEntityCreate rejected ${entityConfig.slug} create:`, hookError)
+      const response = createApiError(
+        hookError instanceof Error && hookError.message
+          ? hookError.message
+          : `Create rejected by ${entityConfig.slug} before_create hook`,
+        hookRejectionStatus(hookError),
+        undefined,
+        'BEFORE_CREATE_REJECTED'
+      )
+      return addCorsHeaders(response, request)
+    }
 
     if (idStrategy === 'serial') {
       // SERIAL: Let database generate ID via DEFAULT/SERIAL

--- a/packages/core/src/lib/api/entity/generic-handler.ts
+++ b/packages/core/src/lib/api/entity/generic-handler.ts
@@ -309,6 +309,18 @@ function getTableName(entityConfig: EntityConfig): string {
   return entityConfig.tableName || entityConfig.slug
 }
 
+/**
+ * Whether `fieldName` is a declared field of the entity.
+ *
+ * Every place that turns a caller-supplied name into a SQL identifier
+ * (`?fields=`, `?fields=X&distinct=true`, `?sortBy=`, custom filters) MUST go
+ * through this check first — an unvalidated name lands inside a quoted
+ * identifier position and becomes a SQL injection vector (#96).
+ */
+function isEntityField(entityConfig: EntityConfig, fieldName: string): boolean {
+  return entityConfig.fields.some((field: EntityField) => field.name === fieldName)
+}
+
 // ==========================================
 // PATTERN REFERENCE HELPER FUNCTIONS
 // ==========================================
@@ -680,6 +692,19 @@ export async function handleGenericList(request: NextRequest): Promise<NextRespo
     if (fieldsParam && distinctParam) {
       // For distinct field queries (like relation-prop), handle specially
       const fieldName = fieldsParam
+
+      // #96: the name is interpolated as a SQL identifier below (and inside
+      // handleDistinctJsonbField), so it must be a declared entity field.
+      if (!isEntityField(entityConfig, fieldName)) {
+        const response = createApiError(
+          `Invalid field for distinct query: ${fieldName}`,
+          400,
+          undefined,
+          'INVALID_FIELD'
+        )
+        return addCorsHeaders(response, request)
+      }
+
       const isJsonbField = fieldName === 'contentLanguages' || fieldName === 'brandValues' || fieldName === 'hashtags'
 
       if (isJsonbField) {
@@ -692,9 +717,7 @@ export async function handleGenericList(request: NextRequest): Promise<NextRespo
     } else if (fieldsParam) {
       // Specific fields requested
       const requestedFields = fieldsParam.split(',').map(f => f.trim())
-      const validFields = requestedFields.filter(fieldName =>
-          entityConfig.fields.some(field => field.name === fieldName)
-      )
+      const validFields = requestedFields.filter(fieldName => isEntityField(entityConfig, fieldName))
 
       fields = ['id', ...validFields]
           .map(fieldName => {

--- a/packages/core/src/lib/api/entity/generic-handler.ts
+++ b/packages/core/src/lib/api/entity/generic-handler.ts
@@ -321,6 +321,156 @@ function isEntityField(entityConfig: EntityConfig, fieldName: string): boolean {
   return entityConfig.fields.some((field: EntityField) => field.name === fieldName)
 }
 
+// ==========================================
+// LIST PARAMETER VALIDATION (#97)
+// ==========================================
+
+/**
+ * Query-string keys the list handler (or the helpers it delegates to)
+ * consumes itself. Anything else is treated as a custom field filter and MUST
+ * name a declared entity field — unknown keys are rejected with 400 instead
+ * of being silently dropped.
+ *
+ * Legacy / client-side keys that existing callers send and that this handler
+ * does not act on — reserved so they keep working instead of becoming 400s:
+ * - `meta`, `includeMeta`, `userId`: sent by EntityApiClient.list
+ *   (lib/api/entities.ts) and older clients; metadata is requested via `metas`.
+ * - `userFiltered`: sent by SimpleRelationSelect for distinct lookups.
+ * - `sort` / `order`: aliases of `sortBy` / `sortOrder` (PublicEntityGrid).
+ */
+const LIST_RESERVED_PARAMS = new Set([
+  'page', 'limit', 'fields', 'distinct', 'ids', 'parentId', 'search',
+  'sortBy', 'sortOrder', 'sort', 'order', 'child', 'meta', 'metas',
+  'includeMeta', 'userId', 'from', 'to', 'dateField', 'userFiltered',
+])
+
+/** Taxonomy filter params, accepted only when the entity has taxonomies enabled. */
+const TAXONOMY_FILTER_PARAMS = ['categoryId', 'taxonomyId', 'taxonomyType']
+
+/** Fields `?search=` matches against (any that the entity declares). */
+const SEARCHABLE_FIELDS = ['name', 'title', 'slug', 'content']
+
+/** Base columns every entity table has that may be used for `?sortBy=`. */
+const SORTABLE_BASE_FIELDS = ['id', 'createdAt', 'updatedAt', 'teamId']
+
+/** A bare calendar day (no time component), e.g. `2026-01-15`. */
+const BARE_DATE_RE = /^\d{4}-\d{2}-\d{2}$/
+
+// ==========================================
+// BODY HANDLING (#97)
+// ==========================================
+
+/**
+ * Keys of a create/update body that the handler consumes itself rather than
+ * through the entity schema: the row owner/team (stamped from auth), and the
+ * taxonomy relation arrays (persisted via processTaxonomyRelations). They are
+ * removed before Zod validation so the strict entity schema only judges the
+ * caller's field payload.
+ */
+function omitHandlerManagedKeys(
+  entityConfig: EntityConfig,
+  data: Record<string, unknown>
+): Record<string, unknown> {
+  const managed = new Set(['userId', 'teamId'])
+  if (entityConfig.taxonomies?.enabled) {
+    for (const taxonomyType of entityConfig.taxonomies.types ?? []) {
+      managed.add(taxonomyType.field)
+    }
+  }
+  return Object.fromEntries(Object.entries(data).filter(([key]) => !managed.has(key)))
+}
+
+/**
+ * Human-readable summary for a failed body validation. Unknown keys get
+ * called out by name so a typo'd field is obvious from the message alone.
+ */
+function validationErrorMessage(issues: Array<{ code: string; keys?: string[] }>): string {
+  const unknownKeys = issues
+    .filter(issue => issue.code === 'unrecognized_keys')
+    .flatMap(issue => issue.keys ?? [])
+  return unknownKeys.length > 0
+    ? `Unknown field(s): ${unknownKeys.join(', ')}`
+    : 'Validation error'
+}
+
+// ==========================================
+// DATABASE CONSTRAINT ERRORS (#97)
+// ==========================================
+
+interface PgConstraintError {
+  code: string
+  constraint?: string
+  detail?: string
+  table?: string
+}
+
+function asPgError(error: unknown): PgConstraintError | null {
+  if (error && typeof error === 'object' && 'code' in error && typeof (error as { code: unknown }).code === 'string') {
+    return error as PgConstraintError
+  }
+  return null
+}
+
+/**
+ * Map a PostgreSQL integrity-constraint error (SQLSTATE class 23) to a
+ * client-facing response, or null when the error is not one of those.
+ *
+ * - 23505 unique_violation      → 409 UNIQUE_CONSTRAINT_VIOLATION
+ * - 23514 check_violation       → 422 CHECK_CONSTRAINT_VIOLATION
+ * - 23503 foreign_key_violation → 409 on delete (row still referenced),
+ *                                 422 on create/update (dangling reference)
+ *
+ * Anything else falls through to the generic 500 in the caller. A CHECK
+ * violation is an application-level rule the caller can satisfy by changing
+ * the input, so it must not be reported as a server fault.
+ */
+function mapConstraintViolation(
+  error: unknown,
+  operation: 'create' | 'update' | 'delete'
+): ReturnType<typeof createApiError> | null {
+  const pgError = asPgError(error)
+  if (!pgError) return null
+  const { constraint, detail, table } = pgError
+
+  switch (pgError.code) {
+    case '23505':
+      return createApiError(
+        'A record with this value already exists',
+        409,
+        { constraint, detail },
+        'UNIQUE_CONSTRAINT_VIOLATION'
+      )
+    case '23514':
+      // `detail` for a CHECK violation echoes the whole failing row; only the
+      // constraint identity is useful (and safe) to return.
+      return createApiError(
+        constraint
+          ? `Value rejected by check constraint "${constraint}"`
+          : 'Value rejected by a database check constraint',
+        422,
+        { constraint, table },
+        'CHECK_CONSTRAINT_VIOLATION'
+      )
+    case '23503':
+      if (operation === 'delete') {
+        return createApiError(
+          detail || 'Cannot delete: this record is referenced by other records',
+          409,
+          { constraint },
+          'FOREIGN_KEY_VIOLATION'
+        )
+      }
+      return createApiError(
+        detail ? `Referenced record does not exist: ${detail}` : 'Referenced record does not exist',
+        422,
+        { constraint, detail },
+        'FOREIGN_KEY_VIOLATION'
+      )
+    default:
+      return null
+  }
+}
+
 /**
  * HTTP status to use when a `before_*` entity hook rejects a write by
  * throwing. A hook may attach a numeric 4xx `status` (or `statusCode`) to the
@@ -689,10 +839,9 @@ export async function handleGenericList(request: NextRequest): Promise<NextRespo
 
     // Parse custom filters (any searchParam that isn't a known param)
     // Supports both repeated params (?status=a&status=b) and comma-separated (?status=a,b)
-    const knownParams = new Set(['page', 'limit', 'fields', 'distinct', 'ids', 'parentId', 'search', 'sortBy', 'sortOrder', 'child', 'meta', 'from', 'to', 'dateField'])
     const customFilters: Record<string, string[]> = {}
     url.searchParams.forEach((value, key) => {
-      if (!knownParams.has(key) && value) {
+      if (!LIST_RESERVED_PARAMS.has(key) && value) {
         if (!customFilters[key]) {
           customFilters[key] = []
         }
@@ -704,6 +853,57 @@ export async function handleGenericList(request: NextRequest): Promise<NextRespo
 
     // Build dynamic query from entity configuration
     const entityConfig = resolution.entityConfig
+
+    // ── #97: reject unknown / unsupported list parameters up front ─────────
+    // Each of these used to degrade silently into a plausible-looking 200
+    // (filter dropped, search ignored, default sort) — indistinguishable from
+    // a correct answer for an automated caller.
+
+    // Custom filter keys must be declared entity fields (or, for
+    // taxonomy-enabled entities, the taxonomy filter params).
+    const taxonomyFilterParams = entityConfig.taxonomies?.enabled ? TAXONOMY_FILTER_PARAMS : []
+    const invalidFilterKeys = Object.keys(customFilters).filter(
+      key => !isEntityField(entityConfig, key) && !taxonomyFilterParams.includes(key)
+    )
+    if (invalidFilterKeys.length > 0) {
+      const response = createApiError(
+        `Unknown filter parameter(s) for ${entityConfig.slug}: ${invalidFilterKeys.join(', ')}`,
+        400,
+        {
+          invalidKeys: invalidFilterKeys,
+          allowedKeys: [...entityConfig.fields.map((f: EntityField) => f.name), ...taxonomyFilterParams],
+        },
+        'INVALID_FILTER'
+      )
+      return addCorsHeaders(response, request)
+    }
+
+    // `search` only works against name/title/slug/content; an entity with none
+    // of them cannot honour it, so say so instead of returning every row.
+    const searchParam = url.searchParams.get('search')
+    const searchableFields = SEARCHABLE_FIELDS.filter(name => isEntityField(entityConfig, name))
+    if (searchParam && searchParam.trim() !== '' && searchableFields.length === 0) {
+      const response = createApiError(
+        `Entity ${entityConfig.slug} has no searchable field (${SEARCHABLE_FIELDS.join(', ')}); the search parameter is not supported`,
+        400,
+        { searchableFields: SEARCHABLE_FIELDS },
+        'SEARCH_NOT_SUPPORTED'
+      )
+      return addCorsHeaders(response, request)
+    }
+
+    // `sortBy` (alias `sort`) must be an entity field or a base column — it is
+    // interpolated as an identifier, so this check is also the SQL-injection guard.
+    const sortByParam = url.searchParams.get('sortBy') || url.searchParams.get('sort')
+    if (sortByParam && !isEntityField(entityConfig, sortByParam) && !SORTABLE_BASE_FIELDS.includes(sortByParam)) {
+      const response = createApiError(
+        `Invalid sortBy field for ${entityConfig.slug}: ${sortByParam}`,
+        400,
+        { allowedFields: [...SORTABLE_BASE_FIELDS, ...entityConfig.fields.map((f: EntityField) => f.name)] },
+        'INVALID_SORT_FIELD'
+      )
+      return addCorsHeaders(response, request)
+    }
 
     // Determine which fields to select
     let fields: string
@@ -782,9 +982,6 @@ export async function handleGenericList(request: NextRequest): Promise<NextRespo
     let query: string
     let queryParams: unknown[]
     let paramIndex = 1
-
-    // Extract search parameter early so it's available for both main query and count query
-    const searchParam = url.searchParams.get('search')
 
     // Extract date range parameters early so they're available for both main query and count query
     const fromDate = url.searchParams.get('from')
@@ -948,33 +1145,14 @@ export async function handleGenericList(request: NextRequest): Promise<NextRespo
         whereConditions.push(`t."deletedAt" IS NULL`)
       }
 
-      // Add search filter (searches in name, title, slug, and content fields)
-      if (searchParam && searchParam.trim() !== '') {
+      // Add search filter (searches in name, title, slug, and content fields).
+      // Support for the entity was validated above (SEARCH_NOT_SUPPORTED).
+      if (searchParam && searchParam.trim() !== '' && searchableFields.length > 0) {
         const searchTerm = searchParam.trim()
-        // Search in common text fields if they exist
-        const hasName = entityConfig.fields.some((f: EntityField) => f.name === 'name')
-        const hasTitle = entityConfig.fields.some((f: EntityField) => f.name === 'title')
-        const hasSlug = entityConfig.fields.some((f: EntityField) => f.name === 'slug')
-        const hasContent = entityConfig.fields.some((f: EntityField) => f.name === 'content')
-
-        if (hasName || hasTitle || hasSlug || hasContent) {
-          const searchConditions: string[] = []
-          if (hasName) {
-            searchConditions.push(`t.name ILIKE $${paramIndex}`)
-          }
-          if (hasTitle) {
-            searchConditions.push(`t.title ILIKE $${paramIndex}`)
-          }
-          if (hasSlug) {
-            searchConditions.push(`t.slug ILIKE $${paramIndex}`)
-          }
-          if (hasContent) {
-            searchConditions.push(`t.content ILIKE $${paramIndex}`)
-          }
-          whereConditions.push(`(${searchConditions.join(' OR ')})`)
-          queryParams.push(`%${searchTerm}%`)
-          paramIndex++
-        }
+        const searchConditions = searchableFields.map(name => `t.${name} ILIKE $${paramIndex}`)
+        whereConditions.push(`(${searchConditions.join(' OR ')})`)
+        queryParams.push(`%${searchTerm}%`)
+        paramIndex++
       }
 
       // Add date range filters (from/to) for specified date field
@@ -994,9 +1172,9 @@ export async function handleGenericList(request: NextRequest): Promise<NextRespo
         }
       }
 
-      // Add custom filters
+      // Add custom filters (keys were validated against entityConfig.fields
+      // above; taxonomy params are not fields and are handled separately)
       Object.entries(customFilters).forEach(([key, values]) => {
-        // Validate that the field exists in the entity config
         const field = entityConfig.fields.find((f: EntityField) => f.name === key)
         if (field && values.length > 0) {
           // Use quoted column name for camelCase fields
@@ -1011,6 +1189,23 @@ export async function handleGenericList(request: NextRequest): Promise<NextRespo
             })
             values.forEach(value => {
               queryParams.push(JSON.stringify([value]))
+            })
+            whereConditions.push(`(${orConditions.join(' OR ')})`)
+          } else if (field.type === 'date' || field.type === 'datetime') {
+            // #97: a bare calendar day compared with `=` against a
+            // timestamp(tz) column never matches (the column carries a
+            // time-of-day). Treat `?field=YYYY-MM-DD` as the whole day:
+            // `>= day AND < day + 1`. Values with a time component keep
+            // exact equality — the caller asked for a precise instant.
+            const orConditions = values.map(value => {
+              if (BARE_DATE_RE.test(value)) {
+                const lower = paramIndex++
+                const upper = paramIndex++
+                queryParams.push(value, value)
+                return `(t.${columnName} >= $${lower}::date AND t.${columnName} < $${upper}::date + 1)`
+              }
+              queryParams.push(value)
+              return `t.${columnName} = $${paramIndex++}`
             })
             whereConditions.push(`(${orConditions.join(' OR ')})`)
           } else {
@@ -1054,18 +1249,13 @@ export async function handleGenericList(request: NextRequest): Promise<NextRespo
         `
       }
 
-      // Parse sortBy/sortOrder and validate against entity fields to prevent SQL injection
-      const sortByParam = url.searchParams.get('sortBy')
-      const sortOrderParam = url.searchParams.get('sortOrder')?.toUpperCase() === 'ASC' ? 'ASC' : 'DESC'
-      let orderByClause = 't."createdAt" DESC'
-      if (sortByParam) {
-        // Allow sorting by entity fields or common base fields
-        const baseFields = ['id', 'createdAt', 'updatedAt', 'teamId']
-        const isValidField = entityConfig.fields.some((f: EntityField) => f.name === sortByParam) || baseFields.includes(sortByParam)
-        if (isValidField) {
-          orderByClause = `t."${sortByParam}" ${sortOrderParam}`
-        }
-      }
+      // sortBy was validated against entity fields / base columns above
+      // (INVALID_SORT_FIELD) — that check is what makes this interpolation safe.
+      const sortOrderRaw = url.searchParams.get('sortOrder') || url.searchParams.get('order')
+      const sortOrderParam = sortOrderRaw?.toUpperCase() === 'ASC' ? 'ASC' : 'DESC'
+      const orderByClause = sortByParam
+        ? `t."${sortByParam}" ${sortOrderParam}`
+        : 't."createdAt" DESC'
 
       // Use COUNT(*) OVER() window function to get total count in single query
       // This eliminates a separate COUNT query, saving ~230ms per request
@@ -1198,14 +1388,19 @@ export async function handleGenericCreate(request: NextRequest): Promise<NextRes
     const entityConfig = resolution.entityConfig
     const tableName = getTableName(entityConfig)
     const schemas = generateEntitySchemas(entityConfig)
-    const validation = schemas.create.safeParse(entityData)
+    const validation = schemas.create.safeParse(omitHandlerManagedKeys(entityConfig, entityData))
 
     if (!validation.success) {
       console.error(`[${entityConfig.slug}] Validation failed:`, {
         entityData,
         errors: validation.error.issues
       })
-      const response = createApiError('Validation error', 400, validation.error.issues, 'VALIDATION_ERROR')
+      const response = createApiError(
+        validationErrorMessage(validation.error.issues),
+        400,
+        validation.error.issues,
+        'VALIDATION_ERROR'
+      )
       return addCorsHeaders(response, request)
     }
 
@@ -1556,17 +1751,10 @@ export async function handleGenericCreate(request: NextRequest): Promise<NextRes
   } catch (error) {
     console.error('Error in generic create handler:', error)
 
-    // PostgreSQL unique constraint violation → 409 Conflict
-    if (error && typeof error === 'object' && 'code' in error && (error as { code: string }).code === '23505') {
-      const detail = 'detail' in error ? (error as { detail: string }).detail : undefined
-      const constraint = 'constraint' in error ? (error as { constraint: string }).constraint : undefined
-      const response = createApiError(
-        'A record with this value already exists',
-        409,
-        { constraint, detail },
-        'UNIQUE_CONSTRAINT_VIOLATION'
-      )
-      return addCorsHeaders(response, request)
+    // Unique / check / foreign-key violations are caller-fixable → 4xx
+    const constraintResponse = mapConstraintViolation(error, 'create')
+    if (constraintResponse) {
+      return addCorsHeaders(constraintResponse, request)
     }
 
     const response = createApiError('Internal server error', 500)
@@ -1884,7 +2072,7 @@ export async function handleGenericUpdate(request: NextRequest, { params }: { pa
     }
     const tableName = getTableName(entityConfig)
     const schemas = generateEntitySchemas(entityConfig)
-    const validation = schemas.update.safeParse(entityData)
+    const validation = schemas.update.safeParse(omitHandlerManagedKeys(entityConfig, entityData))
 
     if (!validation.success) {
       // Debug logging for validation errors
@@ -1892,7 +2080,12 @@ export async function handleGenericUpdate(request: NextRequest, { params }: { pa
         entityData,
         errors: validation.error.issues
       })
-      const response = createApiError('Validation error', 400, validation.error.issues, 'VALIDATION_ERROR')
+      const response = createApiError(
+        validationErrorMessage(validation.error.issues),
+        400,
+        validation.error.issues,
+        'VALIDATION_ERROR'
+      )
       return addCorsHeaders(response, request)
     }
 
@@ -2147,17 +2340,10 @@ export async function handleGenericUpdate(request: NextRequest, { params }: { pa
   } catch (error) {
     console.error('Error in generic update handler:', error)
 
-    // PostgreSQL unique constraint violation → 409 Conflict
-    if (error && typeof error === 'object' && 'code' in error && (error as { code: string }).code === '23505') {
-      const detail = 'detail' in error ? (error as { detail: string }).detail : undefined
-      const constraint = 'constraint' in error ? (error as { constraint: string }).constraint : undefined
-      const response = createApiError(
-        'A record with this value already exists',
-        409,
-        { constraint, detail },
-        'UNIQUE_CONSTRAINT_VIOLATION'
-      )
-      return addCorsHeaders(response, request)
+    // Unique / check / foreign-key violations are caller-fixable → 4xx
+    const constraintResponse = mapConstraintViolation(error, 'update')
+    if (constraintResponse) {
+      return addCorsHeaders(constraintResponse, request)
     }
 
     const response = createApiError('Internal server error', 500)
@@ -2305,17 +2491,10 @@ export async function handleGenericDelete(request: NextRequest, { params }: { pa
   } catch (error) {
     console.error('Error in generic delete handler:', error)
 
-    // PostgreSQL foreign key violation → 409 Conflict (entity is referenced by other records)
-    if (error && typeof error === 'object' && 'code' in error && (error as { code: string }).code === '23503') {
-      const detail = 'detail' in error ? (error as { detail: string }).detail : undefined
-      const constraint = 'constraint' in error ? (error as { constraint: string }).constraint : undefined
-      const response = createApiError(
-        detail || 'Cannot delete: this record is referenced by other records',
-        409,
-        { constraint },
-        'FOREIGN_KEY_VIOLATION'
-      )
-      return addCorsHeaders(response, request)
+    // Foreign key violation → 409 Conflict (entity is referenced by other records)
+    const constraintResponse = mapConstraintViolation(error, 'delete')
+    if (constraintResponse) {
+      return addCorsHeaders(constraintResponse, request)
     }
 
     const response = createApiError('Internal server error', 500)

--- a/packages/core/src/lib/entities/schema-generator.ts
+++ b/packages/core/src/lib/entities/schema-generator.ts
@@ -6,6 +6,7 @@
  */
 
 import { z } from 'zod'
+import { SYSTEM_FIELD_NAMES } from './system-fields'
 import type { EntityConfig, EntityField, ChildEntityDefinition } from './types'
 import { mediaRefSchema } from '../../types/blocks'
 
@@ -83,9 +84,23 @@ export function generateEntitySchemas(
   // and the handlers answer 400 VALIDATION_ERROR naming them.
   const createSchema = z.object(createFields).strict()
 
-  // Update schema (all fields optional except id). `.partial()` preserves the
-  // strict unknown-keys policy.
-  const updateSchema = createSchema.partial()
+  // Update schema (all fields optional). `.partial()` preserves the strict
+  // unknown-keys policy for real typos, but the record a client fetched and
+  // PATCHes back legitimately carries the read-only/system columns (`id`,
+  // `createdAt`, `updatedAt`, soft-delete markers, read-only fields). The edit
+  // form does exactly that, so those keys are stripped before validation
+  // instead of failing the whole update as "unknown" (#97 follow-up).
+  const readOnlyKeys = new Set<string>([
+    ...SYSTEM_FIELD_NAMES,
+    ...(entityConfig.table?.softDelete ? ['deletedAt', 'deletedBy'] : []),
+    ...entityConfig.fields
+      .filter(field => field.api.readOnly && !includeReadOnly)
+      .map(field => field.name),
+  ])
+  const updateSchema = z.preprocess(
+    (data) => stripKeys(data, readOnlyKeys),
+    createSchema.partial()
+  )
   
   // Response schema (includes all fields including read-only)
   const responseFields = entityConfig.fields.reduce((acc, field) => {
@@ -134,6 +149,17 @@ export function generateEntitySchemas(
     list: listSchema,
     childSchemas
   }
+}
+
+/**
+ * Drop the given keys from a plain object before validation. Non-object input
+ * is returned untouched so the schema itself reports the type error.
+ */
+function stripKeys(data: unknown, keys: Set<string>): unknown {
+  if (!data || typeof data !== 'object' || Array.isArray(data)) return data
+  return Object.fromEntries(
+    Object.entries(data as Record<string, unknown>).filter(([key]) => !keys.has(key))
+  )
 }
 
 /**

--- a/packages/core/src/lib/entities/schema-generator.ts
+++ b/packages/core/src/lib/entities/schema-generator.ts
@@ -71,11 +71,20 @@ export function generateEntitySchemas(
       })),
       z.unknown(), // Fallback for flexibility
     ]).optional()
+    // The builder editor also sends page `settings` (SEO, custom fields)
+    // alongside `blocks`. Accepted here so the strict schema does not reject
+    // builder saves; the generic handler only persists declared columns.
+    createFields.settings = z.unknown().optional()
   }
 
-  const createSchema = z.object(createFields)
-  
-  // Update schema (all fields optional except id)
+  // #97: strict — z.object() silently STRIPS unknown keys by default, so a
+  // typo'd key (`notes` for `note`) was accepted with a 201 and the value
+  // quietly discarded. Unknown keys now fail validation (`unrecognized_keys`)
+  // and the handlers answer 400 VALIDATION_ERROR naming them.
+  const createSchema = z.object(createFields).strict()
+
+  // Update schema (all fields optional except id). `.partial()` preserves the
+  // strict unknown-keys policy.
   const updateSchema = createSchema.partial()
   
   // Response schema (includes all fields including read-only)
@@ -926,7 +935,8 @@ function generateChildEntitySchema(
     }
   })
 
-  return z.object(fields)
+  // Same unknown-keys policy as the parent create/update schemas (#97)
+  return z.object(fields).strict()
 }
 
 /**

--- a/packages/core/src/lib/mcp/audit.ts
+++ b/packages/core/src/lib/mcp/audit.ts
@@ -1,13 +1,17 @@
 /**
  * MCP audit trail.
  *
- * The core's api_audit_log exists but the generic entity handlers never write
- * to it directly for in-process invocations (logApiUsage only runs inside
- * withApiAuth, which the MCP executor's synthesized requests don't go
- * through). Every MCP tool call is recorded here so destructive actions by an
+ * Every MCP tool call is recorded here so destructive actions by an
  * autonomous agent are at least reconstructable — same insert shape as
  * `logApiUsage` (packages/core/src/lib/api/helpers.ts), including passing the
  * caller's userId as RLS context.
+ *
+ * Since #105 the generic entity handlers also write their own row per
+ * request (endpoint `/api/v1/...`, see lib/api/entity/audit-log.ts), so an
+ * MCP tool call produces two rows: this one (`mcp:<tool>`, with the tool
+ * arguments) and the underlying API call's. They are complementary, not
+ * duplicates — this row carries what the agent asked for, the other what
+ * the API answered.
  *
  * Note for operators: revoking an API key can take up to 5 minutes to become
  * effective (core apiKeyCache TTL) — the audit log covers that window.

--- a/packages/core/tests/jest/api/entity/__helpers__/generic-handler-harness.ts
+++ b/packages/core/tests/jest/api/entity/__helpers__/generic-handler-harness.ts
@@ -1,0 +1,252 @@
+/**
+ * Shared test harness for the generic entity handlers
+ * (`packages/core/src/lib/api/entity/generic-handler.ts`).
+ *
+ * Registers every module mock the handlers need to run outside a generated
+ * project (DB, dual-auth, resolver, permissions, helpers, hooks, billing) and
+ * exposes the mock functions plus small request/auth/entity fixtures.
+ *
+ * Usage — the harness MUST be imported before the handler module so the
+ * `jest.mock` registrations run first:
+ *
+ *   import { harness } from './__helpers__/generic-handler-harness'
+ *   import { handleGenericList } from '@/core/lib/api/entity/generic-handler'
+ *
+ *   beforeEach(() => harness.reset())
+ *
+ * The mock implementations mirror the real, config-free helpers closely enough
+ * for the paths under test (no `metas`/`child` params are sent by these
+ * fixtures, so the "not requested" branches are what's exercised).
+ */
+
+import type { EntityConfig } from '@/core/lib/entities/types'
+
+// ---------------------------------------------------------------------------
+// Module mocks (variables must be `mock`-prefixed to be usable in factories)
+// ---------------------------------------------------------------------------
+
+const mockResolveEntityFromUrl = jest.fn()
+const mockValidateEntityOperation = jest.fn()
+jest.mock('@/core/lib/api/entity/resolver', () => ({
+  resolveEntityFromUrl: (...args: unknown[]) => mockResolveEntityFromUrl(...args),
+  validateEntityOperation: (...args: unknown[]) => mockValidateEntityOperation(...args),
+}))
+
+// Full mock — the real dual-auth.ts transitively loads lib/auth.ts (Better
+// Auth + DB bootstrapping). hasRequiredScope mirrors the real implementation.
+const mockAuthenticateRequest = jest.fn()
+const mockCanBypassTeamContext = jest.fn()
+jest.mock('@/core/lib/api/auth/dual-auth', () => ({
+  authenticateRequest: (...args: unknown[]) => mockAuthenticateRequest(...args),
+  canBypassTeamContext: (...args: unknown[]) => mockCanBypassTeamContext(...args),
+  hasRequiredScope: (authResult: { type: string; scopes?: string[] }, requiredScope: string) => {
+    if (authResult.type === 'session') return true
+    if (authResult.type === 'api-key' && authResult.scopes) {
+      return authResult.scopes.includes(requiredScope) || authResult.scopes.includes('*')
+    }
+    return false
+  },
+}))
+
+const mockCheckPermission = jest.fn()
+jest.mock('@/core/lib/permissions/check', () => ({
+  checkPermission: (...args: unknown[]) => mockCheckPermission(...args),
+}))
+
+const mockQueryWithRLS = jest.fn()
+const mockQueryOneWithRLS = jest.fn()
+const mockMutateWithRLS = jest.fn()
+jest.mock('@/core/lib/db', () => ({
+  queryWithRLS: (...args: unknown[]) => mockQueryWithRLS(...args),
+  queryOneWithRLS: (...args: unknown[]) => mockQueryOneWithRLS(...args),
+  mutateWithRLS: (...args: unknown[]) => mockMutateWithRLS(...args),
+}))
+
+const mockGenerateEntitySchemas = jest.fn()
+jest.mock('@/core/lib/entities/schema-generator', () => ({
+  generateEntitySchemas: (...args: unknown[]) => mockGenerateEntitySchemas(...args),
+}))
+
+const mockBeforeEntityCreate = jest.fn()
+const mockAfterEntityCreate = jest.fn()
+const mockBeforeEntityUpdate = jest.fn()
+const mockAfterEntityUpdate = jest.fn()
+const mockAfterEntityDelete = jest.fn()
+jest.mock('@/core/lib/entities/entity-hooks', () => ({
+  beforeEntityCreate: (...args: unknown[]) => mockBeforeEntityCreate(...args),
+  afterEntityCreate: (...args: unknown[]) => mockAfterEntityCreate(...args),
+  beforeEntityUpdate: (...args: unknown[]) => mockBeforeEntityUpdate(...args),
+  afterEntityUpdate: (...args: unknown[]) => mockAfterEntityUpdate(...args),
+  afterEntityDelete: (...args: unknown[]) => mockAfterEntityDelete(...args),
+}))
+
+jest.mock('@nextsparkjs/registries/billing-registry', () => ({
+  BILLING_REGISTRY: { actionMappings: { limits: {} } },
+}))
+
+jest.mock('@/core/lib/services/pattern-usage.service', () => ({
+  PatternUsageService: { track: jest.fn(), untrack: jest.fn() },
+}))
+jest.mock('@/core/lib/services/subscription.service', () => ({
+  SubscriptionService: { getActive: jest.fn(), canPerformAction: jest.fn() },
+}))
+jest.mock('@/core/lib/services/usage.service', () => ({
+  UsageService: { track: jest.fn(), checkLimit: jest.fn() },
+}))
+
+// Full mock — helpers.ts imports `../auth` (Better Auth + DB bootstrapping).
+jest.mock('@/core/lib/api/helpers', () => ({
+  createApiResponse: (data: unknown, meta?: Record<string, unknown>, status = 200) => ({
+    status,
+    body: { success: true, data, info: { timestamp: new Date().toISOString(), ...meta } },
+    async json() { return this.body },
+  }),
+  createApiError: (message: string, status = 400, details?: unknown, code?: string) => ({
+    status,
+    body: { success: false, error: message, code: code || `HTTP_${status}`, details },
+    async json() { return this.body },
+  }),
+  addCorsHeaders: async (response: unknown) => response,
+  handleCorsPreflightRequest: async () => ({ status: 200 }),
+  parsePaginationParams: (request: { url: string }) => {
+    const { searchParams } = new URL(request.url)
+    const page = Math.max(1, parseInt(searchParams.get('page') || '1'))
+    const limit = Math.min(100, Math.max(1, parseInt(searchParams.get('limit') || '10')))
+    return { page, limit, offset: (page - 1) * limit }
+  },
+  createPaginationMeta: (page: number, limit: number, total: number) => ({
+    page, limit, total, totalPages: Math.ceil(total / limit), hasNextPage: page * limit < total,
+  }),
+  parseMetaParams: () => ({ includeMetadata: false, includeAll: false }),
+  parseChildParams: () => ({ includeChildren: false, includeAll: false }),
+  includeEntityMetadata: async (_entityType: string, entities: unknown[]) => entities,
+  includeEntityChildren: async (_entityName: string, entities: unknown[]) => entities,
+  handleEntityMetadataInResponse: async (_entityType: string, entity: unknown) => entity,
+  processEntityMetadata: async () => ({ success: true, errors: [] }),
+}))
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+export interface MockResponse {
+  status: number
+  body: { success: boolean; data?: unknown; error?: string; code?: string; details?: unknown }
+  json(): Promise<MockResponse['body']>
+}
+
+export function makeRequest(options: {
+  method?: string
+  url?: string
+  headers?: Record<string, string>
+  body?: unknown
+}) {
+  const headerMap = new Map(Object.entries(options.headers ?? {}))
+  const url = options.url ?? 'http://localhost/api/v1/pets'
+  return {
+    method: options.method ?? 'GET',
+    url,
+    nextUrl: new URL(url),
+    headers: { get: (key: string) => headerMap.get(key) ?? null },
+    cookies: { get: () => undefined },
+    json: async () => options.body ?? {},
+  } as unknown as import('next/server').NextRequest
+}
+
+/** Build a list URL with properly encoded query params. */
+export function listUrl(params: Record<string, string>, entity = 'pets') {
+  const url = new URL(`http://localhost/api/v1/${entity}`)
+  Object.entries(params).forEach(([k, v]) => url.searchParams.set(k, v))
+  return url.toString()
+}
+
+export const API_KEY_AUTH = (scopes: string[], userRole = 'user') => ({
+  success: true,
+  type: 'api-key' as const,
+  user: { id: 'key-owner-1', email: 'owner@test.com', role: userRole },
+  scopes,
+  keyId: 'key-1',
+})
+
+export const SESSION_AUTH = (userId = 'session-user-1', userRole = 'user') => ({
+  success: true,
+  type: 'session' as const,
+  user: { id: userId, email: 'user@test.com', role: userRole },
+})
+
+/**
+ * Plain team-scoped entity, no ownership filter. Field mix covers the
+ * branches under test: text, select, datetime and a JSONB `tags` field.
+ */
+export const PETS_ENTITY: EntityConfig = {
+  slug: 'pets',
+  tableName: 'pets',
+  fields: [
+    { name: 'name', type: 'text', api: { readOnly: false } } as never,
+    { name: 'status', type: 'select', api: { readOnly: false } } as never,
+    { name: 'ownerId', type: 'text', api: { readOnly: false } } as never,
+    { name: 'adoptedAt', type: 'datetime', api: { readOnly: false } } as never,
+    { name: 'hashtags', type: 'tags', api: { readOnly: false } } as never,
+  ],
+  access: { api: true },
+} as unknown as EntityConfig
+
+/** Route the `team_members` lookups the handlers perform. */
+export function routeQueryOneWithRLS(teamRole: string | null, memberExists = true) {
+  mockQueryOneWithRLS.mockImplementation(async (sql: string) => {
+    if (sql.includes('SELECT id FROM "team_members"')) {
+      return memberExists ? { id: 'membership-1' } : null
+    }
+    if (sql.includes('SELECT role FROM "team_members"')) {
+      return teamRole ? { role: teamRole } : null
+    }
+    return null
+  })
+}
+
+/** Flush pending microtasks (for fire-and-forget side effects). */
+export async function flushPromises() {
+  await new Promise(resolve => setImmediate(resolve))
+}
+
+function reset() {
+  jest.clearAllMocks()
+  mockResolveEntityFromUrl.mockResolvedValue({
+    isValidEntity: true,
+    entityConfig: PETS_ENTITY,
+    entityName: 'pets',
+    hasCustomOverride: false,
+  })
+  mockValidateEntityOperation.mockReturnValue(true)
+  mockQueryWithRLS.mockResolvedValue([])
+  mockCanBypassTeamContext.mockResolvedValue(false)
+  mockCheckPermission.mockResolvedValue(true)
+  routeQueryOneWithRLS('member')
+  // Pass-through hooks by default (mirrors the real no-plugin behaviour)
+  mockBeforeEntityCreate.mockImplementation(async (_slug: string, data: unknown) => data)
+  mockBeforeEntityUpdate.mockImplementation(async (_slug: string, _id: string, changes: unknown) => changes)
+  mockGenerateEntitySchemas.mockReturnValue({
+    create: { safeParse: (data: unknown) => ({ success: true, data }) },
+    update: { safeParse: (data: unknown) => ({ success: true, data }) },
+  })
+}
+
+export const harness = {
+  reset,
+  mocks: {
+    resolveEntityFromUrl: mockResolveEntityFromUrl,
+    validateEntityOperation: mockValidateEntityOperation,
+    authenticateRequest: mockAuthenticateRequest,
+    canBypassTeamContext: mockCanBypassTeamContext,
+    checkPermission: mockCheckPermission,
+    queryWithRLS: mockQueryWithRLS,
+    queryOneWithRLS: mockQueryOneWithRLS,
+    mutateWithRLS: mockMutateWithRLS,
+    generateEntitySchemas: mockGenerateEntitySchemas,
+    beforeEntityCreate: mockBeforeEntityCreate,
+    afterEntityCreate: mockAfterEntityCreate,
+    beforeEntityUpdate: mockBeforeEntityUpdate,
+    afterEntityUpdate: mockAfterEntityUpdate,
+    afterEntityDelete: mockAfterEntityDelete,
+  },
+}

--- a/packages/core/tests/jest/api/entity/__helpers__/generic-handler-harness.ts
+++ b/packages/core/tests/jest/api/entity/__helpers__/generic-handler-harness.ts
@@ -204,9 +204,9 @@ export function routeQueryOneWithRLS(teamRole: string | null, memberExists = tru
   })
 }
 
-/** Flush pending microtasks (for fire-and-forget side effects). */
+/** Flush pending microtasks (for fire-and-forget side effects). jsdom has no setImmediate. */
 export async function flushPromises() {
-  await new Promise(resolve => setImmediate(resolve))
+  await new Promise(resolve => setTimeout(resolve, 0))
 }
 
 function reset() {

--- a/packages/core/tests/jest/api/entity/generic-handler-audit-log.test.ts
+++ b/packages/core/tests/jest/api/entity/generic-handler-audit-log.test.ts
@@ -1,0 +1,139 @@
+/**
+ * Regression coverage for #105: requests to the generic entity routes were
+ * never written to `api_audit_log`, for either auth type. Every exported
+ * handler now records one row per authenticated request (API key or session)
+ * with endpoint, method, status and timing — fire-and-forget, so an audit
+ * failure never alters the response.
+ */
+
+import { harness, makeRequest, listUrl, API_KEY_AUTH, SESSION_AUTH, flushPromises } from './__helpers__/generic-handler-harness'
+import {
+  handleGenericList,
+  handleGenericCreate,
+  handleGenericRead,
+  handleGenericUpdate,
+  handleGenericDelete,
+} from '@/core/lib/api/entity/generic-handler'
+
+const { mocks } = harness
+
+type Res = { status: number }
+const TEAM_HEADERS = { 'x-team-id': 'team-1', 'user-agent': 'jest-agent/1.0', 'x-forwarded-for': '203.0.113.7' }
+
+function auditCalls(): Array<[string, unknown[], string]> {
+  return mocks.mutateWithRLS.mock.calls.filter(([sql]: [string]) => sql.includes('INSERT INTO "api_audit_log"')) as Array<[string, unknown[], string]>
+}
+
+/** Route entity writes to a canned row; audit inserts resolve to nothing. */
+function routeMutate(entityRow: Record<string, unknown> = { id: 'pet-1', name: 'Rex' }) {
+  mocks.mutateWithRLS.mockImplementation(async (sql: string) => {
+    if (sql.includes('INSERT INTO "api_audit_log"')) return undefined
+    return { rows: [entityRow] }
+  })
+}
+
+beforeEach(() => {
+  harness.reset()
+  routeMutate()
+})
+
+describe('generic handlers — #105 audit logging', () => {
+  it('logs an API-key LIST with the key id, owner, endpoint, method, status and timing', async () => {
+    mocks.authenticateRequest.mockResolvedValue(API_KEY_AUTH(['pets:read']))
+
+    const response = await handleGenericList(makeRequest({ url: listUrl({ limit: '5' }), headers: TEAM_HEADERS })) as unknown as Res
+    await flushPromises()
+
+    expect(response.status).toBe(200)
+    expect(auditCalls()).toHaveLength(1)
+    const [, params, rlsUserId] = auditCalls()[0]
+    expect(params.slice(0, 7)).toEqual(['key-1', 'key-owner-1', '/api/v1/pets', 'GET', 200, '203.0.113.7', 'jest-agent/1.0'])
+    expect(params[7]).toBeNull() // request body is never stored
+    expect(typeof params[8]).toBe('number') // responseTime
+    expect(rlsUserId).toBe('key-owner-1')
+  })
+
+  it('logs a session LIST with a NULL apiKeyId', async () => {
+    mocks.authenticateRequest.mockResolvedValue(SESSION_AUTH())
+
+    await handleGenericList(makeRequest({ headers: TEAM_HEADERS }))
+    await flushPromises()
+
+    expect(auditCalls()).toHaveLength(1)
+    const [, params] = auditCalls()[0]
+    expect(params[0]).toBeNull()
+    expect(params[1]).toBe('session-user-1')
+  })
+
+  it('logs denied requests with their real status (403 from the team-role permission gate)', async () => {
+    mocks.authenticateRequest.mockResolvedValue(API_KEY_AUTH(['pets:read']))
+    mocks.checkPermission.mockResolvedValue(false)
+
+    const response = await handleGenericList(makeRequest({ headers: TEAM_HEADERS })) as unknown as Res
+    await flushPromises()
+
+    expect(response.status).toBe(403)
+    expect(auditCalls()).toHaveLength(1)
+    expect(auditCalls()[0][1][4]).toBe(403)
+  })
+
+  it('does not log unauthenticated requests (nothing to attribute the row to)', async () => {
+    mocks.authenticateRequest.mockResolvedValue({ success: false, type: 'none', user: null })
+
+    const response = await handleGenericList(makeRequest({ headers: TEAM_HEADERS })) as unknown as Res
+    await flushPromises()
+
+    expect(response.status).toBe(401)
+    expect(auditCalls()).toHaveLength(0)
+  })
+
+  it('covers CREATE, READ, UPDATE and DELETE with the right method and path', async () => {
+    mocks.authenticateRequest.mockResolvedValue(API_KEY_AUTH(['pets:read', 'pets:write', 'pets:delete']))
+    mocks.queryWithRLS.mockResolvedValue([{ id: 'pet-1', name: 'Rex' }])
+    const ctx = { params: Promise.resolve({ entity: 'pets', id: 'pet-1' }) }
+
+    await handleGenericCreate(makeRequest({ method: 'POST', url: 'http://localhost/api/v1/pets', headers: TEAM_HEADERS, body: { name: 'Rex' } }))
+    await handleGenericRead(makeRequest({ method: 'GET', url: 'http://localhost/api/v1/pets/pet-1', headers: TEAM_HEADERS }), ctx)
+    await handleGenericUpdate(makeRequest({ method: 'PATCH', url: 'http://localhost/api/v1/pets/pet-1', headers: TEAM_HEADERS, body: { name: 'Rex 2' } }), ctx)
+    await handleGenericDelete(makeRequest({ method: 'DELETE', url: 'http://localhost/api/v1/pets/pet-1', headers: TEAM_HEADERS }), ctx)
+    await flushPromises()
+
+    const rows = auditCalls().map(([, params]) => [params[3], params[2], params[4]])
+    expect(rows).toEqual([
+      ['POST', '/api/v1/pets', 201],
+      ['GET', '/api/v1/pets/pet-1', 200],
+      ['PATCH', '/api/v1/pets/pet-1', 200],
+      ['DELETE', '/api/v1/pets/pet-1', 200],
+    ])
+  })
+
+  it('never lets an audit write failure change the response', async () => {
+    mocks.authenticateRequest.mockResolvedValue(SESSION_AUTH())
+    mocks.mutateWithRLS.mockImplementation(async (sql: string) => {
+      if (sql.includes('INSERT INTO "api_audit_log"')) throw new Error('audit table unavailable')
+      return { rows: [{ id: 'pet-1' }] }
+    })
+    const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {})
+
+    const response = await handleGenericList(makeRequest({ headers: TEAM_HEADERS })) as unknown as Res
+    await flushPromises()
+
+    expect(response.status).toBe(200)
+    expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining('api_audit_log'), expect.any(Error))
+    errorSpy.mockRestore()
+  })
+
+  it('logs a 500 when the handler itself blows up after authentication', async () => {
+    mocks.authenticateRequest.mockResolvedValue(SESSION_AUTH())
+    mocks.queryWithRLS.mockRejectedValue(new Error('connection reset'))
+    const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {})
+
+    const response = await handleGenericList(makeRequest({ headers: TEAM_HEADERS })) as unknown as Res
+    await flushPromises()
+
+    expect(response.status).toBe(500)
+    expect(auditCalls()).toHaveLength(1)
+    expect(auditCalls()[0][1][4]).toBe(500)
+    errorSpy.mockRestore()
+  })
+})

--- a/packages/core/tests/jest/api/entity/generic-handler-before-create-hook.test.ts
+++ b/packages/core/tests/jest/api/entity/generic-handler-before-create-hook.test.ts
@@ -1,0 +1,95 @@
+/**
+ * Regression coverage for #118: `handleGenericCreate` only fired
+ * `afterEntityCreate` (after the INSERT) and never invoked
+ * `beforeEntityCreate`, so plugins had no supported pre-write extension point
+ * on the generic POST route — the `entity.<slug>.before_create` filter could
+ * neither reject nor reshape a payload before it was persisted.
+ */
+
+import { harness, makeRequest, SESSION_AUTH } from './__helpers__/generic-handler-harness'
+import { handleGenericCreate } from '@/core/lib/api/entity/generic-handler'
+
+const { mocks } = harness
+
+type Res = { status: number; body: { code?: string; error?: string; data?: unknown } }
+
+function createRequest(body: Record<string, unknown>) {
+  return makeRequest({
+    method: 'POST',
+    url: 'http://localhost/api/v1/pets',
+    headers: { 'x-team-id': 'team-1' },
+    body,
+  })
+}
+
+beforeEach(() => {
+  harness.reset()
+  mocks.authenticateRequest.mockResolvedValue(SESSION_AUTH())
+  // INSERT ... RETURNING * → then the SELECT that re-reads the created row
+  mocks.mutateWithRLS.mockResolvedValue({ rows: [{ id: 'pet-new' }] })
+  mocks.queryWithRLS.mockResolvedValue([{ id: 'pet-new', name: 'Rex' }])
+})
+
+describe('handleGenericCreate — #118 beforeEntityCreate hook', () => {
+  it('invokes beforeEntityCreate with the validated payload BEFORE the INSERT runs', async () => {
+    const response = await handleGenericCreate(createRequest({ name: 'Rex', status: 'draft' })) as unknown as Res
+
+    expect(response.status).toBe(201)
+    expect(mocks.beforeEntityCreate).toHaveBeenCalledTimes(1)
+    const [slug, data, userId] = mocks.beforeEntityCreate.mock.calls[0] as [string, Record<string, unknown>, string]
+    expect(slug).toBe('pets')
+    expect(data).toMatchObject({ name: 'Rex', status: 'draft' })
+    expect(userId).toBe('session-user-1')
+
+    // Ordering: the hook must run before the write hits the database.
+    const hookOrder = mocks.beforeEntityCreate.mock.invocationCallOrder[0]
+    const insertOrder = mocks.mutateWithRLS.mock.invocationCallOrder[0]
+    expect(hookOrder).toBeLessThan(insertOrder)
+  })
+
+  it('persists the payload returned by the hook, not the original one', async () => {
+    mocks.beforeEntityCreate.mockImplementation(async (_slug: string, data: Record<string, unknown>) => ({
+      ...data,
+      name: `${String(data.name)} (normalized)`,
+    }))
+
+    await handleGenericCreate(createRequest({ name: 'Rex' }))
+
+    const insertCall = mocks.mutateWithRLS.mock.calls.find(([sql]: [string]) => sql.includes('INSERT INTO "pets"'))
+    expect(insertCall).toBeDefined()
+    const [, values] = insertCall as [string, unknown[]]
+    expect(values).toContain('Rex (normalized)')
+    expect(values).not.toContain('Rex')
+  })
+
+  it('rejects the create (no INSERT) when the hook throws, surfacing the reason as a 4xx', async () => {
+    mocks.beforeEntityCreate.mockRejectedValue(new Error('ownerId does not belong to this team'))
+
+    const response = await handleGenericCreate(createRequest({ name: 'Rex', ownerId: 'someone-else' })) as unknown as Res
+
+    expect(response.status).toBe(400)
+    expect(response.body.code).toBe('BEFORE_CREATE_REJECTED')
+    expect(response.body.error).toContain('ownerId does not belong to this team')
+    expect(mocks.mutateWithRLS).not.toHaveBeenCalled()
+    expect(mocks.afterEntityCreate).not.toHaveBeenCalled()
+  })
+
+  it('lets the hook pick the status code by throwing an error that carries one', async () => {
+    const forbidden = Object.assign(new Error('not yours'), { status: 403 })
+    mocks.beforeEntityCreate.mockRejectedValue(forbidden)
+
+    const response = await handleGenericCreate(createRequest({ name: 'Rex' })) as unknown as Res
+
+    expect(response.status).toBe(403)
+    expect(response.body.code).toBe('BEFORE_CREATE_REJECTED')
+    expect(mocks.mutateWithRLS).not.toHaveBeenCalled()
+  })
+
+  it('still fires afterEntityCreate once the row is written', async () => {
+    await handleGenericCreate(createRequest({ name: 'Rex' }))
+
+    expect(mocks.afterEntityCreate).toHaveBeenCalledTimes(1)
+    expect(mocks.beforeEntityCreate.mock.invocationCallOrder[0])
+      .toBeLessThan(mocks.afterEntityCreate.mock.invocationCallOrder[0])
+  })
+})

--- a/packages/core/tests/jest/api/entity/generic-handler-before-create-hook.test.ts
+++ b/packages/core/tests/jest/api/entity/generic-handler-before-create-hook.test.ts
@@ -13,6 +13,12 @@ const { mocks } = harness
 
 type Res = { status: number; body: { code?: string; error?: string; data?: unknown } }
 
+/** No INSERT into the entity table (audit-log INSERTs from #105 don't count). */
+function expectNoEntityWrite() {
+  const entityWrites = mocks.mutateWithRLS.mock.calls.filter(([sql]: [string]) => !sql.includes('api_audit_log'))
+  expect(entityWrites).toHaveLength(0)
+}
+
 function createRequest(body: Record<string, unknown>) {
   return makeRequest({
     method: 'POST',
@@ -70,7 +76,7 @@ describe('handleGenericCreate — #118 beforeEntityCreate hook', () => {
     expect(response.status).toBe(400)
     expect(response.body.code).toBe('BEFORE_CREATE_REJECTED')
     expect(response.body.error).toContain('ownerId does not belong to this team')
-    expect(mocks.mutateWithRLS).not.toHaveBeenCalled()
+    expectNoEntityWrite()
     expect(mocks.afterEntityCreate).not.toHaveBeenCalled()
   })
 
@@ -82,7 +88,7 @@ describe('handleGenericCreate — #118 beforeEntityCreate hook', () => {
 
     expect(response.status).toBe(403)
     expect(response.body.code).toBe('BEFORE_CREATE_REJECTED')
-    expect(mocks.mutateWithRLS).not.toHaveBeenCalled()
+    expectNoEntityWrite()
   })
 
   it('still fires afterEntityCreate once the row is written', async () => {

--- a/packages/core/tests/jest/api/entity/generic-handler-distinct-field.test.ts
+++ b/packages/core/tests/jest/api/entity/generic-handler-distinct-field.test.ts
@@ -1,0 +1,93 @@
+/**
+ * Regression coverage for #96: `GET /api/v1/{entity}?fields=X&distinct=true`
+ * interpolated the raw `fields` query value as a SQL identifier without
+ * validating it against `entityConfig.fields`, unlike the sibling
+ * (non-distinct) `?fields=` branch. Any caller with `<slug>:read` could inject
+ * arbitrary SQL into the SELECT list.
+ *
+ * These tests drive real requests through `handleGenericList` and assert on
+ * the SQL that reaches the DB layer.
+ */
+
+import { harness, makeRequest, listUrl, SESSION_AUTH, PETS_ENTITY } from './__helpers__/generic-handler-harness'
+import { handleGenericList } from '@/core/lib/api/entity/generic-handler'
+import type { EntityConfig } from '@/core/lib/entities/types'
+
+const { mocks } = harness
+
+const TEAM_HEADERS = { 'x-team-id': 'team-1' }
+
+beforeEach(() => {
+  harness.reset()
+  mocks.authenticateRequest.mockResolvedValue(SESSION_AUTH())
+})
+
+describe('handleGenericList — #96 distinct field name is validated against entityConfig.fields', () => {
+  it('rejects a crafted identifier with 400 INVALID_FIELD and never reaches the database', async () => {
+    // Closes the quoted identifier and appends a subquery into the SELECT list.
+    const payload = `name", (SELECT string_agg(email, ',') FROM "users") AS "pwned`
+
+    const request = makeRequest({ url: listUrl({ fields: payload, distinct: 'true' }), headers: TEAM_HEADERS })
+    const response = await handleGenericList(request) as unknown as { status: number; body: { code?: string; error?: string } }
+
+    expect(response.status).toBe(400)
+    expect(response.body.code).toBe('INVALID_FIELD')
+    expect(mocks.queryWithRLS).not.toHaveBeenCalled()
+  })
+
+  it('rejects an unknown (but harmless-looking) field name with 400 rather than querying it', async () => {
+    const request = makeRequest({ url: listUrl({ fields: 'secretColumn', distinct: 'true' }), headers: TEAM_HEADERS })
+    const response = await handleGenericList(request) as unknown as { status: number; body: { code?: string } }
+
+    expect(response.status).toBe(400)
+    expect(response.body.code).toBe('INVALID_FIELD')
+    expect(mocks.queryWithRLS).not.toHaveBeenCalled()
+  })
+
+  it('still serves distinct values for a real entity field', async () => {
+    mocks.queryWithRLS.mockResolvedValue([{ value: 'draft', label: 'draft', entityType: 'pets' }])
+
+    const request = makeRequest({ url: listUrl({ fields: 'status', distinct: 'true' }), headers: TEAM_HEADERS })
+    const response = await handleGenericList(request) as unknown as { status: number }
+
+    expect(response.status).toBe(200)
+    const [sql] = mocks.queryWithRLS.mock.calls[0] as [string]
+    expect(sql).toContain('DISTINCT "status" as value')
+    expect(sql).toContain('ORDER BY "status" ASC')
+  })
+
+  it('guards the JSONB (tags) distinct path with the same validation', async () => {
+    // `hashtags` IS a field of PETS_ENTITY → JSONB branch runs
+    const okRequest = makeRequest({ url: listUrl({ fields: 'hashtags', distinct: 'true' }), headers: TEAM_HEADERS })
+    const okResponse = await handleGenericList(okRequest) as unknown as { status: number }
+    expect(okResponse.status).toBe(200)
+    const [sql] = mocks.queryWithRLS.mock.calls[0] as [string]
+    expect(sql).toContain('jsonb_array_elements_text("hashtags")')
+
+    // Same request against an entity WITHOUT a `hashtags` field → rejected,
+    // even though the name matches the hard-coded JSONB allow-list.
+    mocks.queryWithRLS.mockClear()
+    const noTagsEntity = {
+      ...PETS_ENTITY,
+      fields: PETS_ENTITY.fields.filter(f => f.name !== 'hashtags'),
+    } as EntityConfig
+    mocks.resolveEntityFromUrl.mockResolvedValue({
+      isValidEntity: true, entityConfig: noTagsEntity, entityName: 'pets', hasCustomOverride: false,
+    })
+    const badRequest = makeRequest({ url: listUrl({ fields: 'hashtags', distinct: 'true' }), headers: TEAM_HEADERS })
+    const badResponse = await handleGenericList(badRequest) as unknown as { status: number; body: { code?: string } }
+    expect(badResponse.status).toBe(400)
+    expect(badResponse.body.code).toBe('INVALID_FIELD')
+    expect(mocks.queryWithRLS).not.toHaveBeenCalled()
+  })
+
+  it('regression: the sibling non-distinct ?fields= branch keeps stripping unknown names', async () => {
+    const request = makeRequest({ url: listUrl({ fields: 'name,bogus' }), headers: TEAM_HEADERS })
+    const response = await handleGenericList(request) as unknown as { status: number }
+
+    expect(response.status).toBe(200)
+    const [sql] = mocks.queryWithRLS.mock.calls[0] as [string]
+    expect(sql).toContain('t.name')
+    expect(sql).not.toContain('bogus')
+  })
+})

--- a/packages/core/tests/jest/api/entity/generic-handler-list-validation.test.ts
+++ b/packages/core/tests/jest/api/entity/generic-handler-list-validation.test.ts
@@ -1,0 +1,247 @@
+/**
+ * Regression coverage for #97: silent / misleading failure modes in the
+ * generic entity handlers. Each case previously returned a plausible-looking
+ * 200 (or an opaque 500) instead of an error the caller could act on:
+ *
+ *   1. `search` on an entity with no searchable field was a silent no-op
+ *   2. custom filters with an unknown key were silently dropped
+ *   3. an invalid `sortBy` silently fell back to the default sort
+ *   4. equality filters on date/datetime fields could never match
+ *   6. CHECK-constraint violations (23514) surfaced as a bare 500
+ *
+ * (Case 5 — strict create/update schemas — lives in
+ *  tests/jest/lib/entities/schema-generator-strict.test.ts.)
+ */
+
+import { harness, makeRequest, listUrl, SESSION_AUTH, PETS_ENTITY } from './__helpers__/generic-handler-harness'
+import { handleGenericList, handleGenericCreate, handleGenericUpdate } from '@/core/lib/api/entity/generic-handler'
+import type { EntityConfig } from '@/core/lib/entities/types'
+
+const { mocks } = harness
+
+type Res = { status: number; body: { code?: string; error?: string; details?: unknown } }
+const TEAM_HEADERS = { 'x-team-id': 'team-1' }
+
+function useEntity(entity: EntityConfig) {
+  mocks.resolveEntityFromUrl.mockResolvedValue({
+    isValidEntity: true, entityConfig: entity, entityName: entity.slug, hasCustomOverride: false,
+  })
+}
+
+function listSql(): [string, unknown[]] {
+  const call = mocks.queryWithRLS.mock.calls.find(([sql]: [string]) => sql.includes('FROM "pets"'))
+  expect(call).toBeDefined()
+  return call as [string, unknown[]]
+}
+
+beforeEach(() => {
+  harness.reset()
+  mocks.authenticateRequest.mockResolvedValue(SESSION_AUTH())
+})
+
+describe('handleGenericList — #97 list parameter validation', () => {
+  describe('search', () => {
+    it('returns 400 SEARCH_NOT_SUPPORTED when the entity has none of name/title/slug/content', async () => {
+      useEntity({
+        ...PETS_ENTITY,
+        fields: PETS_ENTITY.fields.filter(f => f.name !== 'name'),
+      } as EntityConfig)
+
+      const response = await handleGenericList(makeRequest({ url: listUrl({ search: 'rex' }), headers: TEAM_HEADERS })) as unknown as Res
+
+      expect(response.status).toBe(400)
+      expect(response.body.code).toBe('SEARCH_NOT_SUPPORTED')
+      expect(mocks.queryWithRLS).not.toHaveBeenCalled()
+    })
+
+    it('still applies search when a searchable field exists', async () => {
+      const response = await handleGenericList(makeRequest({ url: listUrl({ search: 'rex' }), headers: TEAM_HEADERS })) as unknown as Res
+
+      expect(response.status).toBe(200)
+      const [sql, params] = listSql()
+      expect(sql).toContain('t.name ILIKE $')
+      expect(params).toContain('%rex%')
+    })
+  })
+
+  describe('custom filters', () => {
+    it('returns 400 INVALID_FILTER naming the unknown key(s) instead of silently dropping them', async () => {
+      const response = await handleGenericList(
+        makeRequest({ url: listUrl({ statuz: 'active', colour: 'brown', status: 'active' }), headers: TEAM_HEADERS })
+      ) as unknown as Res
+
+      expect(response.status).toBe(400)
+      expect(response.body.code).toBe('INVALID_FILTER')
+      expect(response.body.error).toContain('statuz')
+      expect(response.body.error).toContain('colour')
+      expect(response.body.details).toEqual(expect.objectContaining({ invalidKeys: ['statuz', 'colour'] }))
+      expect(mocks.queryWithRLS).not.toHaveBeenCalled()
+    })
+
+    it('keeps accepting known handler params that are not entity fields', async () => {
+      const response = await handleGenericList(
+        makeRequest({
+          url: listUrl({ page: '2', limit: '5', sortBy: 'name', sortOrder: 'asc', metas: 'all', child: 'all', userFiltered: 'true', status: 'active' }),
+          headers: TEAM_HEADERS,
+        })
+      ) as unknown as Res
+
+      expect(response.status).toBe(200)
+      const [sql, params] = listSql()
+      expect(sql).toContain('t."status" = $')
+      expect(params).toContain('active')
+    })
+
+    it('keeps accepting the legacy client params existing callers send (includeMeta, userId, sort, order)', async () => {
+      // EntityApiClient.list sends includeMeta/userId; PublicEntityGrid sends sort/order.
+      const response = await handleGenericList(
+        makeRequest({
+          url: listUrl({ includeMeta: 'true', userId: 'session-user-1', sort: 'name', order: 'asc' }),
+          headers: TEAM_HEADERS,
+        })
+      ) as unknown as Res
+
+      expect(response.status).toBe(200)
+      const [sql] = listSql()
+      // sort/order are honoured as aliases of sortBy/sortOrder
+      expect(sql).toContain('ORDER BY t."name" ASC')
+    })
+
+    it('accepts taxonomy filter params only for taxonomy-enabled entities', async () => {
+      // Not enabled → categoryId is just an unknown key
+      const rejected = await handleGenericList(makeRequest({ url: listUrl({ categoryId: 'cat-1' }), headers: TEAM_HEADERS })) as unknown as Res
+      expect(rejected.status).toBe(400)
+      expect(rejected.body.code).toBe('INVALID_FILTER')
+
+      // Enabled → routed to the taxonomy EXISTS filter
+      useEntity({
+        ...PETS_ENTITY,
+        taxonomies: { enabled: true, types: [{ type: 'category', field: 'categories' }] },
+      } as unknown as EntityConfig)
+      const accepted = await handleGenericList(makeRequest({ url: listUrl({ categoryId: 'cat-1' }), headers: TEAM_HEADERS })) as unknown as Res
+      expect(accepted.status).toBe(200)
+      const [sql, params] = listSql()
+      expect(sql).toContain('etr."taxonomyId" = $')
+      expect(params).toContain('cat-1')
+    })
+  })
+
+  describe('sortBy', () => {
+    it('returns 400 INVALID_SORT_FIELD for a field that is neither an entity field nor a base column', async () => {
+      const response = await handleGenericList(makeRequest({ url: listUrl({ sortBy: 'nope' }), headers: TEAM_HEADERS })) as unknown as Res
+
+      expect(response.status).toBe(400)
+      expect(response.body.code).toBe('INVALID_SORT_FIELD')
+      expect(response.body.error).toContain('nope')
+      expect(mocks.queryWithRLS).not.toHaveBeenCalled()
+    })
+
+    it('sorts by a valid entity field or base column', async () => {
+      await handleGenericList(makeRequest({ url: listUrl({ sortBy: 'name', sortOrder: 'asc' }), headers: TEAM_HEADERS }))
+      expect(listSql()[0]).toContain('ORDER BY t."name" ASC')
+
+      mocks.queryWithRLS.mockClear()
+      await handleGenericList(makeRequest({ url: listUrl({ sortBy: 'updatedAt' }), headers: TEAM_HEADERS }))
+      expect(listSql()[0]).toContain('ORDER BY t."updatedAt" DESC')
+    })
+  })
+
+  describe('date / datetime equality filters', () => {
+    it('expands a bare YYYY-MM-DD equality filter on a datetime field into a whole-day range', async () => {
+      const response = await handleGenericList(
+        makeRequest({ url: listUrl({ adoptedAt: '2026-01-15' }), headers: TEAM_HEADERS })
+      ) as unknown as Res
+
+      expect(response.status).toBe(200)
+      const [sql, params] = listSql()
+      // No bare equality against the timestamptz column
+      expect(sql).not.toMatch(/t\."adoptedAt" = \$/)
+      // Lower bound inclusive, upper bound exclusive (next day)
+      expect(sql).toMatch(/t\."adoptedAt" >= \$\d+::date AND t\."adoptedAt" < \$\d+::date \+ 1/)
+      expect(params.filter(p => p === '2026-01-15')).toHaveLength(2)
+    })
+
+    it('ORs multiple day values on the same datetime field', async () => {
+      await handleGenericList(makeRequest({ url: listUrl({ adoptedAt: '2026-01-15,2026-01-16' }), headers: TEAM_HEADERS }))
+
+      const [sql, params] = listSql()
+      expect(sql.match(/t\."adoptedAt" >= \$\d+::date/g)).toHaveLength(2)
+      expect(params).toEqual(expect.arrayContaining(['2026-01-15', '2026-01-16']))
+    })
+
+    it('keeps exact equality when the value carries a time component', async () => {
+      await handleGenericList(makeRequest({ url: listUrl({ adoptedAt: '2026-01-15T10:30:00Z' }), headers: TEAM_HEADERS }))
+
+      const [sql, params] = listSql()
+      expect(sql).toMatch(/t\."adoptedAt" = \$/)
+      expect(params).toContain('2026-01-15T10:30:00Z')
+    })
+
+    it('leaves non-date fields on plain equality', async () => {
+      await handleGenericList(makeRequest({ url: listUrl({ status: '2026-01-15' }), headers: TEAM_HEADERS }))
+
+      const [sql] = listSql()
+      expect(sql).toMatch(/t\."status" = \$/)
+      expect(sql).not.toContain('::date')
+    })
+  })
+})
+
+describe('handleGenericCreate / handleGenericUpdate — #97 CHECK constraint violations', () => {
+  function pgError(code: string, extra: Record<string, unknown> = {}) {
+    return Object.assign(new Error('db error'), { code, ...extra })
+  }
+
+  it('maps a 23514 on INSERT to 422 CHECK_CONSTRAINT_VIOLATION naming the constraint', async () => {
+    mocks.mutateWithRLS.mockRejectedValue(pgError('23514', { constraint: 'pets_week_start_monday', table: 'pets' }))
+
+    const response = await handleGenericCreate(makeRequest({
+      method: 'POST', url: 'http://localhost/api/v1/pets', headers: TEAM_HEADERS, body: { name: 'Rex' },
+    })) as unknown as Res
+
+    expect(response.status).toBe(422)
+    expect(response.body.code).toBe('CHECK_CONSTRAINT_VIOLATION')
+    expect(response.body.error).toContain('pets_week_start_monday')
+    expect(response.body.details).toEqual(expect.objectContaining({ constraint: 'pets_week_start_monday' }))
+  })
+
+  it('maps a 23514 on UPDATE the same way', async () => {
+    mocks.mutateWithRLS.mockRejectedValue(pgError('23514', { constraint: 'pets_status_check' }))
+
+    const response = await handleGenericUpdate(
+      makeRequest({ method: 'PATCH', url: 'http://localhost/api/v1/pets/pet-1', headers: TEAM_HEADERS, body: { status: 'bogus' } }),
+      { params: Promise.resolve({ entity: 'pets', id: 'pet-1' }) }
+    ) as unknown as Res
+
+    expect(response.status).toBe(422)
+    expect(response.body.code).toBe('CHECK_CONSTRAINT_VIOLATION')
+    expect(response.body.details).toEqual(expect.objectContaining({ constraint: 'pets_status_check' }))
+  })
+
+  it('maps a 23503 on INSERT (dangling reference) to 422 FOREIGN_KEY_VIOLATION', async () => {
+    mocks.mutateWithRLS.mockRejectedValue(pgError('23503', { constraint: 'pets_ownerId_fkey', detail: 'Key (ownerId)=(x) is not present in table "users".' }))
+
+    const response = await handleGenericCreate(makeRequest({
+      method: 'POST', url: 'http://localhost/api/v1/pets', headers: TEAM_HEADERS, body: { name: 'Rex', ownerId: 'x' },
+    })) as unknown as Res
+
+    expect(response.status).toBe(422)
+    expect(response.body.code).toBe('FOREIGN_KEY_VIOLATION')
+    expect(response.body.details).toEqual(expect.objectContaining({ constraint: 'pets_ownerId_fkey' }))
+  })
+
+  it('regression: 23505 still maps to 409 UNIQUE_CONSTRAINT_VIOLATION and unknown errors stay 500', async () => {
+    mocks.mutateWithRLS.mockRejectedValueOnce(pgError('23505', { constraint: 'pets_name_key' }))
+    const conflict = await handleGenericCreate(makeRequest({
+      method: 'POST', url: 'http://localhost/api/v1/pets', headers: TEAM_HEADERS, body: { name: 'Rex' },
+    })) as unknown as Res
+    expect(conflict.status).toBe(409)
+    expect(conflict.body.code).toBe('UNIQUE_CONSTRAINT_VIOLATION')
+
+    mocks.mutateWithRLS.mockRejectedValueOnce(new Error('connection reset'))
+    const boom = await handleGenericCreate(makeRequest({
+      method: 'POST', url: 'http://localhost/api/v1/pets', headers: TEAM_HEADERS, body: { name: 'Rex' },
+    })) as unknown as Res
+    expect(boom.status).toBe(500)
+  })
+})

--- a/packages/core/tests/jest/api/entity/generic-handler-update-system-fields.test.ts
+++ b/packages/core/tests/jest/api/entity/generic-handler-update-system-fields.test.ts
@@ -1,0 +1,104 @@
+/**
+ * Regression coverage for the #97 follow-up found in the integration E2E run:
+ * the dashboard edit form PATCHes the whole record it loaded (system columns
+ * included) and the strict update schema answered 400 "Unknown field(s): id,
+ * createdAt, updatedAt", so no entity could be edited from the UI. The update
+ * path must strip those columns and keep rejecting real typos.
+ *
+ * Uses the real schema generator through the harness mock.
+ */
+
+import { harness, makeRequest, SESSION_AUTH } from './__helpers__/generic-handler-harness'
+import { handleGenericUpdate } from '@/core/lib/api/entity/generic-handler'
+import type { EntityConfig } from '@/core/lib/entities/types'
+
+const { mocks } = harness
+
+type Res = { status: number; body: { success: boolean; code?: string; error?: string; data?: Record<string, unknown> } }
+const TEAM_HEADERS = { 'x-team-id': 'team-1' }
+
+const NOTES_ENTITY = {
+  slug: 'notes',
+  tableName: 'notes',
+  access: { api: true },
+  fields: [
+    {
+      name: 'title',
+      type: 'text',
+      required: true,
+      display: { label: 'Title', description: '', showInList: true, showInDetail: true, showInForm: true, order: 1 },
+      validation: {},
+      api: { searchable: true, sortable: true, readOnly: false },
+    },
+    {
+      name: 'body',
+      type: 'textarea',
+      required: false,
+      display: { label: 'Body', description: '', showInList: true, showInDetail: true, showInForm: true, order: 2 },
+      validation: {},
+      api: { searchable: false, sortable: false, readOnly: false },
+    },
+  ],
+} as unknown as EntityConfig
+
+const STORED_ROW = {
+  id: 'note-1',
+  userId: 'user-1',
+  teamId: 'team-1',
+  createdAt: '2026-09-01T22:24:55.058Z',
+  updatedAt: '2026-09-01T22:24:55.058Z',
+  title: 'Original',
+  body: 'Original body',
+}
+
+function patch(body: Record<string, unknown>) {
+  return handleGenericUpdate(
+    makeRequest({ method: 'PATCH', url: 'http://localhost/api/v1/notes/note-1', headers: TEAM_HEADERS, body }),
+    { params: Promise.resolve({ entity: 'notes', id: 'note-1' }) }
+  ) as unknown as Promise<Res>
+}
+
+beforeEach(() => {
+  harness.reset()
+  mocks.resolveEntityFromUrl.mockResolvedValue({
+    isValidEntity: true,
+    entityConfig: NOTES_ENTITY,
+    entityName: 'notes',
+    hasCustomOverride: false,
+  })
+  mocks.authenticateRequest.mockResolvedValue(SESSION_AUTH())
+  // Real schemas, not the permissive harness stub — the strict policy is the subject here.
+  const { generateEntitySchemas } = jest.requireActual('@/core/lib/entities/schema-generator') as typeof import('@/core/lib/entities/schema-generator')
+  mocks.generateEntitySchemas.mockImplementation(generateEntitySchemas)
+  mocks.mutateWithRLS.mockResolvedValue({ rows: [{ ...STORED_ROW, title: 'Edited from the form' }] })
+})
+
+describe('handleGenericUpdate — PATCH with the full record (#97 follow-up)', () => {
+  it('accepts the record the edit form sends back, system columns included, and updates the row', async () => {
+    const response = await patch({ ...STORED_ROW, title: 'Edited from the form' })
+
+    expect(response.status).toBe(200)
+    expect(response.body.success).toBe(true)
+    const updates = mocks.mutateWithRLS.mock.calls.filter(([sql]: [string]) => sql.includes('UPDATE "notes"')) as Array<[string, unknown[]]>
+    expect(updates).toHaveLength(1)
+    const [sql, params] = updates[0]
+    expect(params).toContain('Edited from the form')
+    // The read-only columns from the body never reach the SET clause; the
+    // handler stamps `updatedAt` itself with CURRENT_TIMESTAMP, not from input.
+    for (const column of ['"id" = $', '"createdAt" = $', '"updatedAt" = $']) {
+      expect(sql).not.toContain(column)
+    }
+    expect(sql).toContain('"updatedAt" = CURRENT_TIMESTAMP')
+  })
+
+  it('still answers 400 VALIDATION_ERROR naming a genuinely unknown key', async () => {
+    const response = await patch({ ...STORED_ROW, titel: 'typo' })
+
+    expect(response.status).toBe(400)
+    expect(response.body.code).toBe('VALIDATION_ERROR')
+    expect(response.body.error).toBe('Unknown field(s): titel')
+    // No UPDATE was issued (the only write is #105's audit-log row).
+    const updates = mocks.mutateWithRLS.mock.calls.filter(([sql]: [string]) => sql.includes('UPDATE "notes"'))
+    expect(updates).toHaveLength(0)
+  })
+})

--- a/packages/core/tests/jest/api/entity/generic-handler.test.ts
+++ b/packages/core/tests/jest/api/entity/generic-handler.test.ts
@@ -172,6 +172,16 @@ const PETS_ENTITY: EntityConfig = {
   },
 } as unknown as EntityConfig;
 
+/**
+ * Assert no entity row was written. Since #105 every authenticated request
+ * also INSERTs an api_audit_log row through mutateWithRLS, so "not called at
+ * all" is no longer the right check for a denied write.
+ */
+function expectNoEntityWrite() {
+  const entityWrites = mockMutateWithRLS.mock.calls.filter(([sql]: [string]) => !sql.includes('api_audit_log'));
+  expect(entityWrites).toHaveLength(0);
+}
+
 function routeQueryOneWithRLS(teamRole: string | null, memberExists = true) {
   mockQueryOneWithRLS.mockImplementation(async (sql: string) => {
     if (sql.includes('SELECT id FROM "team_members"')) {
@@ -291,7 +301,7 @@ describe('handleGenericUpdate — fieldGuards now apply to API-key auth', () => 
     const response = await handleGenericUpdate(request, { params: Promise.resolve({ entity: 'pets', id: 'pet-1' }) });
 
     expect((response as { status: number }).status).toBe(403);
-    expect(mockMutateWithRLS).not.toHaveBeenCalled();
+    expectNoEntityWrite();
   });
 
   it('allows an API-key PATCH that does not touch a guarded field', async () => {
@@ -350,7 +360,7 @@ describe('handleGenericCreate & handleGenericUpdate — a :write scope does not 
 
     expect((response as { status: number }).status).toBe(403);
     expect(mockCheckPermission).toHaveBeenCalledWith('key-owner-1', 'team-1', 'pets.create');
-    expect(mockMutateWithRLS).not.toHaveBeenCalled();
+    expectNoEntityWrite();
   });
 
   it('allows update for the SAME :write-scoped key, since that role does hold update permission', async () => {

--- a/packages/core/tests/jest/lib/entities/schema-generator-strict.test.ts
+++ b/packages/core/tests/jest/lib/entities/schema-generator-strict.test.ts
@@ -114,3 +114,55 @@ describe('generateEntitySchemas — #97 strict object schemas', () => {
     expect(result.success).toBe(false)
   })
 })
+
+describe('generateEntitySchemas — update schema tolerates the record a client PATCHes back (#97 follow-up)', () => {
+  const fullRecord = {
+    id: 'row-1',
+    userId: 'user-1',
+    teamId: 'team-1',
+    createdAt: '2026-09-01T22:24:55.058Z',
+    updatedAt: '2026-09-01T22:24:55.058Z',
+    title: 'Edited from the form',
+    note: null,
+  }
+
+  it('strips the system/read-only columns instead of rejecting them as unknown keys', () => {
+    const { update } = generateEntitySchemas(makeConfig())
+
+    const result = update.safeParse(fullRecord)
+
+    expect(result.success).toBe(true)
+    expect(result.success && result.data).toEqual({ title: 'Edited from the form', note: null })
+  })
+
+  it('also strips soft-delete markers and entity fields flagged api.readOnly', () => {
+    const { update } = generateEntitySchemas(makeConfig({
+      table: { softDelete: true },
+      fields: [
+        ...makeConfig().fields,
+        {
+          name: 'computedScore',
+          type: 'number',
+          required: false,
+          display: { label: 'Score', description: '', showInList: true, showInDetail: true, showInForm: false, order: 3 },
+          validation: {},
+          api: { searchable: false, sortable: true, readOnly: true },
+        },
+      ],
+    } as unknown as Partial<EntityConfig>))
+
+    const result = update.safeParse({ ...fullRecord, deletedAt: null, deletedBy: null, computedScore: 42 })
+
+    expect(result.success).toBe(true)
+    expect(result.success && result.data).toEqual({ title: 'Edited from the form', note: null })
+  })
+
+  it('still rejects a genuinely unknown key alongside the system columns', () => {
+    const { update } = generateEntitySchemas(makeConfig())
+
+    const result = update.safeParse({ ...fullRecord, notes: 'typo' })
+
+    expect(result.success).toBe(false)
+    expect(result.success || result.error.issues.map(issue => issue.code)).toContain('unrecognized_keys')
+  })
+})

--- a/packages/core/tests/jest/lib/entities/schema-generator-strict.test.ts
+++ b/packages/core/tests/jest/lib/entities/schema-generator-strict.test.ts
@@ -1,0 +1,116 @@
+/**
+ * Regression coverage for #97 (case 5): the create/update schemas built by
+ * generateEntitySchemas used plain z.object(), whose default is to silently
+ * STRIP unknown keys. `POST { notes: '...' }` against an entity whose field is
+ * `note` returned 201 with the value quietly discarded. The schemas are now
+ * strict: unknown keys fail validation so the handler can answer 400.
+ */
+
+jest.mock('server-only', () => ({}))
+
+import { generateEntitySchemas } from '@/core/lib/entities/schema-generator'
+import type { EntityConfig } from '@/core/lib/entities/types'
+import { FileText } from 'lucide-react'
+
+function makeConfig(extra: Partial<EntityConfig> = {}): EntityConfig {
+  return {
+    slug: 'events',
+    enabled: true,
+    names: { singular: 'Event', plural: 'Events' },
+    icon: FileText,
+    access: { public: false, api: true, metadata: false, shared: false },
+    ui: {
+      dashboard: { showInMenu: false, showInTopbar: false },
+      public: { hasArchivePage: false, hasSinglePage: false },
+      features: { searchable: false, sortable: false, filterable: false, bulkOperations: false, importExport: false },
+    },
+    i18n: { fallbackLocale: 'en', loaders: { en: async () => ({}) } },
+    fields: [
+      {
+        name: 'title',
+        type: 'text',
+        required: true,
+        display: { label: 'Title', description: '', showInList: true, showInDetail: true, showInForm: true, order: 1 },
+        validation: {},
+        api: { searchable: true, sortable: true, readOnly: false },
+      },
+      {
+        name: 'note',
+        type: 'textarea',
+        required: false,
+        display: { label: 'Note', description: '', showInList: true, showInDetail: true, showInForm: true, order: 2 },
+        validation: {},
+        api: { searchable: false, sortable: false, readOnly: false },
+      },
+    ],
+    ...extra,
+  } as unknown as EntityConfig
+}
+
+describe('generateEntitySchemas — #97 strict object schemas', () => {
+  it('create schema rejects an unknown key instead of stripping it', () => {
+    const { create } = generateEntitySchemas(makeConfig())
+
+    const result = create.safeParse({ title: 'Launch', notes: 'typo for note' })
+
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      const issue = result.error.issues.find(i => i.code === 'unrecognized_keys')
+      expect(issue).toBeDefined()
+      expect((issue as { keys: string[] }).keys).toEqual(['notes'])
+    }
+  })
+
+  it('update schema (partial) is strict as well', () => {
+    const { update } = generateEntitySchemas(makeConfig())
+
+    const ok = update.safeParse({ note: 'fine' })
+    expect(ok.success).toBe(true)
+
+    const bad = update.safeParse({ notes: 'typo' })
+    expect(bad.success).toBe(false)
+  })
+
+  it('still accepts every declared field, plus the handler-managed `children`, `blocks` and builder `settings` keys', () => {
+    const { create } = generateEntitySchemas(makeConfig({
+      builder: { enabled: true },
+      childEntities: {
+        sessions: {
+          fields: [{ name: 'label', type: 'text', required: false }],
+        },
+      },
+    } as unknown as Partial<EntityConfig>))
+
+    const result = create.safeParse({
+      title: 'Launch',
+      note: 'ok',
+      blocks: [],
+      settings: { seo: {}, customFields: [] },
+      children: { sessions: [{ label: 'Day 1' }] },
+    })
+
+    expect(result.success).toBe(true)
+  })
+
+  it('rejects builder-only keys on entities without the builder enabled', () => {
+    const { create } = generateEntitySchemas(makeConfig())
+
+    expect(create.safeParse({ title: 'Launch', blocks: [] }).success).toBe(false)
+    expect(create.safeParse({ title: 'Launch', settings: {} }).success).toBe(false)
+  })
+
+  it('child entity schemas are strict too', () => {
+    const { create } = generateEntitySchemas(makeConfig({
+      childEntities: {
+        sessions: { fields: [{ name: 'label', type: 'text', required: false }] },
+      },
+    } as unknown as Partial<EntityConfig>))
+
+    const result = create.safeParse({
+      title: 'Launch',
+      children: { sessions: [{ label: 'Day 1', lable: 'typo' }] },
+    })
+
+    expect(result.success).toBe(false)
+  })
+})


### PR DESCRIPTION
## Description
Four related fixes to `packages/core/src/lib/api/entity/generic-handler.ts`.

## Changes
- **#96 (security, highest priority)**: `?fields=X&distinct=true` interpolated the field name into SQL without validating it against `entityConfig.fields` — the sibling non-distinct branch already validated correctly. Now validates identically. Live-verified: injection payload now rejected with 400 instead of executing.
- #118: `beforeEntityCreate` hook is now invoked in `handleGenericCreate` (was already wired for update, never for create)
- #97: rejects invalid list params and unknown body keys, maps unmapped CHECK-constraint errors to proper responses
- #105: adds audit logging for generic entity routes, with a new migration making `api_audit_log.apiKeyId` nullable

## Regression found and fixed in this same branch
The original #97 implementation added `.strict()` to generated update schemas, which broke saving **any** entity edit from the dashboard UI (the edit form submits the full record including read-only system fields like `id`/`createdAt`/`updatedAt`, which `.strict()` then rejected with a silent 400 — no toast, `console.error` only). Fixed by having the update schema `.omit()` system/read-only fields instead of rejecting them, and by surfacing save errors in the UI form instead of swallowing them. This was caught during a full clean-install + browser E2E validation pass, not by unit tests alone.

## ⚠️ Coordination needed with other open PRs
- **Expect a real merge conflict with #141** (`bugfix/112-93-api-auth-helpers-fg`) in `generic-handler.ts` if that PR is merged first, or vice versa. Both branches modify the same handlers independently. Resolution: preserve both sides — #105's audit wrapper needs to keep working around #93's early returns on scope failure. A combined-branch reference resolution exists if needed.
- **Migration numbering**: this PR's new migration and #143 were both authored independently as `025_...`, with different filenames (no git conflict). Whichever of the two PRs merges **second** must renumber its migration to `026_...` and re-run migrations to confirm the sequence is still consistent.

## Testing
- [x] Live curl verification for #96 (injection rejected)
- [x] Unit tests for all four (40/40 for #97's validation alone)
- [x] Regression test for the update-schema fix (RED before, GREEN after) + real UI edit flow re-verified against a packaged clean install
- [x] Full core suite: only the 3 known pre-existing failures

## Related Issues
- Fixes #96, #118, #97, #105
