### PR TITLE
Fix silent tsup copy failure for nextspark-registries.d.ts

### DIFF
--- a/packages/core/tsup.config.ts
+++ b/packages/core/tsup.config.ts
@@ -299,7 +299,7 @@ export default defineConfig({
 
     // Copy registry type declarations
     await cp(
-      join(process.cwd(), 'nextspark-registries.d.ts'),
+      join(process.cwd(), 'src', 'nextspark-registries.d.ts'),
       join(distDir, 'nextspark-registries.d.ts')
     ).catch(() => console.log('No registry declarations to copy'))
 


### PR DESCRIPTION
## Summary
- #131 moved \`nextspark-registries.d.ts\` from the package root into \`src/\`, but \`tsup.config.ts\` still copied it from the old root path.
- The copy's \`.catch()\` swallowed the resulting ENOENT silently, logging an easy-to-miss \"No registry declarations to copy\" — the published tarball shipped a 0-byte \`dist/nextspark-registries.d.js\` instead of the real declaration file.
- Found during the final e2e validation pass before publishing \`0.1.0-beta.187\`, by diffing the packed tarball against the previously published \`0.1.0-beta.186\`.

## Impact
Measured as none: no template or export map in a generated project actually references this ambient file (they resolve \`@nextsparkjs/registries/*\` via their own \`tsconfig\` \`paths\`), so it was dead weight either way. Fixing the source path anyway — the file is meant to ship, and a silently-swallowed copy failure is exactly the kind of bug that bites again later unnoticed.

## Verification
- \`rm -rf dist && pnpm build\` in \`packages/core\`: \`dist/nextspark-registries.d.ts\` now present, 868 lines / ~30KB, matching the real source file — not the previous 0-byte placeholder.