### PR TITLE
Fix #110: dark: utilities frozen to OS preference across all 4 themes (not a mobile bug)

### DIFF
--- a/themes/blog/styles/globals.css
+++ b/themes/blog/styles/globals.css
@@ -27,7 +27,20 @@
 @custom-variant dark (&:where(.dark, .dark *));
 
 @plugin "@tailwindcss/container-queries";
-@import "@nextsparkjs/core/styles/ui.css";
+/* @nextsparkjs/core/styles/ui.css is intentionally NOT imported here: it is
+   pre-compiled by packages/core/scripts/build/build-ui-css.mjs with a plain
+   `@import "tailwindcss"` that has no knowledge of this theme's
+   `@custom-variant dark` override above, so it bakes every dark: utility it
+   contains (including ThemeToggle's own dark:-rotate-90/scale-0 icon
+   classes) using Tailwind's default `@media (prefers-color-scheme: dark)`
+   strategy. Importing that already-compiled CSS re-declares the same
+   classes with that conflicting strategy, so they stop following
+   next-themes' `.dark`/`.light` class and instead silently track the
+   visitor's OS/browser color-scheme preference (issue #110). The @source
+   globs below already scan core's source (monorepo) and its compiled dist
+   output (npm) directly into THIS compilation, so they pick up the same
+   classes correctly scoped to `@custom-variant dark` — the separate ui.css
+   import is redundant. */
 @import "@nextsparkjs/core/styles/utilities.css";
 @import "@nextsparkjs/core/styles/docs.css";
 @source "../../../**/*.{js,ts,jsx,tsx}";

--- a/themes/crm/styles/globals.css
+++ b/themes/crm/styles/globals.css
@@ -29,7 +29,20 @@
 @custom-variant dark (&:where(.dark, .dark *));
 
 @plugin "@tailwindcss/container-queries";
-@import "@nextsparkjs/core/styles/ui.css";
+/* @nextsparkjs/core/styles/ui.css is intentionally NOT imported here: it is
+   pre-compiled by packages/core/scripts/build/build-ui-css.mjs with a plain
+   `@import "tailwindcss"` that has no knowledge of this theme's
+   `@custom-variant dark` override above, so it bakes every dark: utility it
+   contains (including ThemeToggle's own dark:-rotate-90/scale-0 icon
+   classes) using Tailwind's default `@media (prefers-color-scheme: dark)`
+   strategy. Importing that already-compiled CSS re-declares the same
+   classes with that conflicting strategy, so they stop following
+   next-themes' `.dark`/`.light` class and instead silently track the
+   visitor's OS/browser color-scheme preference (issue #110). The @source
+   globs below already scan core's source (monorepo) and its compiled dist
+   output (npm) directly into THIS compilation, so they pick up the same
+   classes correctly scoped to `@custom-variant dark` — the separate ui.css
+   import is redundant. */
 @import "@nextsparkjs/core/styles/utilities.css";
 @import "@nextsparkjs/core/styles/docs.css";
 @source "../../../**/*.{js,ts,jsx,tsx}";

--- a/themes/default/styles/globals.css
+++ b/themes/default/styles/globals.css
@@ -27,7 +27,20 @@
 @custom-variant dark (&:where(.dark, .dark *));
 
 @plugin "@tailwindcss/container-queries";
-@import "@nextsparkjs/core/styles/ui.css";
+/* @nextsparkjs/core/styles/ui.css is intentionally NOT imported here: it is
+   pre-compiled by packages/core/scripts/build/build-ui-css.mjs with a plain
+   `@import "tailwindcss"` that has no knowledge of this theme's
+   `@custom-variant dark` override above, so it bakes every dark: utility it
+   contains (including ThemeToggle's own dark:-rotate-90/scale-0 icon
+   classes) using Tailwind's default `@media (prefers-color-scheme: dark)`
+   strategy. Importing that already-compiled CSS re-declares the same
+   classes with that conflicting strategy, so they stop following
+   next-themes' `.dark`/`.light` class and instead silently track the
+   visitor's OS/browser color-scheme preference (issue #110). The @source
+   globs below already scan core's source (monorepo) and its compiled dist
+   output (npm) directly into THIS compilation, so they pick up the same
+   classes correctly scoped to `@custom-variant dark` — the separate ui.css
+   import is redundant. */
 @import "@nextsparkjs/core/styles/utilities.css";
 @import "@nextsparkjs/core/styles/docs.css";
 @source "../../../**/*.{js,ts,jsx,tsx}";

--- a/themes/productivity/styles/globals.css
+++ b/themes/productivity/styles/globals.css
@@ -27,7 +27,20 @@
 @custom-variant dark (&:where(.dark, .dark *));
 
 @plugin "@tailwindcss/container-queries";
