### PR TITLE
Fix #115 follow-up: GET /api/v1/teams never sent joinedAt, the merged fix was a no-op

### DIFF
--- a/apps/dev/app/api/v1/teams/route.ts
+++ b/apps/dev/app/api/v1/teams/route.ts
@@ -91,7 +91,7 @@ export const GET = withRateLimitTier(withApiLogging(async (req: NextRequest): Pr
     // Add pagination params
     queryValues.push(limit, offset)
 
-    let teams: (Team & { userRole: string | null; memberCount: string })[]
+    let teams: (Team & { userRole: string | null; joinedAt?: string; memberCount: string })[]
     let totalResult: { count: string }[]
 
     if (requestAllTeams) {
@@ -120,17 +120,27 @@ export const GET = withRateLimitTier(withApiLogging(async (req: NextRequest): Pr
       )
     } else {
       // Regular user query: filter by membership
-      teams = await queryWithRLS<Team & { userRole: string; memberCount: string }>(
+      // tm."joinedAt" is unambiguous here (not an aggregation concern): the
+      // WHERE clause already pins tm."userId" = the caller, so tm is exactly
+      // this user's own membership row in each team — the same "joinedAt"
+      // dual-auth.ts's getUserDefaultTeamId() uses to pick a default team.
+      // Its absence here (never selected, even though the client sorted by
+      // it) made TeamContext's #115 fix a no-op in production: every
+      // `joinedAt` came back undefined, so `new Date(undefined).getTime()`
+      // compared NaN to NaN and the client silently kept the API's row
+      // order instead of the earliest-joined team.
+      teams = await queryWithRLS<Team & { userRole: string; joinedAt: string; memberCount: string }>(
         `SELECT
           t.*,
           tm.role as "userRole",
+          tm."joinedAt" as "joinedAt",
           COUNT(DISTINCT tm2.id) as "memberCount"
         FROM "teams" t
         INNER JOIN "team_members" tm ON t.id = tm."teamId"
         LEFT JOIN "team_members" tm2 ON t.id = tm2."teamId"
         ${whereClause}
         GROUP BY t.id, t.name, t.slug, t.description, t."ownerId", t."avatarUrl",
-                 t.settings, t.metadata, t."createdAt", t."updatedAt", tm.role
+                 t.settings, t.metadata, t."createdAt", t."updatedAt", tm.role, tm."joinedAt"
         ORDER BY ${orderByClause}
         LIMIT $${paramCount++} OFFSET $${paramCount++}`,
         queryValues,

--- a/packages/core/tests/jest/contexts/TeamContext.test.tsx
+++ b/packages/core/tests/jest/contexts/TeamContext.test.tsx
@@ -28,8 +28,14 @@ jest.mock('next-intl', () => ({
 const TEAM_A = { id: 'team-a', name: 'Team A', slug: 'team-a', description: null, owner_id: 'user-1', avatar_url: null, settings: {}, created_at: '2026-01-01', updated_at: '2026-01-01' }
 const TEAM_B = { id: 'team-b', name: 'Team B', slug: 'team-b', description: null, owner_id: 'user-2', avatar_url: null, settings: {}, created_at: '2026-01-01', updated_at: '2026-01-01' }
 
+// `joinedAt` (camelCase), matching apps/dev/app/api/v1/teams/route.ts's real
+// `tm."joinedAt" as "joinedAt"` column alias — NOT `joined_at`. A prior
+// version of this fixture used the snake_case fallback field instead of the
+// one the real endpoint actually sends, which is exactly how the #157 fix
+// shipped as a no-op in production: the mock exercised a code path the real
+// API response never took. See #157's follow-up fix in that route.
 function membershipRow(team: typeof TEAM_A, role = 'owner', joinedAt = '2026-01-01T00:00:00Z') {
-  return { ...team, userRole: role, joined_at: joinedAt }
+  return { ...team, userRole: role, joinedAt }
 }
 
 function Probe() {


### PR DESCRIPTION
## Critical finding

#115's merged fix (PR #157) sorts \`userTeams\` by \`joinedAt\` client-side
instead of trusting API response order. It was verified only against a Jest
mock that included a \`joined_at\` field the **real endpoint never returns**.

\`GET /api/v1/teams\`'s regular-user query selected \`t.*\`, \`tm.role\`, and a
member count — never \`tm."joinedAt"\`. In production, every
\`UserTeamMembership.joinedAt\` came back \`undefined\`, \`new
Date(undefined).getTime()\` compared \`NaN\` to \`NaN\` in the sort comparator,
and the client silently kept the API's row order — **the exact bug #115 was
supposed to fix, still present** in the merged code.

Found by an independent end-to-end validation pass dispatched through a
different worker (gpt-5.6 via Foundry/\`codex\`, orchestrated through Orca,
not Claude) that read the actual generated route source instead of trusting
the existing unit test — a genuinely useful catch from using a different
model/tooling for verification.

## Fix

- \`apps/dev/app/api/v1/teams/route.ts\`: select \`tm."joinedAt" as
  "joinedAt"\` (unambiguous — the \`WHERE\` clause already pins
  \`tm."userId"\` to the caller, so \`tm\` is exactly this user's own
  membership row per team) and add it to the \`GROUP BY\`. The superadmin
  \`scope=all\` query is untouched — \`joinedAt\` isn't a meaningful concept
  there.
- \`TeamContext.test.tsx\`: the fixture had been asserting through the
  snake_case \`joined_at\` fallback field instead of the camelCase
  \`joinedAt\` the real route actually sends — the exact mismatch class that
  let this ship as a no-op. Corrected to match the real contract.

## Verification

- Full Jest suite: same pre-existing failures as \`main\`, zero new.
- Typecheck clean for both the route (\`apps/dev\`'s own tsconfig) and
  \`packages/core\`.
- \`packages/core\` build clean.
- Still pending, and the real decisive check: a live browser + real Postgres
  re-run confirming a multi-team user actually lands on the earliest-joined
  team now — in progress separately.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_012Cs8ZvM2ySYUtyuRaDNdgM