### PR TITLE
Fix #132: repair 3 stale tests and 1 flaky test in packages/core

### DIFF
--- a/packages/core/tests/jest/components/dashboard/block-editor/block-preview-canvas.test.tsx
+++ b/packages/core/tests/jest/components/dashboard/block-editor/block-preview-canvas.test.tsx
@@ -78,7 +78,7 @@ describe('BlockPreviewCanvas', () => {
 
   const defaultProps = {
     blocks: mockBlocks,
-    selectedBlockId: null,
+    selectedBlockIds: new Set<string>(),
     onSelectBlock: jest.fn(),
     onMoveUp: jest.fn(),
     onMoveDown: jest.fn(),
@@ -117,7 +117,7 @@ describe('BlockPreviewCanvas', () => {
   describe('Selection', () => {
     test('passes isSelected=true to selected block', () => {
       const { container } = render(
-        <BlockPreviewCanvas {...defaultProps} selectedBlockId="block-2" />
+        <BlockPreviewCanvas {...defaultProps} selectedBlockIds={new Set(["block-2"])} />
       )
 
       const selectedBlock = container.querySelector('[data-cy="blockEditor-previewCanvas-block-block-2"]')
@@ -131,17 +131,17 @@ describe('BlockPreviewCanvas', () => {
       const firstBlock = screen.getByTestId('block-hero-section')
       fireEvent.click(firstBlock)
 
-      expect(onSelectBlock).toHaveBeenCalledWith('block-1')
+      expect(onSelectBlock).toHaveBeenCalledWith('block-1', { metaKey: false, shiftKey: false, ctrlKey: false })
     })
 
     test('shows Editing badge when isSelected is true', () => {
-      render(<BlockPreviewCanvas {...defaultProps} selectedBlockId="block-1" />)
+      render(<BlockPreviewCanvas {...defaultProps} selectedBlockIds={new Set(["block-1"])} />)
 
       expect(screen.getByText('Editing')).toBeInTheDocument()
     })
 
     test('does not show Editing badge when block is not selected', () => {
-      render(<BlockPreviewCanvas {...defaultProps} selectedBlockId={null} />)
+      render(<BlockPreviewCanvas {...defaultProps} selectedBlockIds={new Set<string>()} />)
 
       expect(screen.queryByText('Editing')).not.toBeInTheDocument()
     })
@@ -151,7 +151,7 @@ describe('BlockPreviewCanvas', () => {
     test('calls onMoveUp when up button clicked', () => {
       const onMoveUp = jest.fn()
       const { container } = render(
-        <BlockPreviewCanvas {...defaultProps} onMoveUp={onMoveUp} selectedBlockId="block-2" />
+        <BlockPreviewCanvas {...defaultProps} onMoveUp={onMoveUp} selectedBlockIds={new Set(["block-2"])} />
       )
 
       const upButton = container.querySelector('[data-cy="blockEditor-previewCanvas-moveUp-block-2"]')
@@ -164,7 +164,7 @@ describe('BlockPreviewCanvas', () => {
     test('calls onMoveDown when down button clicked', () => {
       const onMoveDown = jest.fn()
       const { container } = render(
-        <BlockPreviewCanvas {...defaultProps} onMoveDown={onMoveDown} selectedBlockId="block-2" />
+        <BlockPreviewCanvas {...defaultProps} onMoveDown={onMoveDown} selectedBlockIds={new Set(["block-2"])} />
       )
 
       const downButton = container.querySelector('[data-cy="blockEditor-previewCanvas-moveDown-block-2"]')
@@ -176,7 +176,7 @@ describe('BlockPreviewCanvas', () => {
 
     test('disables up button for first block', () => {
       const { container } = render(
-        <BlockPreviewCanvas {...defaultProps} selectedBlockId="block-1" />
+        <BlockPreviewCanvas {...defaultProps} selectedBlockIds={new Set(["block-1"])} />
       )
 
       const upButton = container.querySelector('[data-cy="blockEditor-previewCanvas-moveUp-block-1"]')
@@ -185,7 +185,7 @@ describe('BlockPreviewCanvas', () => {
 
     test('disables down button for last block', () => {
       const { container } = render(
-        <BlockPreviewCanvas {...defaultProps} selectedBlockId="block-3" />
+        <BlockPreviewCanvas {...defaultProps} selectedBlockIds={new Set(["block-3"])} />
       )
 
       const downButton = container.querySelector('[data-cy="blockEditor-previewCanvas-moveDown-block-3"]')
@@ -194,7 +194,7 @@ describe('BlockPreviewCanvas', () => {
 
     test('does not disable up button for middle block', () => {
       const { container } = render(
-        <BlockPreviewCanvas {...defaultProps} selectedBlockId="block-2" />
+        <BlockPreviewCanvas {...defaultProps} selectedBlockIds={new Set(["block-2"])} />
       )
 
       const upButton = container.querySelector('[data-cy="blockEditor-previewCanvas-moveUp-block-2"]')
@@ -203,7 +203,7 @@ describe('BlockPreviewCanvas', () => {
 
     test('does not disable down button for middle block', () => {
       const { container } = render(
-        <BlockPreviewCanvas {...defaultProps} selectedBlockId="block-2" />
+        <BlockPreviewCanvas {...defaultProps} selectedBlockIds={new Set(["block-2"])} />
       )
 
       const downButton = container.querySelector('[data-cy="blockEditor-previewCanvas-moveDown-block-2"]')
@@ -229,14 +229,14 @@ describe('BlockPreviewCanvas', () => {
     })
 
     test('keeps floating toolbar visible when block is selected', () => {
-      render(<BlockPreviewCanvas {...defaultProps} selectedBlockId="block-1" />)
+      render(<BlockPreviewCanvas {...defaultProps} selectedBlockIds={new Set(["block-1"])} />)
 
       expect(screen.getByTestId('toolbar-block-1')).toBeInTheDocument()
     })
 
     test('calls onDuplicate when duplicate button in toolbar clicked', () => {
       const onDuplicate = jest.fn()
-      render(<BlockPreviewCanvas {...defaultProps} onDuplicate={onDuplicate} selectedBlockId="block-1" />)
+      render(<BlockPreviewCanvas {...defaultProps} onDuplicate={onDuplicate} selectedBlockIds={new Set(["block-1"])} />)
 
       const duplicateBtn = screen.getByTestId('duplicate-block-1')
       fireEvent.click(duplicateBtn)
@@ -246,7 +246,7 @@ describe('BlockPreviewCanvas', () => {
 
     test('calls onRemove when remove button in toolbar clicked', () => {
       const onRemove = jest.fn()
-      render(<BlockPreviewCanvas {...defaultProps} onRemove={onRemove} selectedBlockId="block-1" />)
+      render(<BlockPreviewCanvas {...defaultProps} onRemove={onRemove} selectedBlockIds={new Set(["block-1"])} />)
 
       const removeBtn = screen.getByTestId('remove-block-1')
       fireEvent.click(removeBtn)

--- a/packages/core/tests/jest/components/dashboard/block-editor/tree-view.test.tsx
+++ b/packages/core/tests/jest/components/dashboard/block-editor/tree-view.test.tsx
@@ -60,7 +60,7 @@ jest.mock('@/core/components/dashboard/block-editor/tree-view-node', () => ({
     <div
       data-testid={`tree-node-${block.id}`}
       data-selected={isSelected}
-      onClick={onSelect}
+      onClick={(e: React.MouseEvent) => onSelect({ metaKey: e.metaKey, shiftKey: e.shiftKey, ctrlKey: e.ctrlKey })}
     >
       {block.blockSlug || block.ref}
     </div>
@@ -139,7 +139,7 @@ describe('TreeView', () => {
       const block1 = screen.getByTestId('tree-node-block-1')
       fireEvent.click(block1)
 
-      expect(onSelectBlock).toHaveBeenCalledWith('block-1')
+      expect(onSelectBlock).toHaveBeenCalledWith('block-1', { metaKey: false, shiftKey: false, ctrlKey: false })
     })
   })
 })

--- a/packages/core/tests/jest/hooks/useLastAuthMethod.test.ts
+++ b/packages/core/tests/jest/hooks/useLastAuthMethod.test.ts
@@ -49,7 +49,7 @@ describe('useLastAuthMethod Hook', () => {
       // Wait for the 150ms delay
       await waitFor(() => {
         expect(result.current.isReady).toBe(true)
-      }, { timeout: 300 })
+      }, { timeout: 2000 })
 
       expect(result.current.lastMethod).toBe(null)
       expect(result.current.isReady).toBe(true)
@@ -67,7 +67,7 @@ describe('useLastAuthMethod Hook', () => {
       // Wait for the 150ms delay
       await waitFor(() => {
         expect(result.current.isReady).toBe(true)
-      }, { timeout: 300 })
+      }, { timeout: 2000 })
 
       expect(result.current.lastMethod).toBe('email')
       expect(result.current.isReady).toBe(true)
@@ -85,7 +85,7 @@ describe('useLastAuthMethod Hook', () => {
       // Wait for the 150ms delay
       await waitFor(() => {
         expect(result.current.isReady).toBe(true)
-      }, { timeout: 300 })
+      }, { timeout: 2000 })
 
       expect(result.current.lastMethod).toBe('google')
       expect(result.current.isReady).toBe(true)
@@ -103,7 +103,7 @@ describe('useLastAuthMethod Hook', () => {
       // Wait for the 150ms delay
       await waitFor(() => {
         expect(result.current.isReady).toBe(true)
-      }, { timeout: 300 })
+      }, { timeout: 2000 })
 
       expect(result.current.lastMethod).toBe(null)
       expect(result.current.isReady).toBe(true)
@@ -119,7 +119,7 @@ describe('useLastAuthMethod Hook', () => {
       // Wait for initial load to complete
       await waitFor(() => {
         expect(result.current.isReady).toBe(true)
-      }, { timeout: 300 })
+      }, { timeout: 2000 })
 
       act(() => {
         result.current.saveAuthMethod('email')
@@ -138,7 +138,7 @@ describe('useLastAuthMethod Hook', () => {
       // Wait for initial load to complete
       await waitFor(() => {
         expect(result.current.isReady).toBe(true)
-      }, { timeout: 300 })
+      }, { timeout: 2000 })
 
       act(() => {
         result.current.saveAuthMethod('google')
@@ -157,7 +157,7 @@ describe('useLastAuthMethod Hook', () => {
       // Wait for initial load to complete
       await waitFor(() => {
         expect(result.current.isReady).toBe(true)
-      }, { timeout: 300 })
+      }, { timeout: 2000 })
 
       expect(result.current.lastMethod).toBe('email')
       expect(result.current.isReady).toBe(true)
@@ -179,7 +179,7 @@ describe('useLastAuthMethod Hook', () => {
       // Wait for initial load to complete
       await waitFor(() => {
         expect(result.current.isReady).toBe(true)
-      }, { timeout: 300 })
+      }, { timeout: 2000 })
 
       expect(result.current.lastMethod).toBe('google')
       expect(result.current.isReady).toBe(true)
@@ -203,7 +203,7 @@ describe('useLastAuthMethod Hook', () => {
       // Wait for initial load to complete
       await waitFor(() => {
         expect(result.current.isReady).toBe(true)
-      }, { timeout: 300 })
+      }, { timeout: 2000 })
 
       expect(result.current.lastMethod).toBe('email')
       expect(result.current.isReady).toBe(true)
@@ -225,7 +225,7 @@ describe('useLastAuthMethod Hook', () => {
       // Wait for initial load to complete
       await waitFor(() => {
         expect(result.current.isReady).toBe(true)
-      }, { timeout: 300 })
+      }, { timeout: 2000 })
 
       expect(result.current.lastMethod).toBe(null)
       expect(result.current.isReady).toBe(true)
@@ -251,7 +251,7 @@ describe('useLastAuthMethod Hook', () => {
       // Wait for the hook to complete initialization
       await waitFor(() => {
         expect(result.current.isReady).toBe(true)
-      }, { timeout: 300 })
+      }, { timeout: 2000 })
 
       expect(mockLocalStorage.getItem).toHaveBeenCalledWith(expectedKey)
 
@@ -285,7 +285,7 @@ describe('useLastAuthMethod Hook', () => {
       // Wait for the delay to complete
       await waitFor(() => {
         expect(result.current.isReady).toBe(true)
-      }, { timeout: 300 })
+      }, { timeout: 2000 })
 
       expect(result.current.lastMethod).toBe(null)
       expect(result.current.isReady).toBe(true)
@@ -305,7 +305,7 @@ describe('useLastAuthMethod Hook', () => {
       // Should become ready after delay
       await waitFor(() => {
         expect(result.current.isReady).toBe(true)
-      }, { timeout: 300 })
+      }, { timeout: 2000 })
 
       expect(result.current.isReady).toBe(true)
       expect(result.current.lastMethod).toBe('email')
@@ -332,7 +332,7 @@ describe('useLastAuthMethod Hook', () => {
 
       await waitFor(() => {
         expect(result.current.isReady).toBe(true)
-      }, { timeout: 300 })
+      }, { timeout: 2000 })
 
       expect(result.current.lastMethod).toBe(null)
       expect(result.current.isReady).toBe(true)
@@ -345,7 +345,7 @@ describe('useLastAuthMethod Hook', () => {
 
       await waitFor(() => {
         expect(result.current.isReady).toBe(true)
-      }, { timeout: 300 })
+      }, { timeout: 2000 })
 
       expect(result.current.lastMethod).toBe(null)
       expect(result.current.isReady).toBe(true)
@@ -358,7 +358,7 @@ describe('useLastAuthMethod Hook', () => {
 
       await waitFor(() => {
         expect(result.current.isReady).toBe(true)
-      }, { timeout: 300 })
+      }, { timeout: 2000 })
 
       expect(result.current.lastMethod).toBe(null)
       expect(result.current.isReady).toBe(true)
@@ -387,7 +387,7 @@ describe('useLastAuthMethod Hook', () => {
 
       await waitFor(() => {
         expect(result.current.isReady).toBe(true)
-      }, { timeout: 300 })
+      }, { timeout: 2000 })
 
       // These should compile and work
       act(() => {
@@ -418,7 +418,7 @@ describe('useLastAuthMethod Hook', () => {
 
       await waitFor(() => {
         expect(result.current.isReady).toBe(true)
-      }, { timeout: 300 })
+      }, { timeout: 2000 })
 
       expect(result.current.isReady).toBe(true)
     })

--- a/packages/core/tests/jest/services/team.service.test.ts
+++ b/packages/core/tests/jest/services/team.service.test.ts
@@ -90,14 +90,14 @@ describe('TeamService', () => {
   })
 
   describe('getGlobal', () => {
-    it('returns first team for single-tenant mode', async () => {
+    it('returns the team flagged isGlobal for single-tenant mode', async () => {
       mockQueryOneWithRLS.mockResolvedValue(mockTeam)
 
       const result = await TeamService.getGlobal()
 
       expect(result).toEqual(mockTeam)
       expect(mockQueryOneWithRLS).toHaveBeenCalledWith(
-        expect.stringContaining('ORDER BY "createdAt" ASC'),
+        expect.stringContaining('"isGlobal" = TRUE'),
         []
       )
     })


### PR DESCRIPTION
## Summary

Four pre-existing test failures/flakiness in `packages/core`, all caused by tests that never
got updated when the underlying production behavior legitimately changed — no production code
was touched.

- **`team.service.test.ts`** — `TeamService.getGlobal()` queries by the explicit `isGlobal` flag
  column (set at team creation time for single-tenant mode) instead of `ORDER BY "createdAt" ASC`.
  The test still asserted the old query shape.
- **`tree-view.test.tsx`** / **`block-preview-canvas.test.tsx`** — both mock `TreeViewNode`'s
  `onSelect` as a raw DOM `onClick`, so it forwarded the native click event instead of the
  `{metaKey, shiftKey, ctrlKey}` object the real component normalizes for multi-select. Fixed the
  mocks to normalize the event like the real component does, and updated assertions to match the
  `(id, modifiers)` call signature.
- **`block-preview-canvas.test.tsx`** — separately, `BlockPreviewCanvas` replaced the singular
  `selectedBlockId` prop with `selectedBlockIds: Set<string>` when multi-select landed; the test
  file was never migrated, so all 21 tests crashed reading `.size` off `undefined`. Migrated every
  `selectedBlockId` usage to `selectedBlockIds`.
- **`useLastAuthMethod.test.ts`** (flaky) — all 18 `waitFor()` calls race a real (non-fake)
  150ms `setTimeout` with only a 300ms `waitFor` timeout — 2x margin is too tight under CI
  scheduler jitter, which is what made one of them flake. Widened the margin to 2000ms across
  the file (not just the reported case — all 18 shared the identical fragile pattern).

Closes #132.

## Test plan
- [x] Each of the 4 suites passes individually.
- [x] Full `packages/core` suite: 139/139 suites, 3246 passed (0 failing, previously 3
      consistently failing + 1 flaky).
- [x] No production code changed — test-only fix.