### PR TITLE
Fix the 2 remaining tsc errors (and the real ClientEntityConfig shape bug behind them)

### DIFF
--- a/packages/core/src/components/patterns/pages/PatternEditPage.tsx
+++ b/packages/core/src/components/patterns/pages/PatternEditPage.tsx
@@ -2,7 +2,11 @@
  * Patterns Edit Page
  *
  * Wrapper that delegates to the BuilderEditorView for pattern editing.
- * Uses useEntityConfig hook for entity configuration.
+ * Reads entity config from the generated client registry (getEntityBySlug),
+ * the same source BuilderEditorView itself and the generic [entity]/[id]/edit
+ * page use — instead of the runtime-hydrated useEntityConfig() hook, whose
+ * EntityConfig shape (names.singular/plural, full field configs, functions)
+ * never structurally matched ClientEntityConfig (#131 follow-up).
  */
 
 'use client'
@@ -10,10 +14,10 @@
 import { notFound, useRouter } from 'next/navigation'
 import { useParams } from 'next/navigation'
 import { useEffect, useState } from 'react'
+import { getEntityBySlug, type ClientEntityConfig } from '@nextsparkjs/registries/entity-registry.client'
 import { EntityFormWrapper } from '../../entities/wrappers/EntityFormWrapper'
 import { BuilderEditorView } from '../../dashboard/block-editor/builder-editor-view'
 import { Alert, AlertDescription } from '../../ui/alert'
-import { useEntityConfig } from '../../../hooks/useEntityConfig'
 import { getEntityData } from '../../../lib/api/entities'
 
 export default function PatternEditPage() {
@@ -21,12 +25,22 @@ export default function PatternEditPage() {
   const router = useRouter()
   const [initialData, setInitialData] = useState<Record<string, unknown> | null>(null)
   const [dataLoading, setDataLoading] = useState(true)
+  const [entityConfig, setEntityConfig] = useState<ClientEntityConfig | null>(null)
+  const [configLoading, setConfigLoading] = useState(true)
 
   const entitySlug = 'patterns'
   const entityId = params.id as string
 
-  // Use the centralized hook for entity configuration
-  const { config: entityConfig, isLoading: configLoading } = useEntityConfig(entitySlug)
+  useEffect(() => {
+    try {
+      setEntityConfig(getEntityBySlug(entitySlug))
+    } catch (error) {
+      console.error('Error loading patterns entity config:', error)
+      setEntityConfig(null)
+    } finally {
+      setConfigLoading(false)
+    }
+  }, [])
 
   useEffect(() => {
     async function loadEntityData() {
@@ -63,7 +77,7 @@ export default function PatternEditPage() {
     )
   }
 
-  if (!entityConfig || !entityConfig.enabled) {
+  if (!entityConfig || !entityConfig.features?.enabled) {
     return (
       <Alert>
         <AlertDescription>

--- a/packages/core/src/components/patterns/pages/PatternsCreatePage.tsx
+++ b/packages/core/src/components/patterns/pages/PatternsCreatePage.tsx
@@ -2,23 +2,35 @@
  * Patterns Create Page
  *
  * Wrapper that delegates to the generic entity create page.
- * Uses useEntityConfig hook for entity configuration.
+ * Reads entity config from the generated client registry — see
+ * PatternEditPage.tsx for why (#131 follow-up).
  */
 
 'use client'
 
+import { useEffect, useState } from 'react'
 import { useRouter } from 'next/navigation'
+import { getEntityBySlug, type ClientEntityConfig } from '@nextsparkjs/registries/entity-registry.client'
 import { EntityFormWrapper } from '../../entities/wrappers/EntityFormWrapper'
 import { BuilderEditorView } from '../../dashboard/block-editor/builder-editor-view'
 import { Alert, AlertDescription } from '../../ui/alert'
-import { useEntityConfig } from '../../../hooks/useEntityConfig'
 
 export default function PatternsCreatePage() {
   const router = useRouter()
   const entitySlug = 'patterns'
+  const [entityConfig, setEntityConfig] = useState<ClientEntityConfig | null>(null)
+  const [isLoading, setIsLoading] = useState(true)
 
-  // Use the centralized hook for entity configuration
-  const { config: entityConfig, isLoading } = useEntityConfig(entitySlug)
+  useEffect(() => {
+    try {
+      setEntityConfig(getEntityBySlug(entitySlug))
+    } catch (error) {
+      console.error('Error loading patterns entity config:', error)
+      setEntityConfig(null)
+    } finally {
+      setIsLoading(false)
+    }
+  }, [])
 
   if (isLoading) {
     return (
@@ -28,7 +40,7 @@ export default function PatternsCreatePage() {
     )
   }
 
-  if (!entityConfig || !entityConfig.enabled) {
+  if (!entityConfig || !entityConfig.features?.enabled) {
     return (
       <Alert>
         <AlertDescription>

--- a/packages/core/src/nextspark-registries.d.ts
+++ b/packages/core/src/nextspark-registries.d.ts
@@ -245,20 +245,25 @@ declare module '@nextsparkjs/registries/entity-registry.client' {
   }
 
   export interface ClientEntityConfig {
-    slug: string
-    label: string
-    labelPlural: string
-    icon?: string
-    enabled: boolean
-    showInMenu: boolean
-    permissions?: Record<string, string[]>
-    fields?: Array<{
-      name: string
-      label: string
-      type: string
-      tab?: string
-      required?: boolean
-    }>
+    // Matches the REAL shape apps/dev's registry:build actually generates
+    // (packages/cli's entity-registry.client.ts template) — verified against
+    // a live-regenerated apps/dev/.nextspark/registries/entity-registry.client.ts,
+    // not guessed. A prior version of this ambient declaration invented a
+    // flat slug/label/labelPlural/enabled/showInMenu shape that never existed
+    // anywhere; it went uncaught because none of this package's own
+    // ClientEntityConfig consumers happened to read those particular fields
+    // (#131 follow-up).
+    name: string
+    apiPath: string
+    displayName: string
+    features: {
+      enabled: boolean
+      showInMenu?: boolean
+      canCreate?: boolean
+      canEdit?: boolean
+      canDelete?: boolean
+      searchable?: boolean
+    }
     builder?: {
       enabled?: boolean
       sidebarFields?: string[]


### PR DESCRIPTION
## Summary
- \`PatternEditPage.tsx\`/\`PatternsCreatePage.tsx\` got the server-shape \`EntityConfig\` from the runtime-hydrated \`useEntityConfig()\` hook and passed it straight to \`BuilderEditorView\`, which expects the build-time-generated \`ClientEntityConfig\`. Switched both to \`getEntityBySlug()\` from \`@nextsparkjs/registries/entity-registry.client\` — the same source \`BuilderEditorView\` itself and the generic \`[entity]/create\`, \`[entity]/[id]/edit\` pages already use.
- While fixing this, found the ambient \`ClientEntityConfig\` in \`nextspark-registries.d.ts\` (#131) was itself wrong for the fields these two pages needed: it declared a flat \`slug/label/labelPlural/enabled/showInMenu\` shape that doesn't exist anywhere. Verified against a live regeneration of \`apps/dev/.nextspark/registries/entity-registry.client.ts\` (packages/cli's real template) and \`patterns.config.ts\`: the real shape is \`name/apiPath/displayName\`, with \`enabled\`/\`showInMenu\` nested under \`features\`. This was invisible before because none of the 5 existing \`ClientEntityConfig\` consumers in this package happened to read those particular fields — my new code would have been the first to, and would have silently always hit the "not configured" branch in a real project despite the entity being enabled.
- Corrected the ambient declaration to the real shape and updated both pages to read \`entityConfig.features?.enabled\` instead of the nonexistent top-level \`entityConfig.enabled\`.

## Verification
- \`tsc --noEmit\`: 0 errors (was 2, the last remaining ones from #131).
- \`build:core\` DTS: 40 errors (was 42).
- Full \`packages/core\` suite: 140/140 suites, 3260 passed — no regressions.
- Traced the real generated registry entry for \`patterns\` (\`features.enabled: true\`, \`builder: {enabled: true, ...}\`) against \`patterns.config.ts\`'s actual \`enabled: true\` / \`builder.enabled: true\` — confirms the corrected code renders \`BuilderEditorView\` exactly as before, not the "not configured" alert.