### PR TITLE
Fix #170: trust the request's own LAN origin in dev-like environments

### DIFF
--- a/packages/core/src/lib/auth.ts
+++ b/packages/core/src/lib/auth.ts
@@ -21,7 +21,7 @@ import { isDomainAllowed } from './auth/registration-helpers';
 import { registrationGuardPlugin } from './auth/registration-guard-plugin';
 import { resolveSessionConfig } from './auth/session-config';
 import { isPasswordLoginEnabled } from './auth/auth-methods';
-import { getCorsOrigins } from './utils/cors';
+import { getCorsOrigins, isPrivateLanOrigin, normalizeCorsEnvironment } from './utils/cors';
 
 /**
  * Does this email have a pending, unexpired team invitation waiting?
@@ -265,8 +265,29 @@ export const auth = betterAuth({
     },
   },
   baseURL: baseUrl,
-  // Use unified CORS configuration from app.config.ts + theme extensions + env vars
-  trustedOrigins: getCorsOrigins(APP_CONFIG_MERGED),
+  // Use unified CORS configuration from app.config.ts + theme extensions + env vars.
+  // A function (rather than a static array) so dev-like environments can also
+  // trust the request's OWN origin when it's a private LAN address — #163's
+  // client fix made the browser call back to whatever origin the page was
+  // loaded from (LAN IP, phone, etc.), but the static origin list could never
+  // enumerate that address in advance, so the server still rejected it with
+  // "Invalid origin" (#170). Scoped to private/LAN addresses and non-production
+  // only: never trusts an arbitrary public origin, and never applies in prod.
+  // Public-internet cases (Vercel previews, tenant subdomains) are covered by
+  // adding a wildcard entry (e.g. "https://*.vercel.app") to
+  // api.cors.additionalOrigins — better-auth's own trustedOrigins matching
+  // already supports the same wildcard syntax as isOriginAllowed() above.
+  trustedOrigins: async (request?: Request) => {
+    const origins = getCorsOrigins(APP_CONFIG_MERGED);
+    if (normalizeCorsEnvironment(process.env.NODE_ENV || 'development') === 'production') {
+      return origins;
+    }
+    const requestOrigin = request?.headers.get('origin');
+    if (requestOrigin && isPrivateLanOrigin(requestOrigin)) {
+      return [...origins, requestOrigin];
+    }
+    return origins;
+  },
   // Redirect auth errors to our custom error page instead of Better Auth's default
   onAPIError: {
     errorURL: '/auth-error',

--- a/packages/core/src/lib/utils/cors.ts
+++ b/packages/core/src/lib/utils/cors.ts
@@ -177,6 +177,41 @@ function escapeRegExp(value: string): string {
 }
 
 /**
+ * True when `origin`'s hostname is a private/local-network address — RFC 1918
+ * ranges (10/8, 172.16/12, 192.168/16), link-local (169.254/16), or mDNS
+ * `.local` — i.e. reachable only from the same physical/local network, never
+ * from the public internet.
+ *
+ * Used to auto-trust a request's own origin for LAN/device testing (#170)
+ * without hand-listing every developer's IP: a private-network address is a
+ * meaningfully different trust boundary than an arbitrary public origin, so
+ * this stays safe even though it's dynamic. Never call this to decide
+ * production trust — pair with an environment check.
+ */
+export function isPrivateLanOrigin(origin: string): boolean {
+  let hostname: string
+  try {
+    hostname = new URL(origin).hostname
+  } catch {
+    return false
+  }
+
+  if (hostname.endsWith('.local')) return true
+
+  const octets = hostname.split('.')
+  if (octets.length !== 4) return false
+  const nums = octets.map(Number)
+  if (nums.some((n) => !Number.isInteger(n) || n < 0 || n > 255)) return false
+
+  const [a, b] = nums
+  if (a === 10) return true
+  if (a === 172 && b >= 16 && b <= 31) return true
+  if (a === 192 && b === 168) return true
+  if (a === 169 && b === 254) return true
+  return false
+}
+
+/**
  * Check whether a request origin is allowed, supporting wildcard-pattern entries
  * in the allow-list. A `*` in an entry matches exactly ONE host label (no dots),
  * so `https://*.example.app` matches `https://tenant.example.app` but NOT

--- a/packages/core/tests/jest/lib/utils/cors.test.ts
+++ b/packages/core/tests/jest/lib/utils/cors.test.ts
@@ -8,7 +8,7 @@
  * - Debug logging
  */
 
-import { getCorsOrigins, normalizeCorsEnvironment, normalizeOrigin, type CorsEnvironment } from '@/core/lib/utils/cors'
+import { getCorsOrigins, normalizeCorsEnvironment, normalizeOrigin, isPrivateLanOrigin, type CorsEnvironment } from '@/core/lib/utils/cors'
 import type { ApplicationConfig } from '@/core/lib/config/config-types'
 
 // =============================================================================
