### PR TITLE
Fix #171: enforce published-only for anonymous public entity access

### DIFF
--- a/packages/core/src/lib/api/entity/generic-handler.ts
+++ b/packages/core/src/lib/api/entity/generic-handler.ts
@@ -1058,6 +1058,17 @@ async function handleGenericListImpl(request: NextRequest, audit: AuditContext):
       console.log(`[GenericHandler] Public access mode: skipping userId filter for ${entityConfig.slug} (status=published)`)
     }
 
+    // Anonymous requests to a public entity have no userId to gate on (the
+    // filter above only ever applies `if (userId && ...)`), so requestingPublishedOnly
+    // was never actually enforced server-side — it only decided whether to skip
+    // an ownership filter that already didn't apply. An unauthenticated caller
+    // could omit `status=published` entirely (or ask for `status=draft`) and see
+    // every row regardless of status, team, or owner (#171). Force the
+    // constraint here instead of trusting the caller's own filter intent.
+    const forcePublishedOnly = isPublicEntity
+      && userId === null
+      && entityConfig.fields.some((f: EntityField) => f.name === 'status')
+
     // Get table name (uses tableName if specified, otherwise slug)
     const tableName = getTableName(entityConfig)
 
@@ -1095,6 +1106,11 @@ async function handleGenericListImpl(request: NextRequest, audit: AuditContext):
       if (teamId) {
         query += ` AND t."teamId" = $${paramIndex++}`
         queryParams.push(teamId)
+      }
+
+      // Anonymous public access: force published-only regardless of caller's filters (#171)
+      if (forcePublishedOnly) {
+        query += ` AND t."status" = 'published'`
       }
 
       // Add user filter if authenticated and not shared (CASE 1 only)
@@ -1156,6 +1172,11 @@ async function handleGenericListImpl(request: NextRequest, audit: AuditContext):
         query += ` AND t."deletedAt" IS NULL`
       }
 