-@import "@nextsparkjs/core/styles/ui.css";
+/* @nextsparkjs/core/styles/ui.css is intentionally NOT imported here: it is
+   pre-compiled by packages/core/scripts/build/build-ui-css.mjs with a plain
+   `@import "tailwindcss"` that has no knowledge of this theme's
+   `@custom-variant dark` override above, so it bakes every dark: utility it
+   contains (including ThemeToggle's own dark:-rotate-90/scale-0 icon
+   classes) using Tailwind's default `@media (prefers-color-scheme: dark)`
+   strategy. Importing that already-compiled CSS re-declares the same
+   classes with that conflicting strategy, so they stop following
+   next-themes' `.dark`/`.light` class and instead silently track the
+   visitor's OS/browser color-scheme preference (issue #110). The @source
+   globs below already scan core's source (monorepo) and its compiled dist
+   output (npm) directly into THIS compilation, so they pick up the same
+   classes correctly scoped to `@custom-variant dark` — the separate ui.css
+   import is redundant. */
 @import "@nextsparkjs/core/styles/utilities.css";
 @import "@nextsparkjs/core/styles/docs.css";
 @source "../../../**/*.{js,ts,jsx,tsx}";


### PR DESCRIPTION
## What #110 actually was

The reported symptom (\"ThemeToggle confirms the change but doesn't visually
apply on mobile <1024px\") turned out to have nothing to do with mobile,
viewport, or `ThemeToggle.tsx`'s own logic — it reproduces identically on
desktop, and was only reported as \"mobile\" because the reporter's OS
happened to be in dark mode at the time.

## Root cause

Every theme's `globals.css` did:
```css
@import \"@nextsparkjs/core/styles/ui.css\";
```
which resolves to `packages/core/dist/styles/ui.css` — a bundle **pre-compiled
in isolation** by `packages/core/scripts/build/build-ui-css.mjs`, with a
plain `@import \"tailwindcss\"` and no knowledge of any theme's
`@custom-variant dark`. Each theme separately declares:
```css
@custom-variant dark (&:where(.dark, .dark *));
```
so `next-themes` can drive dark mode via a class on `<html>`. Because
`ui.css` is compiled *before* that variant exists, every `dark:` utility
class living in `packages/core`'s own components — including
`ThemeToggle`'s own Sun/Moon icon (`dark:-rotate-90`, `dark:scale-0`, etc.),
`DevKeyring.tsx`, `DeveloperGuard.tsx`, the devtools viewers — got compiled
with Tailwind's *default* strategy, `@media (prefers-color-scheme: dark)`,
completely disconnected from the actual toggle. Reproduces in production
builds too, not a dev/Turbopack artifact.

Each theme's `globals.css` already has `@source` directives scanning
`packages/core`'s real component code (source in monorepo mode, `dist/**/*.js`
in npm mode) inside the *same* Tailwind compilation as the theme — so the
`ui.css` import was redundant on top of being harmful.

## Fix

Removed the `@import \"@nextsparkjs/core/styles/ui.css\";` line from all 4
themes (`default`, `crm`, `blog`, `productivity`), with a comment explaining
why, so it isn't reintroduced by accident. Verified each theme individually
before touching it — all 4 had the identical pattern.

Filed **#151** separately (not blocking this fix) to investigate whether
`ui.css`/`build-ui-css.mjs` should be removed entirely at the `packages/core`
build-system level, since nothing stops a new or regressed theme from
reintroducing this same import.

## Verification

- Isolated `@tailwindcss/cli` compilation of each theme's real
  `globals.css`: before the fix, 1 orphaned `@media
  (prefers-color-scheme: dark)` block per theme (111–146 classes,
  varies by theme); after, 0 — all `dark:` rules correctly scoped under
  `:where(.dark, .dark *)`. Confirmed `ThemeToggle`'s own `dark:scale-0`
  class specifically survives the fix, correctly re-scoped (nothing lost).
- End-to-end repro in `next dev --turbopack` with `agent-browser` (login,
  toggle theme, viewport 390×844 AND 1440×900): before the fix, background
  changes but the Sun/Moon icon stays frozen; after, icon switches
  correctly on both viewports. Toast + `aria-live` + `PATCH
  /api/user/profile` (200) unaffected in either state.
- Existing Jest suite for `ThemeToggle` unaffected (2/2 passing) — this bug
  is a CSS build-configuration issue, not React logic, so it was never
  visible to (and isn't fixed by) a component test.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_012Cs8ZvM2ySYUtyuRaDNdgM