### PR TITLE
Fix GHSA-66jx-f27r-q2fh: HTML-escape team-invitation email interpolation

### DIFF
--- a/packages/core/src/emails/team-invitation.ts
+++ b/packages/core/src/emails/team-invitation.ts
@@ -7,6 +7,7 @@
 
 import { getTranslations } from 'next-intl/server';
 import type { EmailContent, TeamInvitationEmailData } from '../lib/email/types';
+import { escapeHtml } from '../lib/auth/security-notifications/templates/shared';
 
 const APP_NAME_FALLBACK = process.env.NEXT_PUBLIC_APP_NAME || 'Your App';
 
@@ -47,7 +48,7 @@ export default async function teamInvitation(
                       <h2 style="color: #333333; font-size: 24px; margin: 0 0 20px 0; font-weight: 600;">${t('title')}</h2>
 
                       <p style="color: #666666; font-size: 16px; line-height: 1.6; margin: 0 0 20px 0;">
-                        ${t('bodyIntro', { inviterName: data.inviterName, teamName: data.teamName, role: data.role })}
+                        ${t('bodyIntro', { inviterName: escapeHtml(data.inviterName), teamName: escapeHtml(data.teamName), role: data.role })}
                       </p>
 
                       <p style="color: #666666; font-size: 16px; line-height: 1.6; margin: 0 0 30px 0;">
@@ -89,7 +90,7 @@ export default async function teamInvitation(
                         ${t('copyright', { year, appName })}
                       </p>
                       <p style="color: #999999; font-size: 12px; margin: 0;">
-                        ${t('footerSentTo', { inviteeEmail: data.inviteeEmail })}<br>
+                        ${t('footerSentTo', { inviteeEmail: escapeHtml(data.inviteeEmail) })}<br>
                         ${t('footerUnexpected')}
                       </p>
                     </td>

--- a/packages/core/tests/jest/emails/team-invitation-xss.test.ts
+++ b/packages/core/tests/jest/emails/team-invitation-xss.test.ts
@@ -1,0 +1,87 @@
+/**
+ * Regression test for GHSA-66jx-f27r-q2fh.
+ *
+ * teamName/inviterName/inviteeEmail are attacker-controllable (a team's name
+ * has no character restriction beyond a length CHECK; inviterName traces back
+ * to the inviter's own display name) and render in the INVITEE's inbox — a
+ * different person than whoever chose the value. Unescaped, that's a stored
+ * HTML injection with a distinct victim, not self-XSS.
+ */
+import teamInvitation from '../../../src/emails/team-invitation'
+
+const XSS_PAYLOAD = '<img src=x onerror=alert(document.domain)>'
+const ESCAPED_PAYLOAD = '&lt;img src=x onerror=alert(document.domain)&gt;'
+
+describe('GHSA-66jx-f27r-q2fh — team-invitation email HTML escaping', () => {
+  it('escapes an XSS payload in teamName and inviterName in the HTML body', async () => {
+    const result = await teamInvitation(
+      {
+        inviteeEmail: 'victim@example.com',
+        inviterName: XSS_PAYLOAD,
+        teamName: XSS_PAYLOAD,
+        role: 'member',
+        acceptUrl: 'https://example.com/accept-invite/tok',
+        expiresIn: '7 days',
+        appName: 'NextSpark',
+      },
+      'en',
+    )
+
+    expect(result.html).not.toContain(XSS_PAYLOAD)
+    expect(result.html).toContain(ESCAPED_PAYLOAD)
+  })
+
+  it('escapes an XSS payload in inviteeEmail in the HTML body', async () => {
+    const result = await teamInvitation(
+      {
+        inviteeEmail: `"><img src=x onerror=alert(1)>@example.com`,
+        inviterName: 'Alex Alpha',
+        teamName: 'Alpha Tech',
+        role: 'member',
+        acceptUrl: 'https://example.com/accept-invite/tok',
+        expiresIn: '7 days',
+        appName: 'NextSpark',
+      },
+      'en',
+    )
+
+    expect(result.html).not.toMatch(/<img src=x onerror=alert\(1\)>/)
+    expect(result.html).toContain('&lt;img src=x onerror=alert(1)&gt;')
+  })
+
+  it('does not double-escape a plain, non-malicious name', async () => {
+    const result = await teamInvitation(
+      {
+        inviteeEmail: 'victim@example.com',
+        inviterName: "O'Brien & Associates",
+        teamName: 'Alpha Tech',
+        role: 'member',
+        acceptUrl: 'https://example.com/accept-invite/tok',
+        expiresIn: '7 days',
+        appName: 'NextSpark',
+      },
+      'en',
+    )
+
+    expect(result.html).toContain('O&#39;Brien &amp; Associates')
+  })
+
+  it('leaves the subject line un-escaped (it is a mail header, not HTML)', async () => {
+    const result = await teamInvitation(
+      {
+        inviteeEmail: 'victim@example.com',
+        inviterName: 'Alex Alpha',
+        teamName: "O'Brien & Co",
+        role: 'member',
+        acceptUrl: 'https://example.com/accept-invite/tok',
+        expiresIn: '7 days',
+        appName: 'NextSpark',
+      },
+      'en',
+    )
+
+    expect(result.subject).toContain("O'Brien & Co")
+    expect(result.subject).not.toContain('&#39;')
+    expect(result.subject).not.toContain('&amp;')
+  })
+})


### PR DESCRIPTION
## Security fix (GHSA-66jx-f27r-q2fh, draft advisory)

`teamName`/`inviterName`/`inviteeEmail` are attacker-controllable (a team's
name has no character restriction beyond a length CHECK; `inviterName`
traces to the inviter's own display name) and rendered unescaped into the
HTML body of the team-invitation email — a stored HTML injection landing in
the **invitee's** inbox, a different person than whoever chose the value.

## Fix
`escapeHtml()` (already used elsewhere in `security-notifications/templates`)
applied to `inviterName`, `teamName` (body) and `inviteeEmail` (footer).
`subject` is intentionally left unescaped — it's a mail header, not HTML.

## Verification
New regression test: `packages/core/tests/jest/emails/team-invitation-xss.test.ts`
(4 cases: payload escaped in body/footer, no double-escaping of normal
characters, subject stays unescaped).

Please review before merge.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_012Cs8ZvM2ySYUtyuRaDNdgM