@@ -610,5 +610,51 @@ describe('normalizeOrigin', () => {
     // Falls back to lowercase + remove trailing slashes
     expect(normalizeOrigin('not-a-valid-url/')).toBe('not-a-valid-url')
     expect(normalizeOrigin('INVALID/')).toBe('invalid')
+  })
+})
+
+describe('isPrivateLanOrigin', () => {
+  it('should accept RFC 1918 ranges', () => {
+    expect(isPrivateLanOrigin('http://10.0.0.1:3000')).toBe(true)
+    expect(isPrivateLanOrigin('http://10.255.255.255:3000')).toBe(true)
+    expect(isPrivateLanOrigin('http://172.16.0.1:3000')).toBe(true)
+    expect(isPrivateLanOrigin('http://172.31.255.255:3000')).toBe(true)
+    expect(isPrivateLanOrigin('http://192.168.0.1:3000')).toBe(true)
+    expect(isPrivateLanOrigin('http://192.168.68.107:3005')).toBe(true)
+  })
+
+  it('should accept link-local addresses', () => {
+    expect(isPrivateLanOrigin('http://169.254.1.1:3000')).toBe(true)
+  })
+
+  it('should accept mDNS .local hostnames', () => {
+    expect(isPrivateLanOrigin('http://my-laptop.local:3000')).toBe(true)
+  })
+
+  it('should reject the 172.x range outside 16-31', () => {
+    expect(isPrivateLanOrigin('http://172.15.0.1:3000')).toBe(false)
+    expect(isPrivateLanOrigin('http://172.32.0.1:3000')).toBe(false)
+  })
+
+  it('should reject public IPs', () => {
+    expect(isPrivateLanOrigin('http://8.8.8.8')).toBe(false)
+    expect(isPrivateLanOrigin('http://1.1.1.1')).toBe(false)
+    expect(isPrivateLanOrigin('https://93.184.216.34')).toBe(false)
+  })
+
+  it('should reject public hostnames, including look-alikes', () => {
+    expect(isPrivateLanOrigin('https://example.com')).toBe(false)
+    expect(isPrivateLanOrigin('https://192.168.0.1.evil.com')).toBe(false)
+    expect(isPrivateLanOrigin('https://vercel.app')).toBe(false)
+  })
+
+  it('should reject loopback (already covered by the static allow-list)', () => {
+    expect(isPrivateLanOrigin('http://localhost:3000')).toBe(false)
+    expect(isPrivateLanOrigin('http://127.0.0.1:3000')).toBe(false)
+  })
+
+  it('should reject malformed input instead of throwing', () => {
+    expect(isPrivateLanOrigin('not-a-url')).toBe(false)
+    expect(isPrivateLanOrigin('')).toBe(false)
   })
 })

--- a/packages/core/tsup.config.ts
+++ b/packages/core/tsup.config.ts
@@ -299,7 +299,7 @@ export default defineConfig({
 
     // Copy registry type declarations
     await cp(
-      join(process.cwd(), 'nextspark-registries.d.ts'),
+      join(process.cwd(), 'src', 'nextspark-registries.d.ts'),
       join(distDir, 'nextspark-registries.d.ts')
     ).catch(() => console.log('No registry declarations to copy'))
 


### PR DESCRIPTION
## Summary
- Closes #170. Completes #163: the client-side fix (PR #167) made the browser call back to the page's real origin, but the server's static \`trustedOrigins\` list could never enumerate a developer's LAN IP in advance, so LAN/device testing still hit \`403 {"code":"INVALID_ORIGIN"}\`.
- \`trustedOrigins\` is now a function. In dev-like environments (\`normalizeCorsEnvironment\`), it additionally trusts the incoming request's own \`Origin\` header **only** when it's a private LAN address (new \`isPrivateLanOrigin()\`: RFC 1918 ranges, link-local, mDNS \`.local\`) — never in production.
- Vercel previews / tenant subdomains don't need new code: \`api.cors.additionalOrigins\` already supports wildcard entries (\`https://*.vercel.app\`) via better-auth's own \`matchesOriginPattern\`, using the same syntax this file's \`isOriginAllowed()\` already implements for CORS headers.

## Verification
- Live: started \`apps/dev\`'s dev server, \`POST /api/auth/sign-in/email\` from this machine's real LAN IP (\`192.168.68.107\`) with a matching \`Origin\` header → **200**, valid session cookie with \`ipAddress: 192.168.68.107\`. Previously 403.
- 8 new unit tests for \`isPrivateLanOrigin\` (RFC 1918 ranges, link-local, \`.local\`, the 172.x boundary, public IPs, look-alike hostnames, loopback, malformed input).
- Full \`packages/core\` suite: 139/139 suites, 3254 passed (3246 + 8 new), 9 skipped — no regressions.