### PR TITLE
Fix #175 and #176: theme System option, and guard hydration mismatch

### DIFF
--- a/apps/dev/app/layout.ppr.tsx
+++ b/apps/dev/app/layout.ppr.tsx
@@ -79,7 +79,12 @@ export default async function RootLayout({
           <NextThemeProvider
             attribute="class"
             defaultTheme={DEFAULT_THEME_MODE}
-            enableSystem={DEFAULT_THEME_MODE === 'system'}
+            // Always true here: this layout never passes forcedTheme, so
+            // ThemeToggle is unconditionally visible and offers "System" as one
+            // of its 3 choices — gating on DEFAULT_THEME_MODE === 'system' had
+            // the same bug as the non-PPR layout (see #175): a build-time
+            // default of 'light'/'dark' silently broke the "System" option.
+            enableSystem
             disableTransitionOnChange
           >
             <CustomThemeProvider>

--- a/apps/dev/app/layout.tsx
+++ b/apps/dev/app/layout.tsx
@@ -81,8 +81,17 @@ export default async function RootLayout({
             defaultTheme={defaultMode}
             // When allowUserToggle is false, force the theme and ignore localStorage/system
             forcedTheme={!allowUserToggle ? defaultMode : undefined}
-            // Only detect OS preference when theme configures defaultMode: 'system' AND user can toggle
-            enableSystem={allowUserToggle && defaultMode === 'system'}
+            // Detect OS preference whenever the user can toggle at all. ThemeToggle
+            // always offers "System" as one of its 3 choices when toggling is
+            // allowed, so the provider must be able to resolve it whenever that's
+            // true — gating on `defaultMode === 'system'` looks equivalent at
+            // first render, but defaultMode is the user's last SAVED preference
+            // for a logged-in user (see getThemeSettings), not a static "is
+            // system-matching enabled" flag. That made "System" silently write a
+            // literal, unmatched `class="system"` for anyone whose saved
+            // preference (or the theme's own config default) wasn't already
+            // 'system' — see #175.
+            enableSystem={allowUserToggle}
             // Force a theme on the routes declared in theme.config.ts (forcedThemeRoutes)
             forcedThemeRoutes={forcedThemeRoutes}
             disableTransitionOnChange

--- a/packages/core/src/components/app/guards/DeveloperGuard.tsx
+++ b/packages/core/src/components/app/guards/DeveloperGuard.tsx
@@ -2,7 +2,7 @@
 
 import { useSession } from '../../../lib/auth-client';
 import { useRouter } from "next/navigation";
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '../../ui/card';
 import { AlertTriangle, ArrowLeft } from "lucide-react";
 import { Button } from '../../ui/button';
@@ -27,17 +27,30 @@ export function DeveloperGuard({ children, fallback }: DeveloperGuardProps) {
   const { data: session, isPending } = useSession();
   const router = useRouter();
   const t = useTranslations();
+  // SSR can never actually resolve the session, so the server always renders
+  // the loading state below — but by the time the client hydrates, useSession()
+  // may have already resolved (isPending: false), so the client's first render
+  // would try to paint the real content immediately and mismatch the server's
+  // HTML. Gate on `mounted` (false on the server and on the client's first
+  // render, flipped by the effect below only after hydration) so both sides
+  // render the identical loading state first, matching the pattern
+  // ThemeToggle.tsx already uses for the same reason (#176).
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => {
+    setMounted(true);
+  }, []);
 
   // Auto-redirect non-developer users
   useEffect(() => {
     // @ts-expect-error — pre-existing type error, tracked in https://github.com/NextSpark-js/nextspark/issues/131
-    if (!isPending && session && session.user?.role !== 'developer') {
+    if (mounted && !isPending && session && session.user?.role !== 'developer') {
       router.push('/dashboard?error=access_denied');
     }
-  }, [session, isPending, router]);
+  }, [mounted, session, isPending, router]);
 
   // Show loading state while checking session
-  if (isPending) {
+  if (!mounted || isPending) {
     return (
       <div className="flex items-center justify-center min-h-screen">
         <div className="animate-pulse">

--- a/packages/core/src/components/app/guards/SuperAdminGuard.tsx
+++ b/packages/core/src/components/app/guards/SuperAdminGuard.tsx
@@ -2,7 +2,7 @@
 
 import { useSession } from '../../../lib/auth-client';
 import { useRouter } from "next/navigation";
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '../../ui/card';
 import { AlertTriangle, ArrowLeft } from "lucide-react";
 import { Button } from '../../ui/button';
@@ -27,17 +27,26 @@ export function SuperAdminGuard({ children, fallback }: SuperAdminGuardProps) {
   const { data: session, isPending } = useSession();
   const router = useRouter();
   const t = useTranslations();
+  // See DeveloperGuard.tsx for why: SSR always renders the loading state below
+  // (it can never resolve the session), but the client's first render may
+  // already have it resolved, so gate on `mounted` to keep both renders
+  // identical until after hydration (#176).
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => {
+    setMounted(true);
+  }, []);
 
   // Auto-redirect users without superadmin or developer access
   useEffect(() => {
     // @ts-expect-error — pre-existing type error, tracked in https://github.com/NextSpark-js/nextspark/issues/131
-    if (!isPending && session && session.user?.role !== 'superadmin' && session.user?.role !== 'developer') {
+    if (mounted && !isPending && session && session.user?.role !== 'superadmin' && session.user?.role !== 'developer') {
       router.push('/dashboard?error=access_denied');
     }
-  }, [session, isPending, router]);
+  }, [mounted, session, isPending, router]);
 
   // Show loading state while checking session
-  if (isPending) {
+  if (!mounted || isPending) {
     return (
       <div className="flex items-center justify-center min-h-screen">
         <div className="animate-pulse">

--- a/packages/core/src/messages/de/navigation.json
+++ b/packages/core/src/messages/de/navigation.json
@@ -7,5 +7,7 @@
   "logout": "Abmelden",
   "features": "Funktionen",
   "pricing": "Preise",
-  "support": "Support"
+  "support": "Support",
+  "quickCreate": "Schnellerstellung",
+  "quickCreateNew": "Neu: {entity}"
 }

--- a/packages/core/src/messages/en/navigation.json
+++ b/packages/core/src/messages/en/navigation.json
@@ -8,5 +8,7 @@
   "logout": "Logout",
   "features": "Features",
   "pricing": "Pricing",
-  "support": "Support"
+  "support": "Support",
+  "quickCreate": "Quick Create",
+  "quickCreateNew": "New {entity}"
 }

--- a/packages/core/src/messages/es/navigation.json
+++ b/packages/core/src/messages/es/navigation.json
@@ -8,5 +8,7 @@
   "logout": "Cerrar Sesión",
   "features": "Características",
   "pricing": "Precios",
-  "support": "Soporte"
+  "support": "Soporte",
+  "quickCreate": "Creación Rápida",
+  "quickCreateNew": "Nuevo {entity}"
 }

--- a/packages/core/src/messages/fr/navigation.json
+++ b/packages/core/src/messages/fr/navigation.json
@@ -7,5 +7,7 @@
   "logout": "Deconnexion",
   "features": "Fonctionnalites",
   "pricing": "Tarifs",
-  "support": "Support"
+  "support": "Support",
+  "quickCreate": "Création Rapide",
+  "quickCreateNew": "Nouveau {entity}"
 }

--- a/packages/core/src/messages/it/navigation.json
+++ b/packages/core/src/messages/it/navigation.json
@@ -7,5 +7,7 @@
   "logout": "Esci",
   "features": "Funzionalita",
   "pricing": "Prezzi",
-  "support": "Supporto"
+  "support": "Supporto",
+  "quickCreate": "Creazione Rapida",
+  "quickCreateNew": "Nuovo {entity}"
 }

--- a/packages/core/src/messages/pt/navigation.json
+++ b/packages/core/src/messages/pt/navigation.json
@@ -7,5 +7,7 @@
   "logout": "Sair",
   "features": "Recursos",
   "pricing": "Precos",
-  "support": "Suporte"
+  "support": "Suporte",
+  "quickCreate": "Criação Rápida",
+  "quickCreateNew": "Novo {entity}"
 }


### PR DESCRIPTION
## Summary

**#175** — `enableSystem` was gated on `defaultMode === 'system'`, but `defaultMode` is the user's last SAVED preference for a logged-in user (`getThemeSettings`), not a static "is system-matching enabled" flag. `ThemeToggle` always offers "System" as one of its 3 choices whenever toggling is allowed, so the provider must be able to resolve it whenever that's true. Fixed both `layout.tsx` (`enableSystem={allowUserToggle}`) and the PPR variant `layout.ppr.tsx` (no `allowUserToggle` concept there at all — made it unconditionally `true`, matching that `ThemeToggle` is unconditionally visible in that layout).

**#176** — `DeveloperGuard` and `SuperAdminGuard` both read `useSession()`'s `isPending` directly to decide between a loading skeleton and the real content. SSR always renders the skeleton (`isPending: true` at request time), but the client's first render can already have the session resolved, so React sees a mismatch between the server HTML and the client's first paint. Added the same `mounted` gate `ThemeToggle.tsx` already uses for the identical reason.

**Bonus**: added the 6-locale translations for `navigation.quickCreate`/`quickCreateNew`, which next-intl's dev-mode auto-fix picked up as `MISSING_MESSAGE` while verifying the above — this exact gap has shown up as dismissed noise in every e2e validation pass this cycle.

Closes #175. Closes #176.

## Verification
Live, with Playwright MCP against a real dev server + real Postgres (console capture validated with a canary first, since `agent-browser console` was confirmed unreliable in this environment):
- **#175**: logged in as `superadmin` (who has a saved `theme: "light"` preference in the DB — the exact bug scenario), emulated OS dark mode, opened the `ThemeToggle` dropdown with a real click, clicked "System". Result: `document.documentElement.className === "dark"` (not the literal `"system"`), body background a real dark color.
- **#176**: navigated to `/devtools` as that same non-developer `superadmin` — full console capture showed zero hydration-related errors, "Developer Access Only" rendered correctly, and the effect-driven redirect to `/dashboard?error=access_denied` completed as expected.
- `tsc --noEmit`: 0 errors. Full `packages/core` suite: 140/140 suites, 3260 passed — no regressions.