### PR TITLE
Fix GHSA-rw2j-9mxg-rx98: gate team members/invitations GET by permission

### DIFF
--- a/apps/dev/app/api/v1/teams/[teamId]/invitations/route.ts
+++ b/apps/dev/app/api/v1/teams/[teamId]/invitations/route.ts
@@ -10,7 +10,7 @@ import {
 } from '@nextsparkjs/core/lib/api/helpers'
 import { authenticateRequest, createAuthFailureResponse } from '@nextsparkjs/core/lib/api/auth/dual-auth'
 import { withRateLimitTier } from '@nextsparkjs/core/lib/api/rate-limit'
-import { TeamMemberService, MembershipService } from '@nextsparkjs/core/lib/services'
+import { MembershipService } from '@nextsparkjs/core/lib/services'
 import type { TeamInvitation } from '@nextsparkjs/core/lib/teams/types'
 
 // Handle CORS preflight
@@ -42,10 +42,17 @@ export const GET = withRateLimitTier(withApiLogging(
         return addCorsHeaders(response, req)
       }
 
-      // Check if user is a member of the team
-      const isMember = await TeamMemberService.isMember(teamId, authResult.user!.id)
+      // Listing invitations — including who invited whom, to what role, and
+      // when it expires — is gated by the same 'team.members.invite'
+      // permission that already protects creating/cancelling one, not bare
+      // membership: an invitation's raw acceptance token grants whoever holds
+      // it the invitee's role, so a low-privilege member (member/viewer, who
+      // typically lack 'team.members.invite') must not be able to read it
+      // (see GHSA-rw2j-9mxg-rx98).
+      const membership = await MembershipService.get(authResult.user!.id, teamId)
+      const actionResult = membership.canPerformAction('team.members.invite')
 
-      if (!isMember) {
+      if (!actionResult.allowed) {
         const response = createApiError('Team not found or access denied', 404, null, 'TEAM_NOT_FOUND')
         return addCorsHeaders(response, req)
       }
@@ -57,15 +64,21 @@ export const GET = withRateLimitTier(withApiLogging(
       const status = searchParams.get('status') || 'pending'
       const offset = (page - 1) * limit
 
-      // Fetch team invitations
+      // Fetch team invitations — explicit column list, deliberately excluding
+      // "token": it is a bearer credential that grants the invitee's role to
+      // whoever holds it, and has no business leaving this endpoint at all
+      // (see GHSA-rw2j-9mxg-rx98). The accept flow re-derives it server-side
+      // from the URL param it already has; nothing legitimate reads it back
+      // from this list response.
       const invitations = await queryWithRLS<
-        TeamInvitation & {
+        Omit<TeamInvitation, 'token'> & {
           inviterName: string | null
           inviterEmail: string
         }
       >(
         `SELECT
-          ti.*,
+          ti.id, ti."teamId", ti.email, ti.role, ti.status, ti."invitedBy",
+          ti."expiresAt", ti."acceptedAt", ti."declinedAt", ti."createdAt", ti."updatedAt",
           u.name as "inviterName",
           u.email as "inviterEmail"
         FROM "team_invitations" ti

--- a/apps/dev/app/api/v1/teams/[teamId]/members/route.ts
+++ b/apps/dev/app/api/v1/teams/[teamId]/members/route.ts
@@ -52,11 +52,15 @@ export const GET = withRateLimitTier(withApiLogging(
       // Superadmins can view members of any team
       const userIsSuperAdmin = isSuperAdmin(authResult)
 
-      // Check if user is a member of the team (unless superadmin)
+      // Listing the roster is gated by the 'team.members.view' permission, not
+      // bare membership — membership only proves you belong to the team, not
+      // that your role is allowed to see who else does (a theme may grant
+      // 'team.members.view' to a subset of roles; see GHSA-rw2j-9mxg-rx98).
       if (!userIsSuperAdmin) {
-        const isMember = await TeamMemberService.isMember(teamId, authResult.user!.id)
+        const membership = await MembershipService.get(authResult.user!.id, teamId)
+        const actionResult = membership.canPerformAction('team.members.view')
 
-        if (!isMember) {
+        if (!actionResult.allowed) {
           const response = createApiError('Team not found or access denied', 404, null, 'TEAM_NOT_FOUND')
           return addCorsHeaders(response, req)
         }

--- a/packages/core/tests/jest/security/team-invitations-authz.test.ts
+++ b/packages/core/tests/jest/security/team-invitations-authz.test.ts
@@ -1,0 +1,40 @@
+/**
+ * Regression guard for GHSA-rw2j-9mxg-rx98.
+ *
+ * The two source-shape assertions below exist because the vulnerability was
+ * never a type error or a runtime crash — a bare membership check and a
+ * `SELECT ti.*` both compile and run fine. Nothing but a test that reads the
+ * actual route source would catch someone reintroducing either regression
+ * (e.g. "simplifying" the SELECT back to `ti.*`, or swapping the permission
+ * check back to `TeamMemberService.isMember`). The full authz behavior
+ * (member role blocked, owner role allowed, real DB round-trip) was verified
+ * live against a disposable database as part of this fix — see the commit
+ * message for the exact repro — since mocking MembershipService/queryWithRLS
+ * for this route has proven brittle elsewhere in this codebase.
+ */
+import { readFileSync } from 'fs'
+import { join } from 'path'
+
+const ROUTES_DIR = join(__dirname, '../../../../../apps/dev/app/api/v1/teams/[teamId]')
+
+describe('GHSA-rw2j-9mxg-rx98 — team members/invitations GET authorization', () => {
+  it('invitations route selects an explicit column list and never selects the bearer token', () => {
+    const source = readFileSync(join(ROUTES_DIR, 'invitations/route.ts'), 'utf8')
+    expect(source).not.toMatch(/SELECT\s+ti\.\*/)
+    expect(source).not.toMatch(/ti\."?token"?(?!Field)/i)
+  })
+
+  it('invitations GET gates on a permission check, not bare membership', () => {
+    const source = readFileSync(join(ROUTES_DIR, 'invitations/route.ts'), 'utf8')
+    const getHandlerSource = source.slice(0, source.indexOf('export const DELETE'))
+    expect(getHandlerSource).not.toMatch(/TeamMemberService\.isMember/)
+    expect(getHandlerSource).toMatch(/canPerformAction\(['"]team\.members\.invite['"]\)/)
+  })
+
+  it('members GET gates the non-superadmin path on a permission check, not bare membership', () => {
+    const source = readFileSync(join(ROUTES_DIR, 'members/route.ts'), 'utf8')
+    const getHandlerSource = source.slice(0, source.indexOf('export const POST'))
+    expect(getHandlerSource).not.toMatch(/TeamMemberService\.isMember/)
+    expect(getHandlerSource).toMatch(/canPerformAction\(['"]team\.members\.view['"]\)/)
+  })
+})


### PR DESCRIPTION
## Security fix (GHSA-rw2j-9mxg-rx98, draft advisory)

`GET /api/v1/teams/[teamId]/members` and `.../invitations` authorized on bare
`TeamMemberService.isMember()` instead of a real permission check, and
invitations selected `ti.*` — including the bearer `token` column — into the
response. Any team member (any role) could list pending invitations and read
their tokens, letting them accept an invite meant for someone else.

## Fix
- Both routes now gate on `MembershipService.get(userId, teamId).canPerformAction(...)`
  (`team.members.view` / `team.members.invite`) instead of bare membership.
- Invitations query uses an explicit column list, excluding `token`.

## Verification
Verified live against a disposable DB with real dev-keyring users: a
`member`-role user is correctly blocked (404) from invitations but still
sees the members roster; `owner` still sees invitations with no token in the
response. New regression test: `packages/core/tests/jest/security/team-invitations-authz.test.ts`.

Please review before merge — this touches team authorization.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_012Cs8ZvM2ySYUtyuRaDNdgM