### PR TITLE
fix(core): gate getTemplateOrDefault debug log behind NODE_ENV

### DIFF
--- a/packages/core/src/lib/template-resolver.ts
+++ b/packages/core/src/lib/template-resolver.ts
@@ -59,8 +59,9 @@ export function getTemplateOrDefault<T = any>(
   appPath: string,
   defaultComponent: T
 ): T {
-  // DEBUG: Always log to trace execution
-  console.log(`[getTemplateOrDefault] Called for: ${appPath}`)
+  if (process.env.NODE_ENV === 'development') {
+    console.log(`[getTemplateOrDefault] Called for: ${appPath}`)
+  }
 
   // SECURITY: Check if component override is allowed at this protection level
   if (!canOverrideComponent(appPath)) {


### PR DESCRIPTION
## Summary

Fixes NextSpark-js/nextspark#181

`getTemplateOrDefault` in `packages/core/src/lib/template-resolver.ts` had one unguarded `console.log` that ran on every call in production. Every other debug log in that file is already gated behind `process.env.NODE_ENV === 'development'`.

This change gates that log the same way, keeping production output quiet.

## Changes

- Wrap the `[getTemplateOrDefault] Called for:` log in a `process.env.NODE_ENV === 'development'` check

## Test plan

- [x] Verified the unguarded log at line 63; all other logs in the file are already development-gated
- [ ] Confirm no console output from `getTemplateOrDefault` in production builds