### PR TITLE
Fix #130: nextspark init preserves local file:/link:/workspace: package refs

### DIFF
--- a/packages/cli/src/wizard/generators/index.ts
+++ b/packages/cli/src/wizard/generators/index.ts
@@ -198,6 +198,18 @@ async function patchTurbopackRootForMonorepo(): Promise<void> {
 }
 
 /**
+ * True when a package.json dependency spec is an explicit local reference
+ * (`file:`, `link:`, or `workspace:`) rather than something pnpm/npm resolved
+ * from a registry. Used to protect a deliberately-local `@nextsparkjs/*`
+ * install (e.g. from the /do:test-package validation flow) from being
+ * silently repinned to a published version by the "coherent install" step
+ * below (#130).
+ */
+function isLocalPackageRef(spec: string | undefined): boolean {
+  return typeof spec === 'string' && /^(file:|link:|workspace:)/.test(spec)
+}
+
+/**
  * Update or create package.json with required scripts and dependencies
  */
 async function updatePackageJson(config: WizardConfig): Promise<void> {
@@ -311,8 +323,17 @@ async function updatePackageJson(config: WizardConfig): Promise<void> {
   for (const [name, version] of Object.entries(depsToAdd)) {
     // Always (re)pin our packages to the CLI version for a coherent install;
     // pnpm may have resolved a different version during the initial install.
+    // EXCEPT when the existing spec is already an explicit local reference
+    // (file:/link:/workspace:) — that's never something pnpm "resolved", it's
+    // someone deliberately pointing this dependency at a local tarball or
+    // workspace package (the /do:test-package validation flow installs one
+    // before running `nextspark init`), and clobbering it back to a published
+    // npm version silently invalidates the whole point of testing local
+    // changes before publishing them (#130).
     if (name.startsWith('@nextsparkjs/')) {
-      packageJson.dependencies[name] = version
+      if (!isLocalPackageRef(packageJson.dependencies[name])) {
+        packageJson.dependencies[name] = version
+      }
     } else if (!packageJson.dependencies[name]) {
       packageJson.dependencies[name] = version
     }
@@ -358,9 +379,12 @@ async function updatePackageJson(config: WizardConfig): Promise<void> {
   }
 
   for (const [name, version] of Object.entries(devDepsToAdd)) {
-    // Always (re)pin our packages to the CLI version for a coherent install
+    // Always (re)pin our packages to the CLI version for a coherent install —
+    // same local-reference exception as the dependencies loop above (#130).
     if (name.startsWith('@nextsparkjs/')) {
-      packageJson.devDependencies[name] = version
+      if (!isLocalPackageRef(packageJson.devDependencies[name])) {
+        packageJson.devDependencies[name] = version
+      }
     } else if (!packageJson.devDependencies[name]) {
       packageJson.devDependencies[name] = version
     }


### PR DESCRIPTION
## Root cause

`updatePackageJson()` in `packages/cli/src/wizard/generators/index.ts` unconditionally (re)pinned every `@nextsparkjs/*` dependency (`core`, `cli` in `dependencies`; `testing` in `devDependencies`) to the CLI's own `nsVersion` during `nextspark init`, with no check for what was already there. The comment on the loop even said "Always (re)pin our packages to the CLI version for a coherent install" — but "always" included the case where someone had deliberately pointed a dependency at a local tarball or workspace package (`file:`, `link:`, `workspace:`), e.g. the `/do:test-package` validation flow that packs an unpublished local build before running `init`. The wizard silently rewrote that back to a published npm version and the subsequent `pnpm install` fetched the published package, invalidating the whole point of testing local changes.

## Fix

Added `isLocalPackageRef(spec)`, which detects an explicit `file:`/`link:`/`workspace:` prefix. Both repin loops (`dependencies` and `devDependencies`) now skip overwriting an `@nextsparkjs/*` entry when the existing spec is already a local reference, while still repinning/adding as before in every other case (third-party packages are unaffected — they were already only added when absent, never overwritten).

## Verification

Independently verified end-to-end in an isolated git worktree, following the exact repro from the issue:

1. `pnpm sync:templates:sync` + real `pnpm pack` of `ui`, `core`, `cli`, `testing`, `create-nextspark-app` into a fresh `.packages/`.
2. Generated a new project with the local `create-nextspark-app` build. **Before `init`**, `package.json` has:
   ```
   "@nextsparkjs/cli": "file:.../.packages/nextsparkjs-cli-0.1.0-beta.185.tgz",
   "@nextsparkjs/core": "file:.../.packages/nextsparkjs-core-0.1.0-beta.185.tgz",
   "@nextsparkjs/ui": "file:.../.packages/nextsparkjs-ui-0.1.0-beta.185.tgz",
   ```
3. Ran `nextspark init --preset saas --name Test130 --slug test130 --description "verify issue 130 fix" --type web --theme starter --yes < /dev/null` (non-interactive).
4. **After `init`**, diffing `package.json` line by line: the three `@nextsparkjs/*` `file:` entries are byte-for-byte unchanged. Only new third-party deps were added (plus `@nextsparkjs/testing`, added fresh at `0.1.0-beta.185` since no local ref existed for it before — correct behavior, not the bug).
5. Deeper check after the wizard's `pnpm install`: `readlink node_modules/@nextsparkjs/{core,cli,ui}` all resolve into `.pnpm/@nextsparkjs+*@file+..+.packages+...tgz.../`, confirming the installed packages are actually the local tarballs, not versions fetched from the registry.

Before this fix, the same repro rewrote the `core`/`cli` specs to a plain `0.1.0-beta.185` and the subsequent install pulled the published package instead of the local one — exactly the bug reported in #130.

Closes #130

🤖 Generated with [Claude Code](https://claude.com/claude-code)