### PR TITLE
Fix #165: generate a real BETTER_AUTH_SECRET on init

### DIFF
--- a/packages/cli/src/wizard/generators/config-generator.ts
+++ b/packages/cli/src/wizard/generators/config-generator.ts
@@ -4,6 +4,7 @@
  * Generates and updates configuration files based on wizard responses.
  */
 
+import crypto from 'crypto'
 import fs from 'fs-extra'
 import path from 'path'
 import type { WizardConfig } from '../types.js'
@@ -417,6 +418,14 @@ export async function updateReadme(config: WizardConfig): Promise<void> {
 /**
  * Copy .env.example to .env for immediate use
  * This allows the project to compile out-of-the-box
+ *
+ * The placeholder BETTER_AUTH_SECRET in .env.example is intentional (it's a
+ * template meant to be read), but copying it verbatim into .env leaves every
+ * generated project signing sessions with the same public, well-known
+ * string — including in the non-interactive/preset path CI and automation
+ * actually use, where nothing else ever prompts for or generates a real one
+ * (#165). Generate a real secret for .env specifically; .env.example keeps
+ * the placeholder as documentation.
  */
 export async function copyEnvExampleToEnv(): Promise<void> {
   const projectRoot = process.cwd()
@@ -425,6 +434,14 @@ export async function copyEnvExampleToEnv(): Promise<void> {
 
   if (await fs.pathExists(envExamplePath) && !await fs.pathExists(envPath)) {
     await fs.copy(envExamplePath, envPath)
+
+    const secret = crypto.randomBytes(32).toString('hex')
+    let content = await fs.readFile(envPath, 'utf-8')
+    content = content.replace(
+      /^BETTER_AUTH_SECRET=.*$/m,
+      `BETTER_AUTH_SECRET="${secret}"`
+    )
+    await fs.writeFile(envPath, content, 'utf-8')
   }
 }
 


### PR DESCRIPTION
## Summary
- Closes #165.
- \`copyEnvExampleToEnv()\` (the only code path that actually produces \`.env\` — invoked unconditionally for every \`nextspark init\`, interactive or not) copied \`.env.example\` byte-for-byte, including the literal placeholder \`BETTER_AUTH_SECRET="your-secret-key-here"\`.
- The properly-implemented secret generator in \`wizard/generators/env-setup.ts\` (and its interactive prompt in \`wizard/prompts/env-config.ts\`) is never called from anywhere in the CLI — dead code left over from an earlier wizard design.
- Fix: \`copyEnvExampleToEnv()\` now generates a real 32-byte hex secret via \`crypto.randomBytes\` and substitutes it into \`.env\` after copying. \`.env.example\` is left untouched (it's meant to be read as a template).

## Verification
- \`tsc --noEmit\` clean.
- Live repro: packed all 5 real tarballs, ran a full non-interactive init (\`--preset saas --theme starter --yes\`) against them. Before the fix, \`.env\` had \`BETTER_AUTH_SECRET="your-secret-key-here"\`; after, it has a unique 64-char hex string, while \`.env.example\` still shows the placeholder.

Found during the final e2e validation pass before publishing \`0.1.0-beta.186\`.