### PR TITLE
Fix #115: TeamContext defaults to earliest-joined team, not API response order

### DIFF
--- a/packages/core/src/contexts/TeamContext.tsx
+++ b/packages/core/src/contexts/TeamContext.tsx
@@ -129,11 +129,25 @@ export function TeamProvider({ children }: { children: ReactNode }) {
     // id here would skip the initial sync entirely.
     if (currentTeam && userTeams.some(t => t.team.id === currentTeam.id)) return
 
-    // Determine active team (priority: localStorage > user's teams)
+    // Determine active team (priority: localStorage > earliest-joined team).
     const storedTeamId = typeof window !== 'undefined' ? localStorage.getItem('activeTeamId') : null
     // Only use stored team if user is actually a member of it
     const storedTeam = storedTeamId ? userTeams.find(t => t.team.id === storedTeamId) : null
-    const activeTeam = storedTeam || userTeams[0]
+    // #115: falling back to `userTeams[0]` picked whatever order the API
+    // response happened to return — for a multi-team user that's effectively
+    // random, and since this choice gets written to the server-side cookie
+    // below, it silently overrides resolveTeamContext()'s own fallback
+    // (dual-auth.ts's getUserDefaultTeamId(): the team with the EARLIEST
+    // "joinedAt"). Sorting by the same joinedAt field client-side — already
+    // present on every UserTeamMembership — matches that definition exactly,
+    // instead of letting the client and server independently improvise two
+    // different tie-breaks that can disagree.
+    const defaultTeam = storedTeam
+      ? undefined
+      : [...userTeams].sort(
+          (a, b) => new Date(a.joinedAt).getTime() - new Date(b.joinedAt).getTime()
+        )[0]
+    const activeTeam = storedTeam || defaultTeam
 
     if (activeTeam) {
       setCurrentTeam(activeTeam.team)

--- a/packages/core/tests/jest/contexts/TeamContext.test.tsx
+++ b/packages/core/tests/jest/contexts/TeamContext.test.tsx
@@ -28,8 +28,8 @@ jest.mock('next-intl', () => ({
 const TEAM_A = { id: 'team-a', name: 'Team A', slug: 'team-a', description: null, owner_id: 'user-1', avatar_url: null, settings: {}, created_at: '2026-01-01', updated_at: '2026-01-01' }
 const TEAM_B = { id: 'team-b', name: 'Team B', slug: 'team-b', description: null, owner_id: 'user-2', avatar_url: null, settings: {}, created_at: '2026-01-01', updated_at: '2026-01-01' }
 
-function membershipRow(team: typeof TEAM_A, role = 'owner') {
-  return { ...team, userRole: role }
+function membershipRow(team: typeof TEAM_A, role = 'owner', joinedAt = '2026-01-01T00:00:00Z') {
+  return { ...team, userRole: role, joined_at: joinedAt }
 }
 
 function Probe() {
@@ -67,6 +67,32 @@ describe('TeamProvider self-heal', () => {
     renderWithProviders()
 
     await waitFor(() => expect(screen.getByTestId('current-team').textContent).toBe('team-b'))
+  })
+
+  it('#115: with no stored team, picks the earliest-joined team, not whichever the API listed first', async () => {
+    // team-b joined first (earlier joinedAt) but is listed SECOND in the API
+    // response — a naive `userTeams[0]` pick would land on team-a instead,
+    // disagreeing with the server's own default (dual-auth.ts's
+    // getUserDefaultTeamId(): earliest "joinedAt").
+    ;(global.fetch as jest.Mock).mockImplementation((url: string) => {
+      if (url === '/api/v1/teams') {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({
+            data: [
+              membershipRow(TEAM_A, 'owner', '2026-03-01T00:00:00Z'),
+              membershipRow(TEAM_B, 'member', '2026-01-01T00:00:00Z'),
+            ],
+          }),
+        })
+      }
+      return Promise.resolve({ ok: true, json: async () => ({}) })
+    })
+
+    renderWithProviders()
+
+    await waitFor(() => expect(screen.getByTestId('current-team').textContent).toBe('team-b'))
+    expect(localStorage.getItem('activeTeamId')).toBe('team-b')
   })
 
   it('re-heals when the active team drops out of userTeams after a later refetch — not just once', async () => {


### PR DESCRIPTION
## Root cause (confirmed by the reporter's own follow-up correction on the issue)

\`TeamContext\`'s self-heal effect fell back to \`userTeams[0]\` when there was
no stored active team — whatever order \`/api/v1/teams\` happened to return,
effectively random for a multi-team user. Because this pick gets written to
the server-side \`activeTeamId\` cookie via \`POST /api/v1/teams/switch\`, it
silently overrides \`resolveTeamContext()\`'s own server-side fallback
(\`dual-auth.ts\`'s \`getUserDefaultTeamId()\`: the team with the **earliest**
\`joinedAt\`). Reported real-world impact: for a two-team user whose CRM data
lived in the second team, 8 of 9 dashboard screens silently rendered the
other (empty) team's data — indistinguishable from a broken list, since API
routes still authorize correctly against whatever team the cookie names.

## Why not literally \"default to \`user.defaultTeamId\`\" as first suggested

There is no client-exposed \`user.defaultTeamId\` — \`useAuth()\`'s session user
(better-auth) doesn't carry it. It's a value \`dual-auth.ts\` computes fresh
on each request (\`SELECT \"teamId\" FROM team_members WHERE \"userId\" = $1
ORDER BY \"joinedAt\" ASC LIMIT 1\`), never attached to the session.

## Fix

Sort the already-fetched \`userTeams\` by their own \`joinedAt\` (present on
every \`UserTeamMembership\`, no new API call needed) and take the earliest —
reproducing the exact same tie-break the server uses, so the client and
server can no longer independently land on two different \"default\" teams.

## Verification

- New test: two teams where the API lists the *later*-joined one first —
  confirms the *earlier*-joined one still wins.
- All 5 pre-existing \`TeamContext\` tests still pass unchanged (none of them
  exercised the no-stored-team path — this was genuinely untested before).
- Full Jest suite: same 3 pre-existing failing suites as \`main\`, zero new
  failures. Typecheck and \`packages/core\` build clean.

## Deliberately out of scope

The issue's secondary, softer finding: the generated dashboard layout's
page-level permission guard (\`if (userId && teamId && pathname) { ... }\`)
*skips* rather than denies when the \`activeTeamId\` cookie hasn't been
written yet on the very first server render (a race, not an absence — API
routes still authorize correctly, so not a data-exposure gap). That's a
template file (\`templates/app/dashboard/(main)/layout.tsx\`) every scaffolded
project inherits, not runtime code in this repo — worth its own decision
before touching it, not bundled into this fix.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_012Cs8ZvM2ySYUtyuRaDNdgM