### PR TITLE
Fix #178: let apps control prefetch on MobileTopBar's profile link

### DIFF
--- a/packages/core/src/components/dashboard/mobile/MobileTopBar.tsx
+++ b/packages/core/src/components/dashboard/mobile/MobileTopBar.tsx
@@ -11,7 +11,16 @@ import { sel } from '../../../lib/test'
 import { isTopbarFeatureEnabled } from '../../../lib/config'
 import { useTranslations } from 'next-intl'
 
-export function MobileTopBar() {
+interface MobileTopBarProps {
+  /**
+   * Se reenvía al `<Link>` del perfil. Sin valor, decide Next (prefetch automático al entrar en
+   * viewport). La barra se monta en toda página del dashboard en mobile, así que `false` ahorra
+   * una request RSC por carga en apps donde casi nadie navega al perfil.
+   */
+  prefetch?: boolean
+}
+
+export function MobileTopBar({ prefetch }: MobileTopBarProps = {}) {
   const { user } = useAuth()
   const t = useTranslations()
 
@@ -52,6 +61,7 @@ export function MobileTopBar() {
         {/* Left: User Avatar + Name */}
         <Link
           href="/dashboard/settings/profile"
+          prefetch={prefetch}
           className="flex items-center gap-3 hover:opacity-80 transition-opacity"
           aria-label={`Ir al perfil de ${user.firstName || user.email}`}
           data-cy={sel('dashboard.mobile.topbar.userProfile')}

--- a/packages/core/tests/jest/components/dashboard/mobile/MobileTopBar.test.tsx
+++ b/packages/core/tests/jest/components/dashboard/mobile/MobileTopBar.test.tsx
@@ -1,0 +1,59 @@
+/**
+ * @jest-environment jsdom
+ *
+ * MobileTopBar (#178): the profile link forwards `prefetch` so apps can stop the
+ * automatic RSC prefetch that this always-mounted bar fires on every dashboard page.
+ */
+import { describe, test, expect, beforeEach, jest } from '@jest/globals'
+import { render } from '@testing-library/react'
+import { MobileTopBar } from '@/core/components/dashboard/mobile/MobileTopBar'
+
+const mockLinkProps: Record<string, unknown>[] = []
+
+jest.mock('next/link', () => ({
+  __esModule: true,
+  default: (props: { children: React.ReactNode; href: string } & Record<string, unknown>) => {
+    mockLinkProps.push(props)
+    return <a href={props.href}>{props.children as React.ReactNode}</a>
+  },
+}))
+
+jest.mock('next/image', () => ({
+  __esModule: true,
+  default: (props: Record<string, unknown>) => <img alt="" {...props} />,
+}))
+
+jest.mock('@/core/hooks/useAuth', () => ({
+  useAuth: () => ({
+    user: { id: 'u1', email: 'ada@example.com', firstName: 'Ada', lastName: 'Lovelace' },
+  }),
+}))
+
+jest.mock('next-intl', () => ({
+  useTranslations: () => (key: string) => key,
+}))
+
+jest.mock('@/core/lib/config', () => ({
+  isTopbarFeatureEnabled: () => false,
+}))
+
+describe('MobileTopBar profile link prefetch (#178)', () => {
+  beforeEach(() => {
+    mockLinkProps.length = 0
+  })
+
+  test('leaves prefetch to Next.js when the prop is not passed', () => {
+    render(<MobileTopBar />)
+
+    expect(mockLinkProps).toHaveLength(1)
+    expect(mockLinkProps[0].href).toBe('/dashboard/settings/profile')
+    expect(mockLinkProps[0].prefetch).toBeUndefined()
+  })
+
+  test('forwards prefetch={false} to the profile link', () => {
+    render(<MobileTopBar prefetch={false} />)
+
+    expect(mockLinkProps).toHaveLength(1)
+    expect(mockLinkProps[0].prefetch).toBe(false)
+  })
+})


### PR DESCRIPTION
## Description

`MobileTopBar` se monta en toda página del dashboard en viewports `< lg`, y su `<Link>` al perfil no pasaba ningún control de `prefetch`, así que Next.js dispara un RSC prefetch automático en cada carga para una navegación que la mayoría de las visitas nunca hace (#178).

## Changes

- `MobileTopBar` acepta un prop opcional `prefetch?: boolean` y lo reenvía al `<Link>` del perfil.
- Sin el prop, el comportamiento no cambia: se deja `undefined` en vez de forzar `prefetch={true}`, porque en el App Router `true` es *más* agresivo que el default automático (fuerza el prefetch completo de la ruta en lugar del parcial hasta el loading boundary).
- Test de regresión en `tests/jest/components/dashboard/mobile/MobileTopBar.test.tsx`.

Uso desde un tema:

```tsx
<MobileTopBar prefetch={false} />
```

## Testing

- [x] `npx jest tests/jest/components/dashboard/mobile/MobileTopBar.test.tsx` → 2/2 pasan.
- [x] `tsc -p tsconfig.dts.json --noEmit`: sin errores nuevos (el único de este archivo, `getUserInitials(user)` con `SessionUser`, ya estaba en `main`).
- [x] `pnpm build:js`: el prop aparece en `dist/components/dashboard/mobile/MobileTopBar.js`.

## Notas

El mismo patrón (nav siempre visible con `<Link>` sin control de prefetch) existe en otros componentes del core — `MobileBottomNav`, `Sidebar`, `TopNavbar` y `SettingsSidebar`. Este PR se limita a lo que pide el issue; si conviene, se puede abrir un issue aparte para extender el prop a esos.

## Related Issues

- Closes #178

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CYykDUrJALXYwx3y7LTmNF