### PR TITLE
Fix #128: audit-log scope/permission denials from a real, identified principal

### DIFF
--- a/packages/core/src/lib/api/auth/dual-auth.ts
+++ b/packages/core/src/lib/api/auth/dual-auth.ts
@@ -123,11 +123,18 @@ export async function authenticateRequest(
     if (failure) {
       // A presented key that fails scope enforcement is rejected outright —
       // it must never silently degrade to cookie auth or to anonymous access.
+      // `user`/`keyId` are carried over (not nulled) even though `success` is
+      // false: this is a REAL, identified key being denied, not an anonymous
+      // caller — #128 relies on that identity to audit-log the denial. Every
+      // consumer of DualAuthResult already gates on `success` before reading
+      // `user` (see canAccessDevtoolsApi, every generic-handler route), so
+      // this can't be mistaken for a granted request anywhere.
       return {
         success: false,
         type: 'api-key',
-        user: null,
+        user: apiKeyResult.user,
         scopes: apiKeyResult.scopes,
+        keyId: apiKeyResult.keyId,
         error: failure,
       }
     }

--- a/packages/core/src/lib/api/entity/audit-log.ts
+++ b/packages/core/src/lib/api/entity/audit-log.ts
@@ -8,8 +8,13 @@
  * written to `api_audit_log`.
  *
  * This module accepts the real `DualAuthResult` the handlers already hold and
- * writes one row per authenticated request (`apiKeyId` is NULL for sessions;
- * migration 025 dropped the NOT NULL). It is invoked fire-and-forget from
+ * writes one row per REQUEST WITH AN IDENTIFIABLE PRINCIPAL (`apiKeyId` is
+ * NULL for sessions; migration 025 dropped the NOT NULL) — a real session or
+ * a real API key, whether the request was ultimately allowed or denied for
+ * scope/permission reasons (#128). A request with no usable credential at all
+ * (anonymous, missing, or invalid) is still never logged: there is no "who"
+ * to attribute it to, and logging it would mostly capture bot/scanner noise
+ * rather than anything actionable. It is invoked fire-and-forget from
  * `runWithAuditLog` in generic-handler.ts, so a logging failure can never turn
  * a successful response into an error.
  *
@@ -36,9 +41,13 @@ export async function logGenericHandlerUsage(
   statusCode: number,
   responseTime?: number
 ): Promise<void> {
-  // Unauthenticated requests (public reads, 401s) have no principal to
-  // attribute the row to — "userId" is NOT NULL and that is intentional.
-  const userId = auth?.success ? auth.user?.id : undefined
+  // Requests with no identifiable principal (public reads, missing/invalid
+  // credentials) have nothing to attribute the row to — "userId" is NOT NULL
+  // and that is intentional. This is deliberately NOT gated on `auth.success`:
+  // a valid API key rejected for insufficient scope (#93's fail-closed
+  // enforcement) still carries a real `user` (see the scope-failure branch in
+  // authenticateRequest, dual-auth.ts) and #128 wants that denial logged too.
+  const userId = auth?.user?.id
   if (!userId) return
 
   const apiKeyId = auth?.type === 'api-key' ? auth.keyId ?? null : null

--- a/packages/core/tests/jest/api/entity/generic-handler-audit-log.test.ts
+++ b/packages/core/tests/jest/api/entity/generic-handler-audit-log.test.ts
@@ -77,6 +77,26 @@ describe('generic handlers — #105 audit logging', () => {
     expect(auditCalls()[0][1][4]).toBe(403)
   })
 
+  it('logs a scope-rejected API key (#128 — a real, identified key denied before it ever reached the handler)', async () => {
+    mocks.authenticateRequest.mockResolvedValue({
+      success: false,
+      type: 'api-key',
+      user: { id: 'key-owner-1', email: 'owner@test.com', role: 'user' },
+      scopes: ['pets:write'],
+      keyId: 'key-1',
+      error: { code: 'INSUFFICIENT_SCOPE', status: 403, message: 'Insufficient scope' },
+    })
+
+    const response = await handleGenericList(makeRequest({ headers: TEAM_HEADERS })) as unknown as Res
+    await flushPromises()
+
+    expect(response.status).toBe(403)
+    expect(auditCalls()).toHaveLength(1)
+    const [, params, rlsUserId] = auditCalls()[0]
+    expect(params.slice(0, 5)).toEqual(['key-1', 'key-owner-1', '/api/v1/pets', 'GET', 403])
+    expect(rlsUserId).toBe('key-owner-1')
+  })
+
   it('does not log unauthenticated requests (nothing to attribute the row to)', async () => {
     mocks.authenticateRequest.mockResolvedValue({ success: false, type: 'none', user: null })
 

--- a/packages/core/tests/jest/lib/api/auth/scope-enforcement.test.ts
+++ b/packages/core/tests/jest/lib/api/auth/scope-enforcement.test.ts
@@ -87,7 +87,11 @@ describe('authenticateRequest — API-key scope enforcement fails closed (#93)',
     const result = await authenticateRequest(makeRequest(KEY_HEADERS));
 
     expect(result.success).toBe(false);
-    expect(result.user).toBeNull();
+    // #128: the key is real and identified even though the request is denied —
+    // `user`/`keyId` are carried over (not nulled) so a denial like this one
+    // can still be attributed in the audit log, instead of looking anonymous.
+    expect(result.user?.id).toBe('user-sa');
+    expect(result.keyId).toBe('key-1');
     expect(result.type).toBe('api-key');
     expect(result.error).toMatchObject({ code: 'SCOPE_NOT_DECLARED', status: 403 });
   });
@@ -126,7 +130,8 @@ describe('authenticateRequest — API-key scope enforcement fails closed (#93)',
     const result = await authenticateRequest(makeRequest(KEY_HEADERS), { requiredScope: 'teams:write' });
 
     expect(result.success).toBe(false);
-    expect(result.user).toBeNull();
+    // #128: identity is preserved on a scope denial (see previous test).
+    expect(result.user?.id).toBe('user-sa');
     expect(result.error).toMatchObject({ code: 'INSUFFICIENT_SCOPE', status: 403 });
     expect(result.error?.message).toContain('teams:write');
   });


### PR DESCRIPTION
## RFC decision

\`api_audit_log\` only recorded successful requests — a request rejected for
insufficient API-key scope (#93's fail-closed enforcement) left zero trace.
Decision: log denials from an **already-authenticated** principal (real
session or real API key) that fails on scope/permission, but keep excluding
anonymous/unauthenticated traffic (no useful \"who\" to attribute it to, and
would mostly add bot/scanner noise).

## Root cause

\`checkAuthPermission\`-driven denials (team-role/permission, which run
*after* authentication already succeeded) were already logged. The real gap
was earlier: when an API key fails scope enforcement,
\`authenticateRequest\` (dual-auth.ts) built its failure result with
\`user: null\`, even though a real, identified key had already been
validated (\`apiKeyResult.user\`/\`apiKeyResult.keyId\` existed). With no
identity on the result, \`audit-log.ts\`'s guard (\`if (!auth.success)
return\`) had nothing to log against.

## Fix

- \`dual-auth.ts\`: the scope-failure branch now carries over
  \`apiKeyResult.user\` and \`apiKeyResult.keyId\` instead of nulling them.
  Every consumer of \`DualAuthResult\` already gates on \`.success\` before
  reading \`.user\` (checked all ~73 call sites plus \`canAccessDevtoolsApi\`
  specifically) — this can't be mistaken for a granted request anywhere.
- \`audit-log.ts\`: logs whenever \`auth.user?.id\` is present, regardless of
  \`auth.success\` — an anonymous/no-credential request still has no \`user\`
  at all, so it's still never logged.

## Verification

- New test: a scope-rejected API key now produces one audit row with the
  real key id/owner and the actual 403 status.
- Updated 2 existing tests in \`scope-enforcement.test.ts\` that asserted the
  old \`user: null\` behavior — this is the intentional change #128 asks
  for, not a regression, so they now assert the identity is preserved.
- Full Jest suite: same 3 pre-existing failing suites as \`main\` (verified
  via \`git stash\`/baseline comparison earlier this session), zero new
  failures. Typecheck and \`packages/core\` build clean.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_012Cs8ZvM2ySYUtyuRaDNdgM