+      // Anonymous public access: force published-only regardless of caller's filters (#171)
+      if (forcePublishedOnly) {
+        query += ` AND t."status" = 'published'`
+      }
+
       query += ` ORDER BY "${fieldName}" ASC LIMIT $${paramIndex++}`
       queryParams.push(pagination.limit)
     } else {
@@ -1193,6 +1214,11 @@ async function handleGenericListImpl(request: NextRequest, audit: AuditContext):
       // Soft delete filter: hide deleted rows for non-bypass users
       if (entityConfig.table?.softDelete && !isBypass) {
         whereConditions.push(`t."deletedAt" IS NULL`)
+      }
+
+      // Anonymous public access: force published-only regardless of caller's filters (#171)
+      if (forcePublishedOnly) {
+        whereConditions.push(`t."status" = 'published'`)
       }
 
       // Add search filter (searches in name, title, slug, and content fields).
@@ -1914,6 +1940,14 @@ async function handleGenericReadImpl(request: NextRequest, audit: AuditContext, 
 
     const fields = [...systemFieldsFormatted, ...configFields].join(', ')
 
+    // Anonymous requests to a public entity have no userId to gate on below (the
+    // ownership filter only ever applies `if (userId && ...)`), so nothing was
+    // enforcing published-only for a direct-by-ID read — an unauthenticated
+    // caller who knew/guessed a draft's id could read it in full (#171).
+    const forcePublishedOnly = entityConfig.access?.public === true
+      && userId === null
+      && entityConfig.fields.some((f: EntityField) => f.name === 'status')
+
     // Build query based on access type and team context
     let query: string
     let queryParams: unknown[]
@@ -1962,6 +1996,12 @@ async function handleGenericReadImpl(request: NextRequest, audit: AuditContext, 
     // Soft delete filter: hide deleted rows for non-bypass users
     if (entityConfig.table?.softDelete && !isBypass) {
       query += ` AND t."deletedAt" IS NULL`
+    }
+
+    // Anonymous public access: force published-only, ignoring nothing the
+    // caller sent since there's no filter param on a by-id read to trust (#171)
+    if (forcePublishedOnly) {
+      query += ` AND t."status" = 'published'`
     }
 
     const items = await queryWithRLS(query, queryParams, userId)

--- a/packages/core/tests/jest/api/entity/generic-handler-public-status.test.ts
+++ b/packages/core/tests/jest/api/entity/generic-handler-public-status.test.ts
@@ -1,0 +1,122 @@
+/**
+ * Regression coverage for #171: an unauthenticated request to a public
+ * entity (`access.public: true`) leaked rows in every status — including
+ * `draft` — because the userId ownership filter only ever applied
+ * `if (userId && ...)`, and `userId` is always `null` for anonymous access.
+ * The `status=published` the docs/comments assumed the caller would send was
+ * never actually enforced server-side, so a client could omit it (or send
+ * `status=draft`) and see everything, across every user and team.
+ */
+
+import { harness, makeRequest, listUrl, PETS_ENTITY } from './__helpers__/generic-handler-harness'
+import { handleGenericList, handleGenericRead } from '@/core/lib/api/entity/generic-handler'
+import type { EntityConfig } from '@/core/lib/entities/types'
+
+const { mocks } = harness
+
+const PUBLIC_PAGES_ENTITY: EntityConfig = {
+  ...PETS_ENTITY,
+  slug: 'pages',
+  tableName: 'pages',
+  fields: [
+    { name: 'title', type: 'text', api: { readOnly: false } } as never,
+    { name: 'status', type: 'select', api: { readOnly: false } } as never,
+  ],
+  access: { api: true, public: true, shared: true },
+} as unknown as EntityConfig
+
+const ANONYMOUS = { success: false, type: 'none', user: null }
+
+function useEntity(entity: EntityConfig) {
+  mocks.resolveEntityFromUrl.mockResolvedValue({
+    isValidEntity: true, entityConfig: entity, entityName: entity.slug, hasCustomOverride: false,
+  })
+}
+
+function listSql(): [string, unknown[]] {
+  const call = mocks.queryWithRLS.mock.calls.find(([sql]: [string]) => sql.includes('FROM "pages"'))
+  expect(call).toBeDefined()
+  return call as [string, unknown[]]
+}
+
+beforeEach(() => {
+  harness.reset()
+  useEntity(PUBLIC_PAGES_ENTITY)
+  mocks.authenticateRequest.mockResolvedValue(ANONYMOUS)
+})
+
+describe('handleGenericList — #171 forces published-only for anonymous public access', () => {
+  it('adds status = published even when the caller sends no status filter at all', async () => {
+    const response = await handleGenericList(makeRequest({ url: listUrl({}, 'pages') })) as unknown as { status: number }
+
+    expect(response.status).toBe(200)
+    const [sql] = listSql()
+    expect(sql).toContain(`t."status" = 'published'`)
+  })
+
+  it('still adds the forced constraint when the caller explicitly asks for status=draft (fails closed, 0 rows)', async () => {
+    const response = await handleGenericList(
+      makeRequest({ url: listUrl({ status: 'draft' }, 'pages') })
+    ) as unknown as { status: number }
+
+    expect(response.status).toBe(200)
+    const [sql] = listSql()
+    // Both conditions land in the query; Postgres can never satisfy both, so
+    // this returns 0 rows rather than leaking drafts — a caller can't launder
+    // draft access through the same filter that's supposed to request it.
+    expect(sql).toContain(`"status" = $`)
+    expect(sql).toContain(`t."status" = 'published'`)
+  })
+
+  it('does NOT force the constraint for an authenticated request (normal team-scoped access)', async () => {
+    mocks.authenticateRequest.mockResolvedValue({ success: true, type: 'session', user: { id: 'user-1', email: 'u@test.com', role: 'user' } })
+
+    const response = await handleGenericList(
+      makeRequest({ url: listUrl({}, 'pages'), headers: { 'x-team-id': 'team-1' } })
+    ) as unknown as { status: number }
+
+    expect(response.status).toBe(200)
+    const [sql] = listSql()
+    expect(sql).not.toContain(`t."status" = 'published'`)
+  })
+
+  it('does NOT force the constraint on a non-public entity (no access.public)', async () => {
+    useEntity(PETS_ENTITY)
+    mocks.authenticateRequest.mockResolvedValue({ success: true, type: 'session', user: { id: 'user-1', email: 'u@test.com', role: 'user' } })
+
+    const response = await handleGenericList(
+      makeRequest({ url: listUrl({}, 'pets'), headers: { 'x-team-id': 'team-1' } })
+    ) as unknown as { status: number }
+
+    expect(response.status).toBe(200)
+    const call = mocks.queryWithRLS.mock.calls.find(([sql]: [string]) => sql.includes('FROM "pets"'))
+    expect(call?.[0]).not.toContain(`"status" = 'published'`)
+  })
+})
+
+describe('handleGenericRead — #171 forces published-only for anonymous public access', () => {
+  const idParams = { params: Promise.resolve({ entity: 'pages', id: 'draft-page-1' }) }
+
+  it('adds status = published to a direct by-id read', async () => {
+    mocks.queryWithRLS.mockResolvedValue([{ id: 'draft-page-1', title: 'Secret Draft', status: 'draft' }])
+
+    await handleGenericRead(makeRequest({ url: 'http://localhost/api/v1/pages/draft-page-1' }), idParams)
+
+    const call = mocks.queryWithRLS.mock.calls.find(([sql]: [string]) => sql.includes('FROM "pages"'))
+    expect(call).toBeDefined()
+    expect(call?.[0]).toContain(`t."status" = 'published'`)
+  })
+
+  it('does NOT force the constraint for an authenticated request', async () => {
+    mocks.authenticateRequest.mockResolvedValue({ success: true, type: 'session', user: { id: 'user-1', email: 'u@test.com', role: 'user' } })
+    mocks.queryWithRLS.mockResolvedValue([{ id: 'draft-page-1', title: 'Secret Draft', status: 'draft' }])
+
+    await handleGenericRead(
+      makeRequest({ url: 'http://localhost/api/v1/pages/draft-page-1', headers: { 'x-team-id': 'team-1' } }),
+      idParams
+    )
+
+    const call = mocks.queryWithRLS.mock.calls.find(([sql]: [string]) => sql.includes('FROM "pages"'))
+    expect(call?.[0]).not.toContain(`t."status" = 'published'`)
+  })
+})


### PR DESCRIPTION
## Summary
- Closes #171.
- An unauthenticated request to an entity with \`access.public: true\` could see rows in **any** status — including drafts — across every user and team, regardless of whether the caller asked for \`status=published\`.
- Root cause: the userId ownership filter in both \`handleGenericList\` and \`handleGenericRead\` only ever applies \`if (userId && ...)\`, and \`userId\` is always \`null\` for anonymous access. The existing \`skipUserFilter\`/\`requestingPublishedOnly\` logic decided whether to skip *that* filter, but it was already inapplicable to a null \`userId\` either way — so \`status=published\` was never actually enforced server-side, only assumed to be something a well-behaved caller would voluntarily send.
- Fix: compute \`forcePublishedOnly\` (public entity + no \`userId\` + entity declares a \`status\` field) and unconditionally \`AND\` it into every query branch (specificIds list, single-field list shortcut, general list, by-id read) — regardless of the caller's own status filter. A caller asking for \`status=draft\` now gets 0 rows instead of a leak.

## Verification
- Live, against real Postgres (disposable DB): pre-fix query shape returned both a published and a draft row for an anonymous request; post-fix returned only the published one, and a by-id read of the draft's id returned 0 rows.
- 6 new regression tests (\`generic-handler-public-status.test.ts\`) covering both handlers: forces the constraint for anonymous public access (no filter sent, and even when \`status=draft\` is explicitly requested), leaves authenticated requests and non-public entities untouched.
- Full \`packages/core\` suite: 140/140 suites, 3252 passed (3246 + 6 new), 9 skipped — no regressions.