### PR TITLE
Fix #163: auth-client uses the page's own origin in the browser

### DIFF
--- a/packages/core/src/lib/auth-client.ts
+++ b/packages/core/src/lib/auth-client.ts
@@ -4,7 +4,17 @@ import { emailOTPClient } from "better-auth/client/plugins";
 import type { auth } from "./auth";
 
 export const authClient = createAuthClient({
-  baseURL: process.env.NEXT_PUBLIC_APP_URL || "http://localhost:5173",
+  // In the browser, always talk to the origin the page was actually served
+  // from — better-auth falls back to `window.location.origin` when baseURL
+  // is undefined (see its getBaseURL()). NEXT_PUBLIC_APP_URL is inlined at
+  // build time to one fixed origin, so using it unconditionally breaks any
+  // request from a different-but-valid origin: LAN/device testing, Vercel
+  // preview deployments, and tenant subdomains (#163). Server-side (no
+  // window), keep the env var since there's no request origin to infer from
+  // on the very first render before hydration.
+  baseURL: typeof window === "undefined"
+    ? (process.env.NEXT_PUBLIC_APP_URL || "http://localhost:5173")
+    : undefined,
   plugins: [
     inferAdditionalFields<typeof auth>(),
     emailOTPClient(),


### PR DESCRIPTION
## Summary
- Closes #163.
- \`authClient\` hardcoded \`baseURL: process.env.NEXT_PUBLIC_APP_URL\`, evaluated identically in browser and server. Every \`/api/auth/*\` call from the browser targeted that fixed origin regardless of the page's actual origin.
- Breaks: LAN/device testing (phone posts to its own localhost), Vercel preview deployments (cross-origin to production, CORS-blocked), tenant subdomains.
- Fix: pass \`undefined\` in the browser branch so better-auth's own \`getBaseURL()\` falls back to \`window.location.origin\`; keep the env var server-side only.

## Verification
- \`tsc --noEmit\` clean.
- Live execution against the actual installed \`better-auth@1.6.30\` runtime (not just reading its source): called its real \`getBaseURL()\` with a mocked browser \`window.location.origin\` of \`http://192.168.1.50:3000\` and \`NEXT_PUBLIC_APP_URL\` set to a bogus value.
  - Before the fix's behavior (always passing the env var): resolved to \`http://this-should-never-be-hit.invalid:9999/api/auth\`.
  - After the fix's browser branch (passing \`undefined\`): resolved to \`http://192.168.1.50:3000/api/auth\` — the page's real origin.